### PR TITLE
Add Vizlayer fullscreen and SVG download controls

### DIFF
--- a/src/components/chat/message/message-markdown-vizlayer.test.tsx
+++ b/src/components/chat/message/message-markdown-vizlayer.test.tsx
@@ -10,9 +10,17 @@ import { MessageMarkdownVizlayer } from "./message-markdown-vizlayer";
 const copyButtonSpy = vi.fn();
 const toChartSpecSpy = vi.fn();
 const parseVizlayerSpecSpy = vi.fn();
+const vizlayerDiagramSpy = vi.fn();
+const toastSpy = vi.fn();
 
 vi.mock("@/components/shared/dashboard/use-is-dark-theme", () => ({
   default: () => false,
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toastManager: {
+    show: (...args: unknown[]) => toastSpy(...args),
+  },
 }));
 
 vi.mock("@/components/ui/copy-button", () => ({
@@ -93,7 +101,14 @@ vi.mock("@vizlayer/react", async () => {
 
   return {
     ...actual,
-    VizlayerDiagram: () => null,
+    VizlayerDiagram: (props: unknown) => {
+      vizlayerDiagramSpy(props);
+      return (
+        <svg data-testid="vizlayer-diagram" xmlns="http://www.w3.org/2000/svg">
+          <text>vizlayer-diagram</text>
+        </svg>
+      );
+    },
     toChartSpec: (props: unknown) => toChartSpecSpy(props),
     Vizlayer: { parse },
     VizlayerSpecParser: { parseVizlayerSpec: parse },
@@ -114,6 +129,13 @@ describe("MessageMarkdownVizlayer", () => {
     copyButtonSpy.mockReset();
     toChartSpecSpy.mockReset();
     parseVizlayerSpecSpy.mockReset();
+    vizlayerDiagramSpy.mockReset();
+    toastSpy.mockReset();
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      writable: true,
+      value: null,
+    });
   });
 
   afterEach(() => {
@@ -180,6 +202,82 @@ describe("MessageMarkdownVizlayer", () => {
         title: "Copy Mermaid code",
       })
     );
+    expect(vizlayerDiagramSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "sequenceDiagram",
+        document: {
+          participants: [
+            { id: "user", label: "User" },
+            { id: "agent", label: "Agent" },
+          ],
+          messages: [{ from: "user", to: "agent", text: "request" }],
+        },
+      })
+    );
+  });
+
+  it("requests browser fullscreen from the fullscreen button", () => {
+    toChartSpecSpy.mockReturnValue("flowchart TD\n  a --> b");
+
+    act(() => {
+      root.render(
+        <MessageMarkdownVizlayer spec='{"kind":"flowchart","document":{"direction":"TD","nodes":[{"id":"a","label":"A"},{"id":"b","label":"B"}],"edges":[{"from":"a","to":"b"}]}}' />
+      );
+    });
+
+    const fullscreenTarget = container.querySelector(
+      '[data-testid="vizlayer-diagram"]'
+    )?.parentElement;
+    expect(fullscreenTarget).not.toBeNull();
+    Object.defineProperty(fullscreenTarget as HTMLDivElement, "requestFullscreen", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(undefined),
+    });
+    const requestFullscreenSpy = vi.mocked(
+      (fullscreenTarget as HTMLDivElement & { requestFullscreen: () => Promise<void> })
+        .requestFullscreen
+    );
+
+    const expandTrigger = container.querySelector(
+      'button[aria-label="Open diagram in fullscreen"]'
+    );
+    expect(expandTrigger).not.toBeNull();
+
+    act(() => {
+      expandTrigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(requestFullscreenSpy).toHaveBeenCalledOnce();
+
+    requestFullscreenSpy.mockRestore();
+  });
+
+  it("downloads the rendered diagram as svg", () => {
+    toChartSpecSpy.mockReturnValue("flowchart TD\n  a --> b");
+    const createObjectURLSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:diagram");
+    const revokeObjectURLSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    act(() => {
+      root.render(
+        <MessageMarkdownVizlayer spec='{"kind":"flowchart","document":{"direction":"TD","nodes":[{"id":"a","label":"A"},{"id":"b","label":"B"}],"edges":[{"from":"a","to":"b"}]}}' />
+      );
+    });
+
+    const downloadButton = container.querySelector('button[aria-label="Download diagram as SVG"]');
+    expect(downloadButton).not.toBeNull();
+
+    act(() => {
+      downloadButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(createObjectURLSpy).toHaveBeenCalledOnce();
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:diagram");
+
+    createObjectURLSpy.mockRestore();
+    revokeObjectURLSpy.mockRestore();
+    clickSpy.mockRestore();
   });
 
   it("keeps copying raw Vizlayer JSON when parsing fails", () => {

--- a/src/components/chat/message/message-markdown-vizlayer.test.tsx
+++ b/src/components/chat/message/message-markdown-vizlayer.test.tsx
@@ -136,6 +136,11 @@ describe("MessageMarkdownVizlayer", () => {
       writable: true,
       value: null,
     });
+    Object.defineProperty(document, "webkitFullscreenElement", {
+      configurable: true,
+      writable: true,
+      value: null,
+    });
   });
 
   afterEach(() => {
@@ -250,6 +255,47 @@ describe("MessageMarkdownVizlayer", () => {
     expect(requestFullscreenSpy).toHaveBeenCalledOnce();
 
     requestFullscreenSpy.mockRestore();
+  });
+
+  it("falls back to prefixed fullscreen methods when standard APIs are unavailable", () => {
+    toChartSpecSpy.mockReturnValue("flowchart TD\n  a --> b");
+
+    act(() => {
+      root.render(
+        <MessageMarkdownVizlayer spec='{"kind":"flowchart","document":{"direction":"TD","nodes":[{"id":"a","label":"A"},{"id":"b","label":"B"}],"edges":[{"from":"a","to":"b"}]}}' />
+      );
+    });
+
+    const fullscreenTarget = container.querySelector(
+      '[data-testid="vizlayer-diagram"]'
+    )?.parentElement;
+    expect(fullscreenTarget).not.toBeNull();
+    Object.defineProperty(fullscreenTarget as HTMLDivElement, "requestFullscreen", {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(fullscreenTarget as HTMLDivElement, "webkitRequestFullscreen", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(undefined),
+    });
+    const webkitRequestFullscreenSpy = vi.mocked(
+      (
+        fullscreenTarget as HTMLDivElement & {
+          webkitRequestFullscreen: () => Promise<void>;
+        }
+      ).webkitRequestFullscreen
+    );
+
+    const expandTrigger = container.querySelector(
+      'button[aria-label="Open diagram in fullscreen"]'
+    );
+    expect(expandTrigger).not.toBeNull();
+
+    act(() => {
+      expandTrigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(webkitRequestFullscreenSpy).toHaveBeenCalledOnce();
   });
 
   it("downloads the rendered diagram as svg", () => {

--- a/src/components/chat/message/message-markdown-vizlayer.tsx
+++ b/src/components/chat/message/message-markdown-vizlayer.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import useIsDarkTheme from "@/components/shared/dashboard/use-is-dark-theme";
+import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
+import { toastManager } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import * as VizlayerReact from "@vizlayer/react";
 import { toChartSpec, VizlayerDiagram, type ParsedVizlayerSpec } from "@vizlayer/react";
-import { AlertCircle } from "lucide-react";
-import { useMemo } from "react";
+import { AlertCircle, Download, Maximize2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface MessageMarkdownVizlayerProps {
   spec: string;
@@ -26,6 +28,8 @@ type BuiltVizlayerChart =
 
 export function MessageMarkdownVizlayer({ spec }: MessageMarkdownVizlayerProps) {
   const isDark = useIsDarkTheme();
+  const inlineViewportRef = useRef<HTMLDivElement>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   const parsed = useMemo<ParsedVizlayerSpec>(() => parseVizlayerSpec(spec), [spec]);
 
@@ -49,6 +53,60 @@ export function MessageMarkdownVizlayer({ spec }: MessageMarkdownVizlayerProps) 
       };
     }
   }, [parsed]);
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(document.fullscreenElement === inlineViewportRef.current);
+    };
+
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () => {
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+    };
+  }, []);
+
+  const handleFullscreenToggle = useCallback(async () => {
+    const container = inlineViewportRef.current;
+    if (!container) {
+      return;
+    }
+
+    try {
+      if (document.fullscreenElement === container) {
+        await document.exitFullscreen();
+      } else {
+        await container.requestFullscreen();
+      }
+    } catch {
+      toastManager.show("Failed to open diagram in fullscreen.", "error");
+    }
+  }, []);
+
+  const handleDownloadSvg = useCallback(() => {
+    const viewport = inlineViewportRef.current;
+    const svg = viewport?.querySelector("svg");
+
+    if (!svg) {
+      toastManager.show("Diagram download is unavailable for this render output.", "error");
+      return;
+    }
+
+    try {
+      const serializedSvg = new XMLSerializer().serializeToString(svg);
+      const blob = new Blob([serializedSvg], { type: "image/svg+xml;charset=utf-8" });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+
+      anchor.href = url;
+      anchor.download = "vizlayer-diagram.svg";
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+    } catch {
+      toastManager.show("Failed to download diagram as SVG.", "error");
+    }
+  }, []);
 
   if (!parsed.ok) {
     return (
@@ -84,19 +142,43 @@ export function MessageMarkdownVizlayer({ spec }: MessageMarkdownVizlayerProps) 
 
   return (
     <div className="group relative my-2 rounded-md bg-background/40 p-3">
-      <CopyButton
-        value={chart?.ok ? chart.chart : spec}
-        variant="ghost"
-        size="icon"
-        className="absolute top-2 right-2 z-10 h-7 w-7 rounded-sm opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 [&_svg]:h-4 [&_svg]:w-4"
-        aria-label="Copy Mermaid code"
-        title="Copy Mermaid code"
-      />
+      <div className="absolute top-2 right-2 z-10 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+        <CopyButton
+          value={chart?.ok ? chart.chart : spec}
+          variant="ghost"
+          size="icon"
+          className="relative !top-auto !right-auto h-6 w-6 rounded-sm [&_svg]:h-3.5 [&_svg]:w-3.5"
+          aria-label="Copy Mermaid code"
+          title="Copy Mermaid code"
+        />
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 rounded-sm [&_svg]:h-3.5 [&_svg]:w-3.5"
+          aria-label={isFullscreen ? "Exit fullscreen diagram" : "Open diagram in fullscreen"}
+          title={isFullscreen ? "Exit fullscreen diagram" : "Open diagram in fullscreen"}
+          onClick={handleFullscreenToggle}
+        >
+          <Maximize2 className="!h-3 !w-3" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 rounded-sm [&_svg]:h-3.5 [&_svg]:w-3.5"
+          aria-label="Download diagram as SVG"
+          title="Download diagram as SVG"
+          onClick={handleDownloadSvg}
+        >
+          <Download className="!h-3 !w-3" />
+        </Button>
+      </div>
 
-      {renderDiagram({
-        spec: parsed.spec,
-        isDark,
-      })}
+      <div ref={inlineViewportRef}>
+        {renderDiagram({
+          spec: parsed.spec,
+          isDark,
+        })}
+      </div>
     </div>
   );
 }
@@ -130,7 +212,6 @@ function renderDiagram({ spec, isDark }: { spec: VizlayerSpec; isDark: boolean }
     <VizlayerDiagram
       {...spec}
       className={cn(
-        "overflow-x-auto",
         "flex min-w-max justify-center",
         "[&_.edgeLabel]:fill-foreground [&_.label]:fill-foreground [&_.node_label]:fill-foreground"
       )}

--- a/src/components/chat/message/message-markdown-vizlayer.tsx
+++ b/src/components/chat/message/message-markdown-vizlayer.tsx
@@ -26,6 +26,21 @@ type BuiltVizlayerChart =
       error: string;
     };
 
+type FullscreenTarget = HTMLDivElement & {
+  webkitRequestFullscreen?: () => Promise<void> | void;
+  mozRequestFullScreen?: () => Promise<void> | void;
+  msRequestFullscreen?: () => Promise<void> | void;
+};
+
+type FullscreenDocument = Document & {
+  webkitFullscreenElement?: Element | null;
+  mozFullScreenElement?: Element | null;
+  msFullscreenElement?: Element | null;
+  webkitExitFullscreen?: () => Promise<void> | void;
+  mozCancelFullScreen?: () => Promise<void> | void;
+  msExitFullscreen?: () => Promise<void> | void;
+};
+
 export function MessageMarkdownVizlayer({ spec }: MessageMarkdownVizlayerProps) {
   const isDark = useIsDarkTheme();
   const inlineViewportRef = useRef<HTMLDivElement>(null);
@@ -56,26 +71,64 @@ export function MessageMarkdownVizlayer({ spec }: MessageMarkdownVizlayerProps) 
 
   useEffect(() => {
     const handleFullscreenChange = () => {
-      setIsFullscreen(document.fullscreenElement === inlineViewportRef.current);
+      const fullscreenDocument = document as FullscreenDocument;
+      const fullscreenElement =
+        fullscreenDocument.fullscreenElement ??
+        fullscreenDocument.webkitFullscreenElement ??
+        fullscreenDocument.mozFullScreenElement ??
+        fullscreenDocument.msFullscreenElement ??
+        null;
+
+      setIsFullscreen(fullscreenElement === inlineViewportRef.current);
     };
 
     document.addEventListener("fullscreenchange", handleFullscreenChange);
+    document.addEventListener("webkitfullscreenchange", handleFullscreenChange);
+    document.addEventListener("mozfullscreenchange", handleFullscreenChange);
+    document.addEventListener("MSFullscreenChange", handleFullscreenChange);
     return () => {
       document.removeEventListener("fullscreenchange", handleFullscreenChange);
+      document.removeEventListener("webkitfullscreenchange", handleFullscreenChange);
+      document.removeEventListener("mozfullscreenchange", handleFullscreenChange);
+      document.removeEventListener("MSFullscreenChange", handleFullscreenChange);
     };
   }, []);
 
   const handleFullscreenToggle = useCallback(async () => {
-    const container = inlineViewportRef.current;
+    const container = inlineViewportRef.current as FullscreenTarget | null;
     if (!container) {
       return;
     }
 
     try {
-      if (document.fullscreenElement === container) {
-        await document.exitFullscreen();
-      } else {
+      const fullscreenDocument = document as FullscreenDocument;
+      const fullscreenElement =
+        fullscreenDocument.fullscreenElement ??
+        fullscreenDocument.webkitFullscreenElement ??
+        fullscreenDocument.mozFullScreenElement ??
+        fullscreenDocument.msFullscreenElement ??
+        null;
+
+      if (fullscreenElement === container) {
+        if (fullscreenDocument.exitFullscreen) {
+          await fullscreenDocument.exitFullscreen();
+        } else if (fullscreenDocument.webkitExitFullscreen) {
+          await fullscreenDocument.webkitExitFullscreen();
+        } else if (fullscreenDocument.mozCancelFullScreen) {
+          await fullscreenDocument.mozCancelFullScreen();
+        } else if (fullscreenDocument.msExitFullscreen) {
+          await fullscreenDocument.msExitFullscreen();
+        }
+      } else if (container.requestFullscreen) {
         await container.requestFullscreen();
+      } else if (container.webkitRequestFullscreen) {
+        await container.webkitRequestFullscreen();
+      } else if (container.mozRequestFullScreen) {
+        await container.mozRequestFullScreen();
+      } else if (container.msRequestFullscreen) {
+        await container.msRequestFullscreen();
+      } else {
+        throw new Error("Fullscreen API unavailable");
       }
     } catch {
       toastManager.show("Failed to open diagram in fullscreen.", "error");
@@ -212,7 +265,7 @@ function renderDiagram({ spec, isDark }: { spec: VizlayerSpec; isDark: boolean }
     <VizlayerDiagram
       {...spec}
       className={cn(
-        "flex min-w-max justify-center",
+        "flex min-w-max justify-center overflow-x-auto",
         "[&_.edgeLabel]:fill-foreground [&_.label]:fill-foreground [&_.node_label]:fill-foreground"
       )}
       loadingFallback={<DiagramLoadingState />}


### PR DESCRIPTION
## Summary
- add compact floating controls for Vizlayer messages
- support browser fullscreen for rendered diagrams
- support downloading rendered diagram SVGs and add focused tests

## Validation
- npm run format
- npm run lint
- npm run test -- src/components/chat/message/message-markdown-vizlayer.test.tsx

## Notes
- npm run build could not complete in the clean worktree because required external dependencies under external/ are not checked out there (build:deps fails before the app build starts).