### PR TITLE
Refine chat sessions sidebar and sample question layout

### DIFF
--- a/src/components/chat/session/chat-session-list.tsx
+++ b/src/components/chat/session/chat-session-list.tsx
@@ -371,6 +371,7 @@ function buildHistoryTree(
       ),
       search: connectionSearchTerms,
       icon: Database,
+      iconClassName: !meta.isCurrent ? "text-muted-foreground" : undefined,
       type: "folder",
       data: {
         kind: "connection",
@@ -393,6 +394,7 @@ function buildHistoryTree(
         ),
         search: `${label.toLowerCase()} ${connectionSearchTerms}`,
         icon: CalendarDays,
+        iconClassName: !meta.isCurrent ? "text-muted-foreground" : undefined,
         type: "folder",
         data: {
           kind: "group",
@@ -427,7 +429,10 @@ function buildHistoryTree(
           ),
           search: `${getChatTitle(chat).toLowerCase()} ${connectionSearchTerms} ${label.toLowerCase()}`,
           icon: chat.running ? Loader2 : MessageSquareText,
-          iconClassName: chat.running ? "animate-spin" : undefined,
+          iconClassName: cn(
+            chat.running && "animate-spin",
+            !meta.isCurrent && "text-muted-foreground"
+          ),
           type: "leaf",
           data: {
             kind: "chat",

--- a/src/components/chat/view/chat-view.tsx
+++ b/src/components/chat/view/chat-view.tsx
@@ -1,28 +1,16 @@
 "use client";
 
-import { AppLogo } from "@/components/app-logo";
 import { useConnection } from "@/components/connection/connection-context";
-import { Skeleton } from "@/components/ui/skeleton";
 import type { AppUIMessage } from "@/lib/ai/chat-types";
 import "@/lib/number-utils"; // Ensure formatTimeDiff is available
 
 import { useChat, type Chat } from "@ai-sdk/react";
-import { Activity, BarChart, Code2, Globe, Lightbulb, Zap } from "lucide-react";
-import {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { v7 as uuidv7 } from "uuid";
 import { ChatActionProvider, type UserActionInput } from "../chat-action-context";
 import { ChatContext, getDatabaseContextFromConnection } from "../chat-context";
 import { ChatFactory } from "../chat-factory";
-import { ChatCommandProvider, useChatCommands } from "../command-context";
+import { ChatCommandProvider } from "../command-context";
 import {
   ChatInput,
   type ChatInputHandle,
@@ -30,173 +18,8 @@ import {
 } from "../input/chat-input";
 import { getTableContextByMentions } from "../input/mention-utils";
 import { ChatMessageList } from "../message/chat-message-list";
+import { SampleQuestions } from "./sample-questions";
 import { useTokenUsage } from "./use-token-usage";
-
-export type Question = { text: string; autoRun?: boolean; requiredSkillId?: string };
-
-export type QuestionGroupData = {
-  icon: ReactNode;
-  questions: Question[];
-};
-
-const GREETINGS = [
-  "Hello there! How can I help you today?",
-  "Hi there! What would you like to explore?",
-  "Good to see you! Ready to dive into your data?",
-  "Nice to meet you! What can I help you analyze?",
-  "Hello and welcome! Let's explore your ClickHouse cluster and data!",
-];
-
-export const DEFAULT_CHAT_QUESTION_GROUPS: Record<string, QuestionGroupData> = {
-  Diagnostics: {
-    icon: <Activity className="w-4 h-4 text-blue-500" />,
-    questions: [
-      { text: "What's the status of the current cluster?", autoRun: true },
-      { text: "Which table has the largest number of parts and what's the cause?", autoRun: true },
-    ],
-  },
-  "Data Exploration": {
-    icon: <Globe className="w-4 h-4 text-green-500" />,
-    questions: [
-      {
-        text: "What're the top 3 SELECT queries that consume the most CPU time over the past 3 hours",
-        autoRun: true,
-      },
-      {
-        text: "How many INSERT queries as well as insert rows, insert bytes were executed in the last 1 hour from @system.query_log?",
-        autoRun: true,
-      },
-    ],
-  },
-  Visualization: {
-    icon: <BarChart className="w-4 h-4 text-purple-500" />,
-    questions: [
-      {
-        text: "Show me the number of SELECT queries by minute from @system.query_log over the past 3 hours in bar chart",
-        autoRun: true,
-      },
-      {
-        text: "Visualize the trend of ProfileEvent_DistributedConnectionFailTry from the @system.metric_log by hour in the last 12 hours",
-        autoRun: true,
-      },
-      {
-        text: "Show the distribution of query kind from the @system.query_log in the last 12 hours in pie chart",
-        autoRun: true,
-      },
-    ],
-  },
-  "SQL Optimization": {
-    icon: <Zap className="w-4 h-4 text-amber-500" />,
-    questions: [
-      { text: "Help me optimize a query", autoRun: true },
-      { text: "Find the top 1 slowest query in the last 1 day and optimize it", autoRun: true },
-    ],
-  },
-  "SQL Generation": {
-    icon: <Code2 className="w-4 h-4 text-green-500" />,
-    questions: [
-      {
-        text: "Generate a SELECT query to get the slowest query from the query log in the last 1 hour",
-        autoRun: true,
-      },
-    ],
-  },
-  General: {
-    icon: <Lightbulb className="w-4 h-4 text-yellow-500" />,
-    questions: [
-      { text: "What are the best practices for partitioning?", autoRun: true },
-      {
-        text: "How does async_insert work from the source code? Will data be lost if the server is restarted when this setting is enabled?",
-        autoRun: true,
-        requiredSkillId: "source-code-inspection",
-      },
-    ],
-  },
-};
-
-export function SampleQuestions({
-  onQuestionClick,
-}: {
-  onQuestionClick: (question: Question) => void;
-}) {
-  const { commands, loading } = useChatCommands();
-  const availableSkillIds = useMemo(() => {
-    return new Set(commands.map((command) => command.skillId));
-  }, [commands]);
-
-  // Wait until commands are loaded so we don't flash empty groups
-  if (loading) {
-    return (
-      <div className="w-full flex flex-col space-y-3 max-w-3xl mx-auto mt-4">
-        {[1, 2, 3].map((i) => (
-          <div
-            key={i}
-            className="flex flex-col border border-border/50 rounded-xl overflow-hidden bg-card shadow-sm"
-          >
-            <div className="flex items-center space-x-2 px-4 py-2.5 bg-muted/30 border-b border-border/50">
-              <Skeleton className="w-4 h-4 rounded-full" />
-              <Skeleton className="h-4 w-32" />
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-1 px-1 py-0">
-              <div className="px-3 py-2.5">
-                <Skeleton className="h-4 w-full mb-1" />
-                <Skeleton className="h-4 w-2/3" />
-              </div>
-              <div className="px-3 py-2.5">
-                <Skeleton className="h-4 w-5/6 mb-1" />
-                <Skeleton className="h-4 w-1/2" />
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-    );
-  }
-
-  const filteredGroups = Object.entries(DEFAULT_CHAT_QUESTION_GROUPS)
-    .map(([group, data]) => {
-      const filteredQuestions = data.questions.filter(
-        (q) => !q.requiredSkillId || availableSkillIds.has(q.requiredSkillId)
-      );
-      return [group, { ...data, questions: filteredQuestions }] as const;
-    })
-    .filter(([_, data]) => data.questions.length > 0);
-
-  if (filteredGroups.length === 0) return null;
-
-  return (
-    <div className="w-full flex flex-col space-y-3 max-w-3xl mx-auto mt-4">
-      {filteredGroups.map(([group, { icon, questions }]) => (
-        <div
-          key={group}
-          className="flex flex-col border border-border/50 rounded-xl overflow-hidden bg-card shadow-sm"
-        >
-          <div className="flex items-center space-x-2 px-4 py-2.5 bg-muted/30 border-b border-border/50">
-            {icon}
-            <h3 className="text-sm font-medium text-foreground/80">{group}</h3>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-1 px-1 py-0">
-            {questions.map((question, index) => {
-              const isLastOdd = questions.length % 2 !== 0 && index === questions.length - 1;
-              return (
-                <button
-                  key={question.text}
-                  type="button"
-                  className={`text-left px-3 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded-lg transition-colors border border-transparent hover:border-border/50 ${
-                    isLastOdd ? "md:col-span-2" : ""
-                  }`}
-                  onClick={() => onQuestionClick(question)}
-                >
-                  {question.text}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
 
 interface ChatViewProps {
   chat: Chat<AppUIMessage>;
@@ -223,8 +46,6 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
 ) {
   const { connection } = useConnection();
   const chatInputRef = useRef<ChatInputHandle | null>(null);
-
-  const [greeting] = useState(() => GREETINGS[Math.floor(Math.random() * GREETINGS.length)]);
   const [promptInput, setPromptInput] = useState<string | undefined>(externalInput);
 
   // Update promptInput when externalInput changes
@@ -354,15 +175,7 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
       <ChatCommandProvider>
         <div className="flex flex-col h-full bg-background overflow-hidden relative">
           {isEmpty ? (
-            <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden px-3 flex flex-col">
-              <div className="flex flex-col items-center w-full max-w-full my-auto pb-8 pt-4">
-                <div className="mb-0">
-                  <AppLogo width={64} height={64} />
-                </div>
-                <p className="text-xl text-center font-medium mb-0 mt-0">{greeting}</p>
-                <SampleQuestions onQuestionClick={handleQuestionClick} />
-              </div>
-            </div>
+            <SampleQuestions onQuestionClick={handleQuestionClick} />
           ) : (
             <ChatMessageList
               messages={messages as AppUIMessage[]}

--- a/src/components/chat/view/sample-questions.test.tsx
+++ b/src/components/chat/view/sample-questions.test.tsx
@@ -1,0 +1,255 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SampleQuestions } from "./sample-questions";
+
+const testGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+const useChatCommandsMock = vi.fn();
+
+vi.mock("../command-context", () => ({
+  useChatCommands: () => useChatCommandsMock(),
+}));
+
+describe("SampleQuestions", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+
+    window.innerWidth = 1280;
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes("767px") ? window.innerWidth <= 767 : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    HTMLElement.prototype.scrollTo = vi.fn();
+    Element.prototype.scrollIntoView = vi.fn();
+
+    container = document.createElement("div");
+    container.setAttribute("data-sample-questions-scroll-root", "true");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("filters questions that require unavailable skills", () => {
+    useChatCommandsMock.mockReturnValue({
+      commands: [],
+      loading: false,
+    });
+
+    act(() => {
+      root.render(<SampleQuestions onQuestionClick={vi.fn()} />);
+    });
+
+    expect(container.textContent).toContain("What are the best practices for partitioning?");
+    expect(container.textContent).not.toContain("How does async_insert work from the source code?");
+  });
+
+  it("scrolls to the selected group section from the desktop sidebar", () => {
+    useChatCommandsMock.mockReturnValue({
+      commands: [{ skillId: "source-code-inspection" }],
+      loading: false,
+    });
+
+    act(() => {
+      root.render(<SampleQuestions onQuestionClick={vi.fn()} />);
+    });
+
+    const navButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Visualization"
+    );
+
+    expect(navButton).toBeTruthy();
+
+    act(() => {
+      navButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("marks the first visible group active near the bottom of the pane", () => {
+    useChatCommandsMock.mockReturnValue({
+      commands: [{ skillId: "source-code-inspection" }],
+      loading: false,
+    });
+
+    act(() => {
+      root.render(<SampleQuestions onQuestionClick={vi.fn()} />);
+    });
+
+    const rightPane = container.querySelector(
+      "[data-sample-questions-right-pane='true']"
+    ) as HTMLDivElement | null;
+    const sections = Array.from(container.querySelectorAll("section"));
+
+    expect(rightPane).toBeTruthy();
+    expect(sections.length).toBeGreaterThan(0);
+
+    Object.defineProperties(rightPane!, {
+      scrollTop: {
+        configurable: true,
+        writable: true,
+        value: 500,
+      },
+      clientHeight: {
+        configurable: true,
+        value: 300,
+      },
+      scrollHeight: {
+        configurable: true,
+        value: 800,
+      },
+    });
+
+    rightPane!.getBoundingClientRect = vi.fn(() => ({
+      top: 0,
+      bottom: 300,
+      left: 0,
+      right: 0,
+      width: 0,
+      height: 300,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }));
+
+    [0, 140, 280, 420, 540, 620].forEach((offsetTop, index) => {
+      Object.defineProperty(sections[index], "offsetTop", {
+        configurable: true,
+        value: offsetTop,
+      });
+      Object.defineProperty(sections[index], "offsetHeight", {
+        configurable: true,
+        value: 120,
+      });
+      sections[index].getBoundingClientRect = vi.fn(() => ({
+        top: offsetTop - 500,
+        bottom: offsetTop - 500 + 120,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: 120,
+        x: 0,
+        y: offsetTop - 500,
+        toJSON: () => ({}),
+      }));
+    });
+
+    act(() => {
+      rightPane?.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+
+    const generalButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "SQL Optimization"
+    );
+
+    expect(generalButton?.className).toContain("bg-muted/40");
+  });
+
+  it("marks SQL Generation active when it becomes the first visible group", () => {
+    useChatCommandsMock.mockReturnValue({
+      commands: [{ skillId: "source-code-inspection" }],
+      loading: false,
+    });
+
+    act(() => {
+      root.render(<SampleQuestions onQuestionClick={vi.fn()} />);
+    });
+
+    const rightPane = container.querySelector(
+      "[data-sample-questions-right-pane='true']"
+    ) as HTMLDivElement | null;
+    const sections = Array.from(container.querySelectorAll("section"));
+
+    expect(rightPane).toBeTruthy();
+
+    Object.defineProperties(rightPane!, {
+      scrollTop: {
+        configurable: true,
+        writable: true,
+        value: 560,
+      },
+      clientHeight: {
+        configurable: true,
+        value: 260,
+      },
+      scrollHeight: {
+        configurable: true,
+        value: 900,
+      },
+    });
+
+    rightPane!.getBoundingClientRect = vi.fn(() => ({
+      top: 0,
+      bottom: 260,
+      left: 0,
+      right: 0,
+      width: 0,
+      height: 260,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }));
+
+    [0, 140, 280, 420, 560, 700].forEach((offsetTop, index) => {
+      Object.defineProperty(sections[index], "offsetTop", {
+        configurable: true,
+        value: offsetTop,
+      });
+      Object.defineProperty(sections[index], "offsetHeight", {
+        configurable: true,
+        value: 110,
+      });
+      sections[index].getBoundingClientRect = vi.fn(() => ({
+        top: offsetTop - 560,
+        bottom: offsetTop - 560 + 110,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: 110,
+        x: 0,
+        y: offsetTop - 560,
+        toJSON: () => ({}),
+      }));
+    });
+
+    act(() => {
+      rightPane?.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+
+    const sqlGenerationButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "SQL Generation"
+    );
+
+    expect(sqlGenerationButton?.className).toContain("bg-muted/40");
+  });
+});

--- a/src/components/chat/view/sample-questions.tsx
+++ b/src/components/chat/view/sample-questions.tsx
@@ -94,22 +94,22 @@ function SampleQuestionsShell({ greeting, children }: { greeting: string; childr
   return (
     <div
       data-sample-questions-scroll-root="true"
-      className="w-full shrink-0 overflow-x-hidden px-3 pt-4"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 pt-4"
     >
-      <div className="mb-0 flex w-full max-w-full flex-col items-center pb-0">
+      <div className="mb-0 flex shrink-0 w-full max-w-full flex-col items-center pb-0">
         <div className="mb-0">
           <AppLogo width={64} height={64} />
         </div>
         <p className="mt-0 mb-0 text-center text-xl font-medium">{greeting}</p>
-        {children}
       </div>
+      {children}
     </div>
   );
 }
 
 function LoadingSkeleton() {
   return (
-    <div className="mt-6 grid w-full max-w-5xl gap-6 md:grid-cols-[200px_minmax(0,1fr)]">
+    <div className="mx-auto mt-6 grid w-full max-w-5xl gap-6 md:grid-cols-[200px_minmax(0,1fr)]">
       <div className="hidden flex-col gap-2 md:flex">
         {[1, 2, 3, 4].map((i) => (
           <Skeleton key={i} className="h-8 w-36 rounded-lg" />
@@ -233,8 +233,8 @@ export function SampleQuestions({
     return null;
   }
 
-  const questionCardClassName =
-    "group relative w-full rounded-2xl border border-border/50 bg-card px-4 py-4 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-border hover:bg-muted/20";
+  const questionItemClassName =
+    "group w-full rounded-lg px-1 py-2 text-left transition-colors hover:bg-muted/20";
 
   const renderGroupSection = (
     [group, { icon, questions }]: readonly [string, QuestionGroupData],
@@ -257,12 +257,12 @@ export function SampleQuestions({
         </div>
         <div className="h-px bg-border/60" />
       </div>
-      <div className="space-y-2.5">
+      <div className="space-y-1.5">
         {questions.map((question) => (
           <button
             key={question.text}
             type="button"
-            className={questionCardClassName}
+            className={questionItemClassName}
             onClick={() => onQuestionClick(question)}
           >
             <span className="flex items-start gap-3">
@@ -270,9 +270,7 @@ export function SampleQuestions({
                 aria-hidden="true"
                 className="mt-2 h-2 w-2 shrink-0 rounded-full bg-foreground/50 transition-colors group-hover:bg-primary"
               />
-              <span className="block text-sm font-medium leading-6 text-foreground">
-                {question.text}
-              </span>
+              <span className="block text-sm leading-6 text-foreground">{question.text}</span>
             </span>
           </button>
         ))}
@@ -283,7 +281,7 @@ export function SampleQuestions({
   if (isMobile) {
     return (
       <SampleQuestionsShell greeting={greeting}>
-        <div className="mt-6 w-full max-w-3xl space-y-6">
+        <div className="mx-auto mt-6 w-full max-w-3xl flex-1 overflow-y-auto space-y-6">
           {filteredGroups.map(renderGroupSection)}
         </div>
       </SampleQuestionsShell>
@@ -292,8 +290,8 @@ export function SampleQuestions({
 
   return (
     <SampleQuestionsShell greeting={greeting}>
-      <div className="mt-6 grid w-full max-w-5xl items-start gap-6 md:grid-cols-[200px_minmax(0,1fr)]">
-        <nav className="hidden h-fit md:block">
+      <div className="mx-auto mt-6 grid min-h-0 flex-1 w-full max-w-5xl gap-6 md:grid-cols-[200px_minmax(0,1fr)]">
+        <nav className="hidden self-start md:block">
           <div className="space-y-1 pr-2">
             {filteredGroups.map(([group, { icon }]) => {
               const isActive = group === activeGroup;
@@ -338,7 +336,7 @@ export function SampleQuestions({
         <div
           ref={rightPaneRef}
           data-sample-questions-right-pane="true"
-          className="space-y-6 md:max-h-[min(56vh,38rem)] md:overflow-y-auto md:pr-2"
+          className="min-h-0 self-stretch space-y-6 overflow-y-auto md:pr-2"
         >
           {filteredGroups.map(renderGroupSection)}
           <div aria-hidden="true" className="hidden md:block md:h-[min(18rem,40vh)]" />

--- a/src/components/chat/view/sample-questions.tsx
+++ b/src/components/chat/view/sample-questions.tsx
@@ -336,7 +336,7 @@ export function SampleQuestions({
         >
           {filteredGroups.map(renderGroupSection)}
 
-          {/* 24rem = 384px padding for scroll */} 
+          {/* 24rem = 384px padding for scroll */}
           <div aria-hidden="true" className="hidden md:block md:h-[24rem]" />
         </div>
       </div>

--- a/src/components/chat/view/sample-questions.tsx
+++ b/src/components/chat/view/sample-questions.tsx
@@ -233,8 +233,8 @@ export function SampleQuestions({
     return null;
   }
 
-  const questionItemClassName =
-    "group w-full rounded-lg px-1 py-2 text-left transition-colors hover:bg-muted/20";
+  const questionCardClassName =
+    "group relative w-full rounded-2xl border border-border/50 bg-card px-4 py-3 text-left shadow-sm transition-colors duration-150 hover:border-primary/40 hover:bg-accent/60 hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40 focus-visible:ring-offset-0 active:bg-accent/70";
 
   const renderGroupSection = (
     [group, { icon, questions }]: readonly [string, QuestionGroupData],
@@ -246,9 +246,9 @@ export function SampleQuestions({
         sectionRefs.current[group] = element;
       }}
       data-group-name={group}
-      className={cn("space-y-2.5", index > 0 && "pt-1")}
+      className={cn("space-y-1.5", index > 0 && "pt-1")}
     >
-      <div className="space-y-2">
+      <div className="space-y-1">
         <div className="flex items-center gap-2 px-1">
           <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted/40">
             {icon}
@@ -257,20 +257,16 @@ export function SampleQuestions({
         </div>
         <div className="h-px bg-border/60" />
       </div>
-      <div className="space-y-1.5">
+      <div className="space-y-2">
         {questions.map((question) => (
           <button
             key={question.text}
             type="button"
-            className={questionItemClassName}
+            className={questionCardClassName}
             onClick={() => onQuestionClick(question)}
           >
-            <span className="flex items-start gap-3">
-              <span
-                aria-hidden="true"
-                className="mt-2 h-2 w-2 shrink-0 rounded-full bg-foreground/50 transition-colors group-hover:bg-primary"
-              />
-              <span className="block text-sm leading-6 text-foreground">{question.text}</span>
+            <span className="block text-sm font-medium leading-6 text-foreground transition-colors group-hover:text-primary group-focus-visible:text-primary">
+              {question.text}
             </span>
           </button>
         ))}

--- a/src/components/chat/view/sample-questions.tsx
+++ b/src/components/chat/view/sample-questions.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import { AppLogo } from "@/components/app-logo";
+import { useChatCommands } from "@/components/chat/command-context";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
+import { Activity, BarChart, Code2, Globe, Lightbulb, Zap } from "lucide-react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+
+export type Question = { text: string; autoRun?: boolean; requiredSkillId?: string };
+
+export type QuestionGroupData = {
+  icon: ReactNode;
+  questions: Question[];
+};
+
+export const DEFAULT_CHAT_QUESTION_GROUPS: Record<string, QuestionGroupData> = {
+  Diagnostics: {
+    icon: <Activity className="h-4 w-4 text-blue-500" />,
+    questions: [
+      { text: "What's the status of the current cluster?", autoRun: true },
+      { text: "Which table has the largest number of parts and what's the cause?", autoRun: true },
+    ],
+  },
+  "Data Exploration": {
+    icon: <Globe className="h-4 w-4 text-green-500" />,
+    questions: [
+      {
+        text: "What're the top 3 SELECT queries that consume the most CPU time over the past 3 hours",
+        autoRun: true,
+      },
+      {
+        text: "How many INSERT queries as well as insert rows, insert bytes were executed in the last 1 hour from @system.query_log?",
+        autoRun: true,
+      },
+    ],
+  },
+  Visualization: {
+    icon: <BarChart className="h-4 w-4 text-purple-500" />,
+    questions: [
+      {
+        text: "Show me the number of SELECT queries by minute from @system.query_log over the past 3 hours in bar chart",
+        autoRun: true,
+      },
+      {
+        text: "Visualize the trend of ProfileEvent_DistributedConnectionFailTry from the @system.metric_log by hour in the last 12 hours",
+        autoRun: true,
+      },
+      {
+        text: "Show the distribution of query kind from the @system.query_log in the last 12 hours in pie chart",
+        autoRun: true,
+      },
+    ],
+  },
+  "SQL Optimization": {
+    icon: <Zap className="h-4 w-4 text-amber-500" />,
+    questions: [
+      { text: "Help me optimize a query", autoRun: true },
+      { text: "Find the top 1 slowest query in the last 1 day and optimize it", autoRun: true },
+    ],
+  },
+  "SQL Generation": {
+    icon: <Code2 className="h-4 w-4 text-green-500" />,
+    questions: [
+      {
+        text: "Generate a SELECT query to get the slowest query from the query log in the last 1 hour",
+        autoRun: true,
+      },
+    ],
+  },
+  General: {
+    icon: <Lightbulb className="h-4 w-4 text-yellow-500" />,
+    questions: [
+      { text: "What are the best practices for partitioning?", autoRun: true },
+      {
+        text: "How does async_insert work from the source code? Will data be lost if the server is restarted when this setting is enabled?",
+        autoRun: true,
+        requiredSkillId: "source-code-inspection",
+      },
+    ],
+  },
+};
+
+const GREETINGS = [
+  "Hello there! How can I help you today?",
+  "Hi there! What would you like to explore?",
+  "Good to see you! Ready to dive into your data?",
+  "Nice to meet you! What can I help you analyze?",
+  "Hello and welcome! Let's explore your ClickHouse cluster and data!",
+];
+
+function SampleQuestionsShell({ greeting, children }: { greeting: string; children: ReactNode }) {
+  return (
+    <div
+      data-sample-questions-scroll-root="true"
+      className="w-full shrink-0 overflow-x-hidden px-3 pt-4"
+    >
+      <div className="mb-0 flex w-full max-w-full flex-col items-center pb-0">
+        <div className="mb-0">
+          <AppLogo width={64} height={64} />
+        </div>
+        <p className="mt-0 mb-0 text-center text-xl font-medium">{greeting}</p>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="mt-6 grid w-full max-w-5xl gap-6 md:grid-cols-[200px_minmax(0,1fr)]">
+      <div className="hidden flex-col gap-2 md:flex">
+        {[1, 2, 3, 4].map((i) => (
+          <Skeleton key={i} className="h-8 w-36 rounded-lg" />
+        ))}
+      </div>
+      <div className="space-y-6">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="space-y-3">
+            <div className="flex items-center gap-2 px-1">
+              <Skeleton className="h-4 w-4 rounded-full" />
+              <Skeleton className="h-5 w-32" />
+            </div>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <Skeleton className="h-32 rounded-2xl" />
+              <Skeleton className="h-32 rounded-2xl" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function SampleQuestions({
+  onQuestionClick,
+}: {
+  onQuestionClick: (question: Question) => void;
+}) {
+  const { commands, loading } = useChatCommands();
+  const isMobile = useIsMobile();
+  const rightPaneRef = useRef<HTMLDivElement | null>(null);
+  const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
+  const [activeGroup, setActiveGroup] = useState<string | null>(null);
+  const [greeting] = useState(() => GREETINGS[Math.floor(Math.random() * GREETINGS.length)]);
+
+  const availableSkillIds = useMemo(
+    () => new Set(commands.map((command) => command.skillId)),
+    [commands]
+  );
+
+  const filteredGroups = useMemo(() => {
+    return Object.entries(DEFAULT_CHAT_QUESTION_GROUPS)
+      .map(([group, data]) => {
+        const questions = data.questions.filter(
+          (question) => !question.requiredSkillId || availableSkillIds.has(question.requiredSkillId)
+        );
+        return [group, { ...data, questions }] as const;
+      })
+      .filter(([, data]) => data.questions.length > 0);
+  }, [availableSkillIds]);
+
+  useEffect(() => {
+    setActiveGroup(filteredGroups[0]?.[0] ?? null);
+  }, [filteredGroups]);
+
+  useEffect(() => {
+    if (isMobile || filteredGroups.length === 0) {
+      return;
+    }
+
+    const scrollRoot = rightPaneRef.current;
+    if (!(scrollRoot instanceof HTMLElement)) {
+      return;
+    }
+
+    const updateActiveGroup = () => {
+      const rootRect = scrollRoot.getBoundingClientRect();
+      const threshold = rootRect.top + 12;
+      let nextGroup = filteredGroups[filteredGroups.length - 1]?.[0] ?? null;
+
+      for (let index = 0; index < filteredGroups.length; index += 1) {
+        const [group] = filteredGroups[index];
+        const section = sectionRefs.current[group];
+        if (!section) {
+          continue;
+        }
+
+        const rect = section.getBoundingClientRect();
+
+        if (rect.bottom > threshold) {
+          nextGroup = group;
+          break;
+        }
+      }
+
+      setActiveGroup((current) => (current === nextGroup ? current : nextGroup));
+    };
+
+    updateActiveGroup();
+
+    let ticking = false;
+    const onScroll = () => {
+      if (ticking) {
+        return;
+      }
+      ticking = true;
+      requestAnimationFrame(() => {
+        ticking = false;
+        updateActiveGroup();
+      });
+    };
+
+    scrollRoot.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+
+    return () => {
+      scrollRoot.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+    };
+  }, [filteredGroups, isMobile]);
+
+  if (loading) {
+    return (
+      <SampleQuestionsShell greeting={greeting}>
+        <LoadingSkeleton />
+      </SampleQuestionsShell>
+    );
+  }
+
+  if (filteredGroups.length === 0) {
+    return null;
+  }
+
+  const questionCardClassName =
+    "group relative w-full rounded-2xl border border-border/50 bg-card px-4 py-4 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-border hover:bg-muted/20";
+
+  const renderGroupSection = (
+    [group, { icon, questions }]: readonly [string, QuestionGroupData],
+    index: number
+  ) => (
+    <section
+      key={group}
+      ref={(element) => {
+        sectionRefs.current[group] = element;
+      }}
+      data-group-name={group}
+      className={cn("space-y-2.5", index > 0 && "pt-1")}
+    >
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 px-1">
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted/40">
+            {icon}
+          </div>
+          <h3 className="text-base font-semibold text-foreground">{group}</h3>
+        </div>
+        <div className="h-px bg-border/60" />
+      </div>
+      <div className="space-y-2.5">
+        {questions.map((question) => (
+          <button
+            key={question.text}
+            type="button"
+            className={questionCardClassName}
+            onClick={() => onQuestionClick(question)}
+          >
+            <span className="flex items-start gap-3">
+              <span
+                aria-hidden="true"
+                className="mt-2 h-2 w-2 shrink-0 rounded-full bg-foreground/50 transition-colors group-hover:bg-primary"
+              />
+              <span className="block text-sm font-medium leading-6 text-foreground">
+                {question.text}
+              </span>
+            </span>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+
+  if (isMobile) {
+    return (
+      <SampleQuestionsShell greeting={greeting}>
+        <div className="mt-6 w-full max-w-3xl space-y-6">
+          {filteredGroups.map(renderGroupSection)}
+        </div>
+      </SampleQuestionsShell>
+    );
+  }
+
+  return (
+    <SampleQuestionsShell greeting={greeting}>
+      <div className="mt-6 grid w-full max-w-5xl items-start gap-6 md:grid-cols-[200px_minmax(0,1fr)]">
+        <nav className="hidden h-fit md:block">
+          <div className="space-y-1 pr-2">
+            {filteredGroups.map(([group, { icon }]) => {
+              const isActive = group === activeGroup;
+              return (
+                <button
+                  key={group}
+                  type="button"
+                  className={cn(
+                    "flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm transition-colors",
+                    isActive
+                      ? "bg-muted/40 text-foreground"
+                      : "text-muted-foreground hover:bg-muted/20 hover:text-foreground"
+                  )}
+                  onClick={() => {
+                    const scrollRoot = rightPaneRef.current;
+                    const section = sectionRefs.current[group];
+                    if (!scrollRoot || !section) {
+                      return;
+                    }
+
+                    setActiveGroup(group);
+                    section.scrollIntoView({
+                      block: "start",
+                      behavior: "smooth",
+                    });
+                  }}
+                >
+                  <span
+                    className={cn(
+                      "flex h-4 w-4 shrink-0 items-center justify-center opacity-80 transition-opacity",
+                      isActive ? "opacity-100" : "opacity-70"
+                    )}
+                  >
+                    {icon}
+                  </span>
+                  <span className="truncate font-medium">{group}</span>
+                </button>
+              );
+            })}
+          </div>
+        </nav>
+        <div
+          ref={rightPaneRef}
+          data-sample-questions-right-pane="true"
+          className="space-y-6 md:max-h-[min(56vh,38rem)] md:overflow-y-auto md:pr-2"
+        >
+          {filteredGroups.map(renderGroupSection)}
+          <div aria-hidden="true" className="hidden md:block md:h-[min(18rem,40vh)]" />
+        </div>
+      </div>
+    </SampleQuestionsShell>
+  );
+}

--- a/src/components/chat/view/sample-questions.tsx
+++ b/src/components/chat/view/sample-questions.tsx
@@ -27,11 +27,11 @@ export const DEFAULT_CHAT_QUESTION_GROUPS: Record<string, QuestionGroupData> = {
     icon: <Globe className="h-4 w-4 text-green-500" />,
     questions: [
       {
-        text: "What're the top 3 SELECT queries that consume the most CPU time over the past 3 hours",
+        text: "What're the top 3 SELECT queries that consume the most CPU time over the past 3 hours?",
         autoRun: true,
       },
       {
-        text: "How many INSERT queries as well as insert rows, insert bytes were executed in the last 1 hour from @system.query_log?",
+        text: "How many INSERT queries, insert rows, insert bytes were executed in the last 1 hour from @system.query_log ?",
         autoRun: true,
       },
     ],
@@ -94,7 +94,7 @@ function SampleQuestionsShell({ greeting, children }: { greeting: string; childr
   return (
     <div
       data-sample-questions-scroll-root="true"
-      className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 pt-4"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 pt-2"
     >
       <div className="mb-0 flex shrink-0 w-full max-w-full flex-col items-center pb-0">
         <div className="mb-0">
@@ -234,7 +234,7 @@ export function SampleQuestions({
   }
 
   const questionCardClassName =
-    "group relative w-full rounded-2xl border border-border/50 bg-card px-4 py-3 text-left shadow-sm transition-colors duration-150 hover:border-primary/40 hover:bg-accent/60 hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40 focus-visible:ring-offset-0 active:bg-accent/70";
+    "group relative w-full rounded-xl border border-border/50 bg-card px-3 py-3 text-left shadow-sm transition-colors duration-150 hover:border-primary/40 hover:bg-accent/60 hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40 focus-visible:ring-offset-0 active:bg-accent/70";
 
   const renderGroupSection = (
     [group, { icon, questions }]: readonly [string, QuestionGroupData],
@@ -249,7 +249,7 @@ export function SampleQuestions({
       className={cn("space-y-1.5", index > 0 && "pt-1")}
     >
       <div className="space-y-1">
-        <div className="flex items-center gap-2 px-1">
+        <div className="flex items-center gap-1 px-1">
           <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted/40">
             {icon}
           </div>
@@ -265,7 +265,7 @@ export function SampleQuestions({
             className={questionCardClassName}
             onClick={() => onQuestionClick(question)}
           >
-            <span className="block text-sm font-medium leading-6 text-foreground transition-colors group-hover:text-primary group-focus-visible:text-primary">
+            <span className="block break-words [overflow-wrap:anywhere] text-sm font-medium leading-6 text-foreground transition-colors group-hover:text-primary group-focus-visible:text-primary">
               {question.text}
             </span>
           </button>
@@ -286,9 +286,9 @@ export function SampleQuestions({
 
   return (
     <SampleQuestionsShell greeting={greeting}>
-      <div className="mx-auto mt-6 grid min-h-0 flex-1 w-full max-w-5xl gap-6 md:grid-cols-[200px_minmax(0,1fr)]">
+      <div className="mx-auto mt-6 grid min-h-0 flex-1 w-full max-w-5xl gap-0 md:grid-cols-[200px_minmax(0,1fr)]">
         <nav className="hidden self-start md:block">
-          <div className="space-y-1 pr-2">
+          <div className="space-y-1">
             {filteredGroups.map(([group, { icon }]) => {
               const isActive = group === activeGroup;
               return (
@@ -335,7 +335,9 @@ export function SampleQuestions({
           className="min-h-0 self-stretch space-y-6 overflow-y-auto md:pr-2"
         >
           {filteredGroups.map(renderGroupSection)}
-          <div aria-hidden="true" className="hidden md:block md:h-[min(18rem,40vh)]" />
+
+          {/* 24rem = 384px padding for scroll */} 
+          <div aria-hidden="true" className="hidden md:block md:h-[24rem]" />
         </div>
       </div>
     </SampleQuestionsShell>

--- a/src/components/sidebar-panel/sidebar-panel.tsx
+++ b/src/components/sidebar-panel/sidebar-panel.tsx
@@ -95,7 +95,7 @@ function SidebarTabHeader() {
             className="shrink-0 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-background h-full px-3 whitespace-nowrap"
           >
             <MessagesSquare className="h-4 w-4 mr-2" />
-            Chats
+            Sessions
           </TabsTrigger>
         </TabsList>
       </div>


### PR DESCRIPTION
## Summary
- rename the sidebar history tab from Chats to Sessions
- mute connection, date-group, and chat icons when they do not belong to the current connection
- continue the sample-questions refactor into a dedicated component and polish the empty-state layout, scrolling, and interaction styling

## Validation
- npm run format
- npm run typecheck
- npm run lint
- npm run test -- src/components/chat/view/sample-questions.test.tsx
- npm run build *(fails in this worktree because vendored paths like external/number-flow and external/*/skills are missing here)*