### PR TITLE
Generalize SQL editor AI actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Primary areas:
 - Before editing, inspect nearby files to match the local style, naming, and data flow.
 - When behavior changes, update or add tests where practical instead of relying on explanation alone.
 - After code changes, run `npm run format`.
+- After TypeScript or TSX changes, run `npm run typecheck`.
 - After code changes, run the narrowest relevant validation first, then broaden only if needed.
 - Mention any validation you could not run and any assumptions that remain unverified.
 
@@ -78,7 +79,7 @@ Apply the `vercel-react-best-practices` skill when writing, reviewing, or refact
 ## Testing Guidance
 
 - After code changes, run `npm run format`.
-- Minimum preferred validation for TypeScript code changes: `npm run typecheck`.
+- For TypeScript or TSX changes, run `npm run typecheck`.
 - For changes to `src/**/*.ts` or `src/**/*.tsx`, run `npm run lint`.
 - For non-`src` changes, run `npm run lint` whenever the touched files or config can affect ESLint behavior or results.
 - For behavior changes with test coverage, run `npm run test` or the narrowest Vitest target available.

--- a/resources/skills/optimize-clickhouse-sql/SKILL.md
+++ b/resources/skills/optimize-clickhouse-sql/SKILL.md
@@ -1,8 +1,9 @@
 ---
-name: optimize-clickhouse-queries
+name: optimize-clickhouse-sql
 description: Optimize slow queries, analyze SQL performance, and collect evidence for expensive workloads.
 metadata:
   author: System
+  show-in-sql-editor-quick-action: true
 ---
 
 # SQL Optimization Skill

--- a/src/components/app-sidebar.test.tsx
+++ b/src/components/app-sidebar.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppSidebar } from "./app-sidebar";
+
+const { openMock, setDisplayModeMock, setActiveSidebarTabMock } = vi.hoisted(() => ({
+  openMock: vi.fn(),
+  setDisplayModeMock: vi.fn(),
+  setActiveSidebarTabMock: vi.fn(),
+}));
+
+const testGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+vi.mock("@/components/chat/view/use-chat-panel", () => ({
+  useChatPanel: () => ({
+    open: openMock,
+    setDisplayMode: setDisplayModeMock,
+    setActiveSidebarTab: setActiveSidebarTabMock,
+  }),
+}));
+
+vi.mock("@/components/connection/connection-context", () => ({
+  useConnection: () => ({
+    isConnectionAvailable: true,
+    pendingConfig: null,
+    connection: null,
+  }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: null }),
+  signOut: vi.fn(),
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  Sidebar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarMenuItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarMenuButton: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => <button onClick={onClick}>{children}</button>,
+  SidebarMenuSub: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarMenuSubButton: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarMenuSubItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  useSidebar: () => ({ isMobile: false, state: "collapsed" }),
+}));
+
+vi.mock("@/components/app-logo", () => ({
+  AppLogo: () => <div>Logo</div>,
+}));
+
+vi.mock("@/components/connection/connection-selector", () => ({
+  ConnectionSelector: () => <div>ConnectionSelector</div>,
+}));
+
+vi.mock("@/components/connection/connection-selector-dialog", () => ({
+  openConnectionSelectorDialog: vi.fn(),
+}));
+
+vi.mock("@/components/release-note/release-notes-view", () => ({
+  openReleaseNotes: vi.fn(),
+}));
+
+vi.mock("./dashboard-tab/dashboard-list", () => ({
+  DashboardList: () => <div>DashboardList</div>,
+}));
+
+vi.mock("./settings/settings-dialog", () => ({
+  showSettingsDialog: vi.fn(),
+}));
+
+vi.mock("@/components/user-profile-image", () => ({
+  UserProfileImage: () => <div>UserProfileImage</div>,
+}));
+
+vi.mock("@/components/ui/collapsible", () => ({
+  Collapsible: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => <button onClick={onClick}>{children}</button>,
+  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <div />,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/hover-card", () => ({
+  HoverCard: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  HoverCardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  HoverCardTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe("AppSidebar", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+    openMock.mockReset();
+    setDisplayModeMock.mockReset();
+    setActiveSidebarTabMock.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("opens the AI sidebar in panel mode when the active tab is the query editor", async () => {
+    await act(async () => {
+      root.render(<AppSidebar />);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent("ACTIVE_TAB_CHANGE", {
+          detail: {
+            tabId: "query",
+            tabInfo: { id: "query", type: "query" },
+          },
+        })
+      );
+    });
+
+    const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("Work with AI")
+    );
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(setActiveSidebarTabMock).toHaveBeenCalledWith("history");
+    expect(setDisplayModeMock).toHaveBeenCalledWith("panel");
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the default chat open behavior when the active tab is not the query editor", async () => {
+    await act(async () => {
+      root.render(<AppSidebar />);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent("ACTIVE_TAB_CHANGE", {
+          detail: {
+            tabId: "database:default",
+            tabInfo: { id: "database:default", type: "database", database: "default" },
+          },
+        })
+      );
+    });
+
+    const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("Work with AI")
+    );
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(setActiveSidebarTabMock).toHaveBeenCalledWith("history");
+    expect(openMock).toHaveBeenCalled();
+    expect(setDisplayModeMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -49,7 +49,7 @@ import { signOut, useSession } from "next-auth/react";
 import React, { useCallback, useEffect, useState } from "react";
 import { DashboardList } from "./dashboard-tab/dashboard-list";
 import { showSettingsDialog } from "./settings/settings-dialog";
-import { TabManager } from "./tab-manager";
+import { TabManager, type TabType } from "./tab-manager";
 
 function HoverCardSidebarMenuItem({
   icon,
@@ -292,11 +292,18 @@ function DashboardsSidebarMenuItem() {
 export function AppSidebar() {
   const { isConnectionAvailable, pendingConfig } = useConnection();
   const { data: session } = useSession();
-  const { open: openChatPanel, setActiveSidebarTab } = useChatPanel();
+  const { open: openChatPanel, setActiveSidebarTab, setDisplayMode } = useChatPanel();
+  const [activeTabType, setActiveTabType] = useState<TabType | null>(null);
 
   // Show connection selector if connection is available OR if there's a pending config (failed initialization)
   // This allows users to switch connections even after a failure
   const showConnectionSelector = isConnectionAvailable || !!pendingConfig;
+
+  useEffect(() => {
+    return TabManager.onActiveTabChange((event) => {
+      setActiveTabType(event.detail.tabInfo?.type ?? null);
+    });
+  }, []);
 
   return (
     <Sidebar collapsible="icon">
@@ -323,7 +330,11 @@ export function AppSidebar() {
                     size="default"
                     onClick={() => {
                       setActiveSidebarTab("history");
-                      openChatPanel();
+                      if (activeTabType === "query") {
+                        setDisplayMode("panel");
+                      } else {
+                        openChatPanel();
+                      }
                     }}
                   >
                     <Sparkles className="h-5 w-5" />

--- a/src/components/chat/agent-command-browser-panel.tsx
+++ b/src/components/chat/agent-command-browser-panel.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+import * as React from "react";
+
+export interface AgentCommandBrowserItem {
+  key: string;
+  label: React.ReactNode;
+  description?: string;
+  icon?: React.ReactNode;
+  separatorBefore?: boolean;
+  itemClassName?: string;
+  labelClassName?: string;
+}
+
+export interface AgentCommandBrowserPanelRef {
+  getActiveItem: () => AgentCommandBrowserItem | null;
+  moveActiveIndex: (delta: number) => void;
+  setActiveIndex: (index: number) => void;
+}
+
+interface AgentCommandBrowserPanelProps {
+  emptyText?: string;
+  groupHeading?: string;
+  items: AgentCommandBrowserItem[];
+  onSelectItem: (item: AgentCommandBrowserItem) => void;
+}
+
+export const AgentCommandBrowserPanel = React.forwardRef<
+  AgentCommandBrowserPanelRef,
+  AgentCommandBrowserPanelProps
+>(function AgentCommandBrowserPanel(
+  { emptyText = "No commands found", groupHeading = "Commands", items, onSelectItem },
+  ref
+) {
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const activeItemRef = React.useRef<HTMLDivElement>(null);
+  const activeItem = items[activeIndex] ?? null;
+
+  React.useEffect(() => {
+    setActiveIndex((current) => {
+      if (items.length === 0) {
+        return 0;
+      }
+      return Math.min(current, items.length - 1);
+    });
+  }, [items]);
+
+  React.useImperativeHandle(
+    ref,
+    () => ({
+      getActiveItem: () => items[activeIndex] ?? null,
+      moveActiveIndex: (delta: number) => {
+        if (items.length === 0) {
+          return;
+        }
+        setActiveIndex((current) => (current + delta + items.length) % items.length);
+      },
+      setActiveIndex: (index: number) => {
+        if (items.length === 0) {
+          setActiveIndex(0);
+          return;
+        }
+        const nextIndex = Math.max(0, Math.min(index, items.length - 1));
+        setActiveIndex(nextIndex);
+      },
+    }),
+    [activeIndex, items]
+  );
+
+  React.useEffect(() => {
+    if (activeItemRef.current && typeof activeItemRef.current.scrollIntoView === "function") {
+      activeItemRef.current.scrollIntoView({ block: "nearest" });
+    }
+  }, [activeIndex]);
+
+  return (
+    <div className="flex items-stretch max-h-[300px]">
+      <div
+        data-panel="left"
+        className={cn(
+          "flex flex-col border shadow-md w-[280px] bg-popover rounded-sm",
+          activeItem?.description && "rounded-r-none"
+        )}
+      >
+        <Command
+          className="flex-1 rounded-none border-0 shadow-none bg-transparent"
+          value={activeItem?.key}
+          shouldFilter={false}
+        >
+          <CommandList className="flex-1 overflow-y-auto pt-1">
+            <CommandEmpty>{emptyText}</CommandEmpty>
+            {items.length > 0 && (
+              <CommandGroup heading={groupHeading} className="py-0 [&_[cmdk-group-heading]]:py-1">
+                {items.map((item, index) => {
+                  const isSelected = index === activeIndex;
+                  const isLastItem = index === items.length - 1;
+                  return (
+                    <React.Fragment key={item.key}>
+                      {item.separatorBefore ? <CommandSeparator className="my-1" /> : null}
+                      <CommandItem
+                        value={item.key}
+                        onSelect={() => onSelectItem(item)}
+                        onMouseEnter={() => setActiveIndex(index)}
+                        className={cn(
+                          "py-1 pl-4 pr-3 flex w-full items-center gap-2 cursor-pointer hover:bg-accent hover:text-accent-foreground",
+                          isLastItem && "pb-2",
+                          item.itemClassName,
+                          isSelected && "bg-accent text-accent-foreground"
+                        )}
+                        ref={isSelected ? activeItemRef : null}
+                      >
+                        {item.icon ? (
+                          <span className="shrink-0 flex items-center">{item.icon}</span>
+                        ) : null}
+                        <span
+                          className={cn(
+                            "flex-1 min-w-0 truncate font-mono text-xs",
+                            item.labelClassName
+                          )}
+                        >
+                          {item.label}
+                        </span>
+                      </CommandItem>
+                    </React.Fragment>
+                  );
+                })}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </div>
+
+      {activeItem?.description ? (
+        <div
+          data-panel="right"
+          className="w-[320px] overflow-y-auto overflow-x-hidden p-2 bg-popover border border-l-0 shadow-md rounded-md rounded-l-none"
+        >
+          <div className="text-xs">
+            <div className="text-muted-foreground mb-0.5">Description</div>
+            <div className="text-foreground whitespace-pre-wrap break-all">
+              {activeItem.description}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+});

--- a/src/components/chat/agent-command-context.tsx
+++ b/src/components/chat/agent-command-context.tsx
@@ -4,19 +4,19 @@ import type { CommandDetail } from "@/lib/ai/commands/command-manager";
 import { BasePath } from "@/lib/base-path";
 import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
 
-interface CommandContextValue {
+interface AgentCommandContextValue {
   commands: CommandDetail[];
   commandsByName: Map<string, CommandDetail>;
   loading: boolean;
 }
 
-const CommandContext = createContext<CommandContextValue>({
+const AgentCommandContext = createContext<AgentCommandContextValue>({
   commands: [],
   commandsByName: new Map<string, CommandDetail>(),
   loading: false,
 });
 
-export function ChatCommandProvider({ children }: { children: React.ReactNode }) {
+export function AgentCommandProvider({ children }: { children: React.ReactNode }) {
   const [commands, setCommands] = useState<CommandDetail[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -48,7 +48,7 @@ export function ChatCommandProvider({ children }: { children: React.ReactNode })
     };
   }, []);
 
-  const value = useMemo<CommandContextValue>(() => {
+  const value = useMemo<AgentCommandContextValue>(() => {
     return {
       commands,
       commandsByName: new Map(commands.map((command) => [command.name, command])),
@@ -56,9 +56,9 @@ export function ChatCommandProvider({ children }: { children: React.ReactNode })
     };
   }, [commands, loading]);
 
-  return <CommandContext.Provider value={value}>{children}</CommandContext.Provider>;
+  return <AgentCommandContext.Provider value={value}>{children}</AgentCommandContext.Provider>;
 }
 
-export function useChatCommands() {
-  return useContext(CommandContext);
+export function useAgentCommands() {
+  return useContext(AgentCommandContext);
 }

--- a/src/components/chat/input/chat-input-commands.tsx
+++ b/src/components/chat/input/chat-input-commands.tsx
@@ -1,17 +1,13 @@
 "use client";
 
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
+  AgentCommandBrowserPanel,
+  type AgentCommandBrowserPanelRef,
+} from "@/components/chat/agent-command-browser-panel";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import type { CommandDetail } from "@/lib/ai/commands/command-manager";
 import { StringUtils } from "@/lib/string-utils";
 import { TextHighlighter } from "@/lib/text-highlighter";
-import { cn } from "@/lib/utils";
 import * as React from "react";
 
 export interface ChatInputCommandsType {
@@ -32,9 +28,8 @@ export const ChatInputCommands = React.memo(
   React.forwardRef<ChatInputCommandsType, ChatInputCommandsProps>(
     ({ commands, onSelect, onInteractOutside }, ref) => {
       const [open, setOpen] = React.useState(false);
-      const [activeIndex, setActiveIndex] = React.useState(0);
       const [query, setQuery] = React.useState("");
-      const activeItemRef = React.useRef<HTMLDivElement>(null);
+      const commandBrowserRef = React.useRef<AgentCommandBrowserPanelRef>(null);
 
       const filtered = React.useMemo(() => {
         if (!query) {
@@ -50,26 +45,26 @@ export const ChatInputCommands = React.memo(
           .filter((c) => c.matchStart >= 0);
       }, [commands, query]);
 
-      const activeCommand = filtered[activeIndex] ?? null;
-
-      const description: React.ReactNode | null = activeCommand?.description ? (
-        <div className="text-xs">
-          <div className="text-muted-foreground mb-0.5">Description</div>
-          <div className="text-foreground whitespace-pre-wrap break-all">
-            {activeCommand.description}
-          </div>
-        </div>
-      ) : null;
+      React.useEffect(() => {
+        if (open) {
+          commandBrowserRef.current?.setActiveIndex(0);
+        }
+      }, [open, query, filtered.length]);
 
       React.useImperativeHandle(ref, () => ({
         open: (searchQuery: string) => {
           setQuery(searchQuery.toLowerCase());
-          setActiveIndex(0);
           setOpen(true);
         },
         close: () => setOpen(false),
         isOpen: () => open,
-        getSelected: () => activeCommand,
+        getSelected: () => {
+          const activeItem = commandBrowserRef.current?.getActiveItem();
+          if (!activeItem) {
+            return null;
+          }
+          return filtered.find((cmd) => cmd.name === activeItem.key) ?? null;
+        },
         handleKeyDown: (e: React.KeyboardEvent) => {
           if (!open) return false;
 
@@ -80,22 +75,26 @@ export const ChatInputCommands = React.memo(
 
           if (filtered.length > 0) {
             if (e.key === "ArrowDown") {
-              setActiveIndex((prev) => (prev + 1) % filtered.length);
+              commandBrowserRef.current?.moveActiveIndex(1);
               e.preventDefault();
               e.stopPropagation();
               return true;
             }
             if (e.key === "ArrowUp") {
-              setActiveIndex((prev) => (prev - 1 + filtered.length) % filtered.length);
+              commandBrowserRef.current?.moveActiveIndex(-1);
               e.preventDefault();
               e.stopPropagation();
               return true;
             }
             if (e.key === "Enter" && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
-              if (activeCommand) {
+              const activeItem = commandBrowserRef.current?.getActiveItem();
+              const selected = activeItem
+                ? (filtered.find((cmd) => cmd.name === activeItem.key) ?? null)
+                : null;
+              if (selected) {
                 e.preventDefault();
                 e.stopPropagation();
-                onSelect(activeCommand);
+                onSelect(selected);
                 setOpen(false);
               }
               return true;
@@ -105,12 +104,6 @@ export const ChatInputCommands = React.memo(
           return false;
         },
       }));
-
-      React.useEffect(() => {
-        if (open && activeItemRef.current) {
-          activeItemRef.current.scrollIntoView({ block: "nearest" });
-        }
-      }, [activeIndex, open]);
 
       const handleSelect = React.useCallback(
         (command: CommandDetail) => {
@@ -137,67 +130,30 @@ export const ChatInputCommands = React.memo(
               }
             }}
           >
-            <div className="flex items-stretch max-h-[300px]">
-              <div
-                data-panel="left"
-                className={cn(
-                  "flex flex-col border shadow-md w-[350px] bg-popover rounded-sm",
-                  description && "rounded-r-none"
-                )}
-              >
-                <Command
-                  className="flex-1 rounded-none border-0 shadow-none bg-transparent"
-                  value={activeCommand?.name}
-                  shouldFilter={false}
-                >
-                  <CommandList className="flex-1 overflow-y-auto pt-1">
-                    <CommandEmpty>No commands found</CommandEmpty>
-                    {filtered.length > 0 && (
-                      <CommandGroup
-                        heading="Commands"
-                        className="py-0 [&_[cmdk-group-heading]]:py-1"
-                      >
-                        {filtered.map((cmd, index) => {
-                          const isSelected = index === activeIndex;
-                          return (
-                            <CommandItem
-                              key={cmd.name}
-                              value={cmd.name}
-                              onSelect={() => handleSelect(cmd)}
-                              onMouseEnter={() => setActiveIndex(index)}
-                              className={cn(
-                                "py-1 pl-6 flex w-full items-center gap-2 cursor-pointer hover:bg-accent hover:text-accent-foreground",
-                                isSelected && "bg-accent text-accent-foreground"
-                              )}
-                              ref={isSelected ? activeItemRef : null}
-                            >
-                              <span className="flex-1 min-w-0 truncate font-mono text-xs">
-                                /
-                                {TextHighlighter.highlight2(
-                                  cmd.name,
-                                  cmd.matchStart,
-                                  cmd.matchStart >= 0 ? cmd.matchStart + cmd.matchLength : -1,
-                                  "text-yellow-500"
-                                )}
-                              </span>
-                            </CommandItem>
-                          );
-                        })}
-                      </CommandGroup>
+            <AgentCommandBrowserPanel
+              ref={commandBrowserRef}
+              items={filtered.map((cmd) => ({
+                key: cmd.name,
+                label: (
+                  <>
+                    /
+                    {TextHighlighter.highlight2(
+                      cmd.name,
+                      cmd.matchStart,
+                      cmd.matchStart >= 0 ? cmd.matchStart + cmd.matchLength : -1,
+                      "text-yellow-500"
                     )}
-                  </CommandList>
-                </Command>
-              </div>
-
-              {description && (
-                <div
-                  data-panel="right"
-                  className="w-[350px] overflow-y-auto overflow-x-hidden p-2 bg-popover border border-l-0 shadow-md rounded-md rounded-l-none"
-                >
-                  {description}
-                </div>
-              )}
-            </div>
+                  </>
+                ),
+                description: cmd.description,
+              }))}
+              onSelectItem={(item) => {
+                const selected = filtered.find((cmd) => cmd.name === item.key);
+                if (selected) {
+                  handleSelect(selected);
+                }
+              }}
+            />
           </PopoverContent>
         </Popover>
       );

--- a/src/components/chat/input/chat-input.images.test.tsx
+++ b/src/components/chat/input/chat-input.images.test.tsx
@@ -21,8 +21,8 @@ vi.mock("@/components/connection/connection-context", () => ({
   }),
 }));
 
-vi.mock("../command-context", () => ({
-  useChatCommands: () => ({
+vi.mock("../agent-command-context", () => ({
+  useAgentCommands: () => ({
     commands: [],
   }),
 }));

--- a/src/components/chat/input/chat-input.resize.test.tsx
+++ b/src/components/chat/input/chat-input.resize.test.tsx
@@ -17,8 +17,8 @@ vi.mock("@/components/connection/connection-context", () => ({
   }),
 }));
 
-vi.mock("../command-context", () => ({
-  useChatCommands: () => ({
+vi.mock("../agent-command-context", () => ({
+  useAgentCommands: () => ({
     commands: [],
   }),
 }));

--- a/src/components/chat/input/chat-input.test.ts
+++ b/src/components/chat/input/chat-input.test.ts
@@ -28,8 +28,8 @@ vi.mock("@/components/connection/connection-context", () => ({
   }),
 }));
 
-vi.mock("../command-context", () => ({
-  useChatCommands: () => ({
+vi.mock("../agent-command-context", () => ({
+  useAgentCommands: () => ({
     commands: [
       {
         name: "review",

--- a/src/components/chat/input/chat-input.tsx
+++ b/src/components/chat/input/chat-input.tsx
@@ -15,7 +15,7 @@ import { cn } from "@/lib/utils";
 import type { LanguageModelUsage } from "ai";
 import { ImagePlus, MessageSquarePlus, Plus, Send, Square, X } from "lucide-react";
 import * as React from "react";
-import { useChatCommands } from "../command-context";
+import { useAgentCommands } from "../agent-command-context";
 import { ChatTokenStatus } from "../message/chat-token-status";
 import { ChatInputCommands, type ChatInputCommandsType } from "./chat-input-commands";
 import {
@@ -418,7 +418,7 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
     const [suggestionStartPos, setSuggestionStartPos] = React.useState(0);
 
     const { connection } = useConnection();
-    const { commands, commandsByName } = useChatCommands();
+    const { commands, commandsByName } = useAgentCommands();
     const { selectedModel } = useModelConfig();
     const isResizable = resizedHeight !== null;
     const leadingCommand = React.useMemo(() => getLeadingCommand(input), [input]);

--- a/src/components/chat/message/message-user.test.tsx
+++ b/src/components/chat/message/message-user.test.tsx
@@ -9,8 +9,8 @@ import { MessageUser } from "./message-user";
 
 const messageMarkdownSpy = vi.fn();
 
-vi.mock("../command-context", () => ({
-  useChatCommands: () => ({
+vi.mock("../agent-command-context", () => ({
+  useAgentCommands: () => ({
     commandsByName: new Map([
       [
         "review",

--- a/src/components/chat/message/message-user.tsx
+++ b/src/components/chat/message/message-user.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo } from "react";
-import { useChatCommands } from "../command-context";
+import { useAgentCommands } from "../agent-command-context";
 import { getLeadingCommand } from "../input/command-utils";
 import { TABLE_MENTION_REGEX } from "../input/mention-utils";
 import { MessageMarkdown } from "./message-markdown";
@@ -12,7 +12,7 @@ import { SkillLink } from "./skill-link";
  * But some places given markdown text, like using ``` code blocks, in this case, we should not do the replacement.
  */
 export const MessageUser = memo(function MessageUser({ text }: { text: string }) {
-  const { commandsByName } = useChatCommands();
+  const { commandsByName } = useAgentCommands();
   const matchedCommand = text ? getLeadingCommand(text) : null;
   const command = matchedCommand ? commandsByName.get(matchedCommand.commandName) : null;
 

--- a/src/components/chat/view/chat-panel.tsx
+++ b/src/components/chat/view/chat-panel.tsx
@@ -33,6 +33,7 @@ interface ChatHeaderProps {
 
 type LoadChatOptions = {
   isNewSession?: boolean;
+  agentContext?: Partial<import("@/lib/ai/chat-types").AgentContext>;
 };
 
 function sanitizeFileName(input: string): string {
@@ -156,9 +157,14 @@ const ChatHeader = React.memo(
     }, []);
 
     return (
-      <div className="h-9 border-b flex items-center justify-between px-2 shrink-0 bg-background z-10">
-        <h2 className="text-sm font-semibold">{title || "Work with AI"}</h2>
-        <div className="flex items-center">
+      <div className="h-9 border-b flex items-center gap-2 px-2 shrink-0 bg-background z-10">
+        <h2
+          className="min-w-0 flex-1 truncate text-sm font-semibold"
+          title={title || "Work with AI"}
+        >
+          {title || "Work with AI"}
+        </h2>
+        <div className="flex items-center shrink-0">
           <Button
             variant="ghost"
             size="icon"
@@ -279,6 +285,7 @@ export function ChatPanel({ currentDatabase, availableTables, onClose }: ChatPan
         sessionId: chatIdToLoad,
         connection: connection!,
         initialMessages,
+        agentContext: options?.agentContext,
       });
       setChat(newChat);
       chatViewRef.current = null;
@@ -314,6 +321,7 @@ export function ChatPanel({ currentDatabase, availableTables, onClose }: ChatPan
         | {
             id: string;
             isNewSession: boolean;
+            agentContext?: Partial<import("@/lib/ai/chat-types").AgentContext>;
           }
         | undefined;
 
@@ -326,21 +334,32 @@ export function ChatPanel({ currentDatabase, availableTables, onClose }: ChatPan
         // Check if initialInput has a specific chatId
         loadTarget = { id: initialInput.chatId, isNewSession: false };
       } else if (currentPendingCommand?.forceNewChat) {
-        loadTarget = { id: createDraftSession().id, isNewSession: true };
+        loadTarget = {
+          id: createDraftSession().id,
+          isNewSession: true,
+          agentContext: currentPendingCommand.agentContext,
+        };
         previousChatIdRef.current = null;
         // Mark this command as processed to prevent duplicate handling
         const commandKey = `${currentPendingCommand.timestamp}-${currentPendingCommand.forceNewChat}`;
         processedPendingCommandRef.current = commandKey;
       } else if (currentPendingCommand?.text) {
         // If there's a pending command (but not forcing new chat), create a fresh session.
-        loadTarget = { id: createDraftSession().id, isNewSession: true };
+        loadTarget = {
+          id: createDraftSession().id,
+          isNewSession: true,
+          agentContext: currentPendingCommand.agentContext,
+        };
       } else {
         // Default to a fresh session when opening chat without an existing selection.
         loadTarget = { id: createDraftSession().id, isNewSession: true };
       }
 
       if (loadTarget) {
-        await loadChat(loadTarget.id, { isNewSession: loadTarget.isNewSession });
+        await loadChat(loadTarget.id, {
+          isNewSession: loadTarget.isNewSession,
+          agentContext: loadTarget.agentContext,
+        });
         if (selectedChat?.chatId === loadTarget.id) {
           clearSelectedChat();
         }
@@ -372,9 +391,13 @@ export function ChatPanel({ currentDatabase, availableTables, onClose }: ChatPan
       const chatId = createDraftSession().id;
       previousChatIdRef.current = chat.id;
       processedPendingCommandRef.current = commandKey;
-      await loadChat(chatId, { isNewSession: true });
+      await loadChat(chatId, {
+        isNewSession: true,
+        agentContext: pendingCommand.agentContext,
+      });
     })();
   }, [
+    pendingCommand?.agentContext,
     pendingCommand?.forceNewChat,
     pendingCommand?.timestamp,
     connection,

--- a/src/components/chat/view/chat-view.tsx
+++ b/src/components/chat/view/chat-view.tsx
@@ -19,7 +19,7 @@ import {
   type ReactNode,
 } from "react";
 import { v7 as uuidv7 } from "uuid";
-import { AgentCommandProvider, useAgentCommands } from "../agent-command-context";
+import { useAgentCommands } from "../agent-command-context";
 import { ChatActionProvider, type UserActionInput } from "../chat-action-context";
 import { ChatContext, getDatabaseContextFromConnection } from "../chat-context";
 import { ChatFactory } from "../chat-factory";
@@ -351,37 +351,35 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
       }
       chatId={chat.id}
     >
-      <AgentCommandProvider>
-        <div className="flex flex-col h-full bg-background overflow-hidden relative">
-          {isEmpty ? (
-            <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden px-3 flex flex-col">
-              <div className="flex flex-col items-center w-full max-w-full my-auto pb-8 pt-4">
-                <div className="mb-0">
-                  <AppLogo width={64} height={64} />
-                </div>
-                <p className="text-xl text-center font-medium mb-0 mt-0">{greeting}</p>
-                <SampleQuestions onQuestionClick={handleQuestionClick} />
+      <div className="flex flex-col h-full bg-background overflow-hidden relative">
+        {isEmpty ? (
+          <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden px-3 flex flex-col">
+            <div className="flex flex-col items-center w-full max-w-full my-auto pb-8 pt-4">
+              <div className="mb-0">
+                <AppLogo width={64} height={64} />
               </div>
+              <p className="text-xl text-center font-medium mb-0 mt-0">{greeting}</p>
+              <SampleQuestions onQuestionClick={handleQuestionClick} />
             </div>
-          ) : (
-            <ChatMessageList
-              messages={messages as AppUIMessage[]}
-              isRunning={isRunning}
-              error={error || null}
-            />
-          )}
-          <ChatInput
-            ref={chatInputRef}
-            onSubmit={handleSubmit}
-            onStop={handleStop}
+          </div>
+        ) : (
+          <ChatMessageList
+            messages={messages as AppUIMessage[]}
             isRunning={isRunning}
-            hasMessages={messages.length > 0}
-            tokenUsage={tokenUsage}
-            onNewChat={onNewChat}
-            externalInput={promptInput}
+            error={error || null}
           />
-        </div>
-      </AgentCommandProvider>
+        )}
+        <ChatInput
+          ref={chatInputRef}
+          onSubmit={handleSubmit}
+          onStop={handleStop}
+          isRunning={isRunning}
+          hasMessages={messages.length > 0}
+          tokenUsage={tokenUsage}
+          onNewChat={onNewChat}
+          externalInput={promptInput}
+        />
+      </div>
     </ChatActionProvider>
   );
 });

--- a/src/components/chat/view/chat-view.tsx
+++ b/src/components/chat/view/chat-view.tsx
@@ -19,10 +19,10 @@ import {
   type ReactNode,
 } from "react";
 import { v7 as uuidv7 } from "uuid";
+import { AgentCommandProvider, useAgentCommands } from "../agent-command-context";
 import { ChatActionProvider, type UserActionInput } from "../chat-action-context";
 import { ChatContext, getDatabaseContextFromConnection } from "../chat-context";
 import { ChatFactory } from "../chat-factory";
-import { ChatCommandProvider, useChatCommands } from "../command-context";
 import {
   ChatInput,
   type ChatInputHandle,
@@ -119,7 +119,7 @@ export function SampleQuestions({
 }: {
   onQuestionClick: (question: Question) => void;
 }) {
-  const { commands, loading } = useChatCommands();
+  const { commands, loading } = useAgentCommands();
   const availableSkillIds = useMemo(() => {
     return new Set(commands.map((command) => command.skillId));
   }, [commands]);
@@ -351,7 +351,7 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
       }
       chatId={chat.id}
     >
-      <ChatCommandProvider>
+      <AgentCommandProvider>
         <div className="flex flex-col h-full bg-background overflow-hidden relative">
           {isEmpty ? (
             <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden px-3 flex flex-col">
@@ -381,7 +381,7 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
             externalInput={promptInput}
           />
         </div>
-      </ChatCommandProvider>
+      </AgentCommandProvider>
     </ChatActionProvider>
   );
 });

--- a/src/components/chat/view/use-chat-panel.tsx
+++ b/src/components/chat/view/use-chat-panel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { AgentContext } from "@/lib/ai/chat-types";
 import React, { createContext, useContext, useState } from "react";
 
 export type ChatPanelDisplayMode = "hidden" | "panel" | "tabWidth" | "fullscreen";
@@ -24,8 +25,16 @@ interface ChatPanelContextType {
   newChatRequestNonce: number;
   activeSidebarTab: SidebarTab;
   setActiveSidebarTab: (tab: SidebarTab) => void;
-  postMessage: (text: string, options?: { forceNewChat?: boolean }) => void;
-  pendingCommand: { text: string; timestamp: number; forceNewChat?: boolean } | null;
+  postMessage: (
+    text: string,
+    options?: { forceNewChat?: boolean; agentContext?: Partial<AgentContext> }
+  ) => void;
+  pendingCommand: {
+    text: string;
+    timestamp: number;
+    forceNewChat?: boolean;
+    agentContext?: Partial<AgentContext>;
+  } | null;
   consumeCommand: () => void;
   setInitialInput: (text: string, chatId?: string) => void;
   initialInput: { text: string; chatId?: string } | null;
@@ -92,6 +101,7 @@ export function ChatPanelProvider({ children }: { children: React.ReactNode }) {
     text: string;
     timestamp: number;
     forceNewChat?: boolean;
+    agentContext?: Partial<AgentContext>;
   } | null>(null);
   const [initialInput, setInitialInputState] = useState<{ text: string; chatId?: string } | null>(
     null
@@ -137,8 +147,16 @@ export function ChatPanelProvider({ children }: { children: React.ReactNode }) {
     setDisplayMode("tabWidth");
   };
 
-  const postMessage = (text: string, options?: { forceNewChat?: boolean }) => {
-    setPendingCommand({ text, timestamp: Date.now(), forceNewChat: options?.forceNewChat });
+  const postMessage = (
+    text: string,
+    options?: { forceNewChat?: boolean; agentContext?: Partial<AgentContext> }
+  ) => {
+    setPendingCommand({
+      text,
+      timestamp: Date.now(),
+      forceNewChat: options?.forceNewChat,
+      agentContext: options?.agentContext,
+    });
     setDisplayMode((prev) => (prev === "hidden" ? "panel" : prev));
   };
 

--- a/src/components/main-page.tsx
+++ b/src/components/main-page.tsx
@@ -675,13 +675,11 @@ export function MainPage() {
       (!connection || connection.name !== pendingConfig.name || !isConnectionAvailable));
   if (showInitializer) {
     return (
-      <AgentCommandProvider>
-        <div className="relative h-full w-full flex min-w-0 overflow-hidden">
-          <div className="fixed inset-0 z-50 bg-background/95 flex items-start justify-center pt-[20vh] px-8 pb-8">
-            <ConnectionInitializer config={pendingConfig || null} onReady={handleReady} />
-          </div>
+      <div className="relative h-full w-full flex min-w-0 overflow-hidden">
+        <div className="fixed inset-0 z-50 bg-background/95 flex items-start justify-center pt-[20vh] px-8 pb-8">
+          <ConnectionInitializer config={pendingConfig || null} onReady={handleReady} />
         </div>
-      </AgentCommandProvider>
+      </div>
     );
   }
 
@@ -692,11 +690,7 @@ export function MainPage() {
   // 4. No active connection (fresh state)
   const showWizard = isInitialized && sessionStatus !== "loading" && !pendingConfig && !connection;
   if (showWizard) {
-    return (
-      <AgentCommandProvider>
-        <ConnectionWizard />
-      </AgentCommandProvider>
-    );
+    return <ConnectionWizard />;
   }
 
   // Mobile: one view at a time — chat full-screen when open, else tabs + schema in a sheet

--- a/src/components/main-page.tsx
+++ b/src/components/main-page.tsx
@@ -1,3 +1,4 @@
+import { AgentCommandProvider } from "@/components/chat/agent-command-context";
 import { useChatPanel } from "@/components/chat/view/use-chat-panel";
 import { useConnection } from "@/components/connection/connection-context";
 import { ConnectionWizard } from "@/components/connection/connection-wizard";
@@ -674,11 +675,13 @@ export function MainPage() {
       (!connection || connection.name !== pendingConfig.name || !isConnectionAvailable));
   if (showInitializer) {
     return (
-      <div className="relative h-full w-full flex min-w-0 overflow-hidden">
-        <div className="fixed inset-0 z-50 bg-background/95 flex items-start justify-center pt-[20vh] px-8 pb-8">
-          <ConnectionInitializer config={pendingConfig || null} onReady={handleReady} />
+      <AgentCommandProvider>
+        <div className="relative h-full w-full flex min-w-0 overflow-hidden">
+          <div className="fixed inset-0 z-50 bg-background/95 flex items-start justify-center pt-[20vh] px-8 pb-8">
+            <ConnectionInitializer config={pendingConfig || null} onReady={handleReady} />
+          </div>
         </div>
-      </div>
+      </AgentCommandProvider>
     );
   }
 
@@ -689,62 +692,70 @@ export function MainPage() {
   // 4. No active connection (fresh state)
   const showWizard = isInitialized && sessionStatus !== "loading" && !pendingConfig && !connection;
   if (showWizard) {
-    return <ConnectionWizard />;
+    return (
+      <AgentCommandProvider>
+        <ConnectionWizard />
+      </AgentCommandProvider>
+    );
   }
 
   // Mobile: one view at a time — chat full-screen when open, else tabs + schema in a sheet
   if (isMobile) {
     if (displayMode !== "hidden") {
       return (
-        <div className="relative h-full w-full flex min-w-0 overflow-hidden">
-          <ChatPanel onClose={closeChatPanel} />
-        </div>
+        <AgentCommandProvider>
+          <div className="relative h-full w-full flex min-w-0 overflow-hidden">
+            <ChatPanel onClose={closeChatPanel} />
+          </div>
+        </AgentCommandProvider>
       );
     }
     return (
-      <div className="relative h-full w-full flex flex-col min-w-0 overflow-hidden">
-        <div className="shrink-0 flex items-center gap-2 border-b bg-background px-2 py-1.5">
-          <SidebarTrigger className="h-8 w-8" />
-          <Sheet open={schemaSheetOpen} onOpenChange={setSchemaSheetOpen}>
-            <SheetTrigger asChild>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="gap-2"
-                aria-label="Open schema browser"
-              >
-                <Database className="h-4 w-4" />
-                Schema
-              </Button>
-            </SheetTrigger>
-            <SheetPortal>
-              <SheetOverlay />
-              <SheetPrimitive.Content
-                className={cn(
-                  "fixed z-50 gap-4 bg-background shadow-lg transition ease-in-out",
-                  "data-[state=open]:animate-in data-[state=closed]:animate-out",
-                  "data-[state=closed]:duration-300 data-[state=open]:duration-500",
-                  "inset-y-0 left-0 h-full w-3/4 border-r",
-                  "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
-                  "w-[min(320px,85vw)] p-0 flex flex-col overflow-hidden"
-                )}
-              >
-                <SheetTitle className="sr-only">Schema Browser</SheetTitle>
-                <SheetDescription className="sr-only">
-                  Browse databases, tables, and columns. Use the search field to filter by name.
-                </SheetDescription>
-                <div className="flex-1 min-h-0 overflow-auto p-2">
-                  <SchemaTreeView initialSchemaData={loadedSchemaData} />
-                </div>
-              </SheetPrimitive.Content>
-            </SheetPortal>
-          </Sheet>
+      <AgentCommandProvider>
+        <div className="relative h-full w-full flex flex-col min-w-0 overflow-hidden">
+          <div className="shrink-0 flex items-center gap-2 border-b bg-background px-2 py-1.5">
+            <SidebarTrigger className="h-8 w-8" />
+            <Sheet open={schemaSheetOpen} onOpenChange={setSchemaSheetOpen}>
+              <SheetTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="gap-2"
+                  aria-label="Open schema browser"
+                >
+                  <Database className="h-4 w-4" />
+                  Schema
+                </Button>
+              </SheetTrigger>
+              <SheetPortal>
+                <SheetOverlay />
+                <SheetPrimitive.Content
+                  className={cn(
+                    "fixed z-50 gap-4 bg-background shadow-lg transition ease-in-out",
+                    "data-[state=open]:animate-in data-[state=closed]:animate-out",
+                    "data-[state=closed]:duration-300 data-[state=open]:duration-500",
+                    "inset-y-0 left-0 h-full w-3/4 border-r",
+                    "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+                    "w-[min(320px,85vw)] p-0 flex flex-col overflow-hidden"
+                  )}
+                >
+                  <SheetTitle className="sr-only">Schema Browser</SheetTitle>
+                  <SheetDescription className="sr-only">
+                    Browse databases, tables, and columns. Use the search field to filter by name.
+                  </SheetDescription>
+                  <div className="flex-1 min-h-0 overflow-auto p-2">
+                    <SchemaTreeView initialSchemaData={loadedSchemaData} />
+                  </div>
+                </SheetPrimitive.Content>
+              </SheetPortal>
+            </Sheet>
+          </div>
+          <div className="flex-1 min-h-0 overflow-hidden">
+            <MainPageTabList selectedConnection={connection} />
+          </div>
         </div>
-        <div className="flex-1 min-h-0 overflow-hidden">
-          <MainPageTabList selectedConnection={connection} />
-        </div>
-      </div>
+      </AgentCommandProvider>
     );
   }
 
@@ -753,78 +764,80 @@ export function MainPage() {
   const showChatPanel = displayMode !== "hidden";
 
   return (
-    <div className="relative h-full w-full flex flex-col min-w-0 overflow-hidden">
-      <NewReleaseBanner />
-      <div className="flex-1 relative flex min-w-0 overflow-hidden">
-        <PanelGroup direction="horizontal" className="h-full w-full min-w-0">
-          {/* Left Panel: Schema Tree View - always mounted, hidden in fullscreen */}
-          <Panel
-            id="schema-panel"
-            order={1}
-            ref={schemaPanelRef}
-            defaultSize={showSchemaTree ? DEFAULT_SCHEMA_PANEL_SIZE : 0}
-            minSize={0}
-            className={`bg-background ${!showSchemaTree ? "hidden" : ""}`}
-          >
-            <SidebarPanel initialSchemaData={loadedSchemaData} />
-          </Panel>
+    <AgentCommandProvider>
+      <div className="relative h-full w-full flex flex-col min-w-0 overflow-hidden">
+        <NewReleaseBanner />
+        <div className="flex-1 relative flex min-w-0 overflow-hidden">
+          <PanelGroup direction="horizontal" className="h-full w-full min-w-0">
+            {/* Left Panel: Schema Tree View - always mounted, hidden in fullscreen */}
+            <Panel
+              id="schema-panel"
+              order={1}
+              ref={schemaPanelRef}
+              defaultSize={showSchemaTree ? DEFAULT_SCHEMA_PANEL_SIZE : 0}
+              minSize={0}
+              className={`bg-background ${!showSchemaTree ? "hidden" : ""}`}
+            >
+              <SidebarPanel initialSchemaData={loadedSchemaData} />
+            </Panel>
 
-          <PanelResizeHandle
-            className={`w-0.5 transition-colors ${
-              showSchemaTree
-                ? "bg-border hover:bg-border/80 cursor-col-resize"
-                : "bg-transparent hover:bg-transparent cursor-default pointer-events-none"
-            }`}
-          />
+            <PanelResizeHandle
+              className={`w-0.5 transition-colors ${
+                showSchemaTree
+                  ? "bg-border hover:bg-border/80 cursor-col-resize"
+                  : "bg-transparent hover:bg-transparent cursor-default pointer-events-none"
+              }`}
+            />
 
-          {/* Right Panel: Contains both Tabs and Chat in a nested layout */}
-          <Panel
-            id="main-content-panel"
-            order={2}
-            defaultSize={100 - DEFAULT_SCHEMA_PANEL_SIZE}
-            minSize={20}
-            className="bg-background"
-          >
-            {/* Nested PanelGroup for Tabs and Chat */}
-            <PanelGroup direction="horizontal" className="h-full w-full">
-              {/* Tabs Panel - always mounted, visibility controlled by CSS */}
-              <Panel
-                id="tabs-panel"
-                order={1}
-                ref={tabsPanelRef}
-                defaultSize={showTabsVisible ? (showChatPanel ? 60 : 100) : 0}
-                minSize={0}
-                className={`bg-background ${!showTabsVisible ? "!w-0 !min-w-0 !max-w-0 overflow-hidden" : ""}`}
-              >
-                <div className={!showTabsVisible ? "hidden" : "h-full"}>
-                  <MainPageTabList selectedConnection={connection} />
-                </div>
-              </Panel>
+            {/* Right Panel: Contains both Tabs and Chat in a nested layout */}
+            <Panel
+              id="main-content-panel"
+              order={2}
+              defaultSize={100 - DEFAULT_SCHEMA_PANEL_SIZE}
+              minSize={20}
+              className="bg-background"
+            >
+              {/* Nested PanelGroup for Tabs and Chat */}
+              <PanelGroup direction="horizontal" className="h-full w-full">
+                {/* Tabs Panel - always mounted, visibility controlled by CSS */}
+                <Panel
+                  id="tabs-panel"
+                  order={1}
+                  ref={tabsPanelRef}
+                  defaultSize={showTabsVisible ? (showChatPanel ? 60 : 100) : 0}
+                  minSize={0}
+                  className={`bg-background ${!showTabsVisible ? "!w-0 !min-w-0 !max-w-0 overflow-hidden" : ""}`}
+                >
+                  <div className={!showTabsVisible ? "hidden" : "h-full"}>
+                    <MainPageTabList selectedConnection={connection} />
+                  </div>
+                </Panel>
 
-              {/* Resize Handle between Tabs and Chat */}
-              <PanelResizeHandle
-                className={`w-0.5 transition-colors ${
-                  showTabsVisible && showChatPanel
-                    ? "bg-border hover:bg-border/80 cursor-col-resize"
-                    : "bg-transparent hover:bg-transparent cursor-default pointer-events-none"
-                }`}
-              />
+                {/* Resize Handle between Tabs and Chat */}
+                <PanelResizeHandle
+                  className={`w-0.5 transition-colors ${
+                    showTabsVisible && showChatPanel
+                      ? "bg-border hover:bg-border/80 cursor-col-resize"
+                      : "bg-transparent hover:bg-transparent cursor-default pointer-events-none"
+                  }`}
+                />
 
-              {/* Chat Panel - always mounted, visibility controlled by CSS */}
-              <Panel
-                id="chat-panel"
-                order={2}
-                ref={chatPanelRef}
-                defaultSize={showChatPanel ? (showTabsVisible ? 40 : 100) : 0}
-                minSize={showChatPanel ? 20 : 0}
-                className={`bg-background ${!showChatPanel ? "!w-0 !min-w-0 !max-w-0 overflow-hidden" : ""}`}
-              >
-                {showChatPanel && <ChatPanel onClose={closeChatPanel} />}
-              </Panel>
-            </PanelGroup>
-          </Panel>
-        </PanelGroup>
+                {/* Chat Panel - always mounted, visibility controlled by CSS */}
+                <Panel
+                  id="chat-panel"
+                  order={2}
+                  ref={chatPanelRef}
+                  defaultSize={showChatPanel ? (showTabsVisible ? 40 : 100) : 0}
+                  minSize={showChatPanel ? 20 : 0}
+                  className={`bg-background ${!showChatPanel ? "!w-0 !min-w-0 !max-w-0 overflow-hidden" : ""}`}
+                >
+                  {showChatPanel && <ChatPanel onClose={closeChatPanel} />}
+                </Panel>
+              </PanelGroup>
+            </Panel>
+          </PanelGroup>
+        </div>
       </div>
-    </div>
+    </AgentCommandProvider>
   );
 }

--- a/src/components/query-tab/query-control/query-control.test.tsx
+++ b/src/components/query-tab/query-control/query-control.test.tsx
@@ -1,0 +1,348 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryControl } from "./query-control";
+
+const {
+  postMessageMock,
+  setDisplayModeMock,
+  executeQueryMock,
+  executeBatchMock,
+  alertDialogMock,
+  mockCommands,
+  mockQueryInput,
+  mockAgentSettings,
+  mockConnection,
+} = vi.hoisted(() => ({
+  postMessageMock: vi.fn(),
+  setDisplayModeMock: vi.fn(),
+  executeQueryMock: vi.fn(),
+  executeBatchMock: vi.fn(),
+  alertDialogMock: vi.fn(),
+  mockCommands: [
+    {
+      name: "review-sql",
+      description: "Review SQL.",
+      skillId: "review-sql",
+      template: "Use review-sql: $ARGUMENTS",
+      showInSqlEditorQuickAction: true,
+    },
+  ],
+  mockQueryInput: {
+    selectedText: "",
+    text: "SELECT 1",
+    cursorRow: 0,
+    cursorColumn: 0,
+  },
+  mockAgentSettings: {
+    aiResponseLanguage: "en",
+  },
+  mockConnection: {
+    connectionId: "connection-1",
+  },
+}));
+
+const testGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+  ResizeObserver?: typeof ResizeObserver;
+};
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (!HTMLElement.prototype.scrollIntoView) {
+  HTMLElement.prototype.scrollIntoView = () => {};
+}
+
+vi.mock("@/components/chat/view/use-chat-panel", () => ({
+  useChatPanel: () => ({
+    postMessage: postMessageMock,
+    setDisplayMode: setDisplayModeMock,
+  }),
+}));
+
+vi.mock("@/components/shared/use-dialog", () => ({
+  Dialog: {
+    alert: alertDialogMock,
+  },
+}));
+
+vi.mock("@/components/chat/agent-command-context", () => ({
+  useAgentCommands: () => ({
+    commands: mockCommands,
+    loading: false,
+  }),
+}));
+
+vi.mock("@/components/connection/connection-context", () => ({
+  useConnection: () => ({
+    connection: mockConnection,
+  }),
+}));
+
+vi.mock("@/components/settings/agent/agent-manager", async () => {
+  const actual = await vi.importActual("@/components/settings/agent/agent-manager");
+  return {
+    ...actual,
+    AgentConfigurationManager: {
+      getConfiguration: () => mockAgentSettings,
+    },
+  };
+});
+
+vi.mock("../query-execution/query-executor", () => ({
+  useQueryExecutor: () => ({
+    isSqlExecuting: false,
+    executeQuery: executeQueryMock,
+    executeBatch: executeBatchMock,
+  }),
+}));
+
+vi.mock("../query-input/use-query-input", () => ({
+  useQueryInput: () => mockQueryInput,
+}));
+
+describe("QueryControl", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+    testGlobal.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+    postMessageMock.mockReset();
+    setDisplayModeMock.mockReset();
+    executeQueryMock.mockReset();
+    executeBatchMock.mockReset();
+    alertDialogMock.mockReset();
+    mockCommands.splice(0, mockCommands.length, {
+      name: "review-sql",
+      description: "Review SQL.",
+      skillId: "review-sql",
+      template: "Use review-sql: $ARGUMENTS",
+      showInSqlEditorQuickAction: true,
+    });
+    mockQueryInput.selectedText = "";
+    mockQueryInput.text = "SELECT 1";
+    mockQueryInput.cursorRow = 0;
+    mockQueryInput.cursorColumn = 0;
+    mockAgentSettings.aiResponseLanguage = "en";
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders a direct button when exactly one sql editor command is available", async () => {
+    await act(async () => {
+      root.render(<QueryControl onOpenHistory={vi.fn()} />);
+    });
+
+    const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("review-sql")
+    );
+
+    expect(button).toBeTruthy();
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(postMessageMock).toHaveBeenCalledWith(
+      expect.stringContaining("/review-sql"),
+      expect.objectContaining({
+        forceNewChat: true,
+        agentContext: expect.objectContaining({
+          responseLanguage: "en",
+        }),
+      })
+    );
+    expect(postMessageMock).toHaveBeenCalledWith(
+      expect.stringContaining("```sql\nSELECT 1\n```"),
+      expect.any(Object)
+    );
+  });
+
+  it("renders a dropdown when multiple sql editor commands are available", async () => {
+    mockCommands.push({
+      name: "diagnose-sql",
+      description: "Diagnose SQL.",
+      skillId: "diagnose-sql",
+      template: "Use diagnose-sql: $ARGUMENTS",
+      showInSqlEditorQuickAction: true,
+    });
+
+    await act(async () => {
+      root.render(<QueryControl onOpenHistory={vi.fn()} />);
+    });
+
+    const trigger = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("AI Actions")
+    );
+
+    expect(trigger).toBeTruthy();
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const reviewItem = Array.from(document.querySelectorAll("[cmdk-item]")).find((candidate) =>
+      candidate.textContent?.includes("/review-sql")
+    );
+
+    expect(reviewItem).toBeTruthy();
+    expect(document.body.textContent).toContain("Review SQL.");
+
+    await act(async () => {
+      reviewItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(postMessageMock).toHaveBeenCalledWith(
+      expect.stringContaining("/review-sql"),
+      expect.any(Object)
+    );
+  });
+
+  it("adds a Toggle Agent item as the last dropdown action", async () => {
+    mockCommands.push({
+      name: "diagnose-sql",
+      description: "Diagnose SQL.",
+      skillId: "diagnose-sql",
+      template: "Use diagnose-sql: $ARGUMENTS",
+      showInSqlEditorQuickAction: true,
+    });
+
+    await act(async () => {
+      root.render(<QueryControl onOpenHistory={vi.fn()} />);
+    });
+
+    const trigger = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("AI Actions")
+    );
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const items = Array.from(document.querySelectorAll("[cmdk-item]"));
+    expect(items.at(-1)?.textContent).toContain("Toggle Agent");
+    const separators = Array.from(document.querySelectorAll("[cmdk-separator]"));
+    expect(separators.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      items.at(-1)?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(setDisplayModeMock).toHaveBeenCalledWith("panel");
+    expect(postMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("does not launch sql editor commands for obvious multi-statement input", async () => {
+    mockQueryInput.text = "SELECT 1; SELECT 2";
+
+    await act(async () => {
+      root.render(<QueryControl onOpenHistory={vi.fn()} />);
+    });
+
+    const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("review-sql")
+    );
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(postMessageMock).not.toHaveBeenCalled();
+    expect(alertDialogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Single Statement Required",
+      })
+    );
+  });
+
+  it("shows an information dialog when no runnable sql is available", async () => {
+    mockQueryInput.text = "-- only comments";
+
+    await act(async () => {
+      root.render(<QueryControl onOpenHistory={vi.fn()} />);
+    });
+
+    const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("review-sql")
+    );
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(postMessageMock).not.toHaveBeenCalled();
+    expect(alertDialogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "No SQL To Send",
+      })
+    );
+  });
+
+  it("uses the dedicated sql review language setting for sql editor commands", async () => {
+    mockAgentSettings.aiResponseLanguage = "ja";
+
+    await act(async () => {
+      root.render(<QueryControl onOpenHistory={vi.fn()} />);
+    });
+
+    const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("review-sql")
+    );
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(postMessageMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        agentContext: expect.objectContaining({
+          responseLanguage: "ja",
+        }),
+      })
+    );
+  });
+
+  it("does not show commands without a sql editor quick action flag", async () => {
+    mockCommands.splice(0, mockCommands.length, {
+      name: "review-sql",
+      description: "Review SQL.",
+      skillId: "review-sql",
+      template: "Use review-sql: $ARGUMENTS",
+    });
+
+    await act(async () => {
+      root.render(<QueryControl onOpenHistory={vi.fn()} />);
+    });
+
+    expect(
+      Array.from(container.querySelectorAll("button")).find((candidate) =>
+        candidate.textContent?.includes("review-sql")
+      )
+    ).toBeFalsy();
+    expect(
+      Array.from(container.querySelectorAll("button")).find((candidate) =>
+        candidate.textContent?.includes("AI Actions")
+      )
+    ).toBeFalsy();
+  });
+});

--- a/src/components/query-tab/query-control/query-control.test.tsx
+++ b/src/components/query-tab/query-control/query-control.test.tsx
@@ -145,19 +145,31 @@ describe("QueryControl", () => {
     container.remove();
   });
 
-  it("renders a direct button when exactly one sql editor command is available", async () => {
+  it("renders a single popover trigger when exactly one sql editor command is available", async () => {
     await act(async () => {
       root.render(<QueryControl onOpenHistory={vi.fn()} />);
     });
 
-    const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
-      candidate.textContent?.includes("review-sql")
+    const trigger = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("AI Actions")
     );
 
-    expect(button).toBeTruthy();
+    expect(trigger).toBeTruthy();
 
     await act(async () => {
-      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      trigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const reviewItem = Array.from(document.querySelectorAll("[cmdk-item]")).find((candidate) =>
+      candidate.textContent?.includes("/review-sql")
+    );
+    expect(reviewItem).toBeTruthy();
+    const items = Array.from(document.querySelectorAll("[cmdk-item]"));
+    expect(items.at(-1)?.textContent ?? "").toContain("Toggle Agent");
+
+    await act(async () => {
+      reviewItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
     expect(postMessageMock).toHaveBeenCalledWith(
@@ -258,12 +270,21 @@ describe("QueryControl", () => {
       root.render(<QueryControl onOpenHistory={vi.fn()} />);
     });
 
-    const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
-      candidate.textContent?.includes("review-sql")
+    const trigger = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("AI Actions")
     );
 
     await act(async () => {
-      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      trigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const reviewItem = Array.from(document.querySelectorAll("[cmdk-item]")).find((candidate) =>
+      candidate.textContent?.includes("/review-sql")
+    );
+
+    await act(async () => {
+      reviewItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
     expect(postMessageMock).not.toHaveBeenCalled();
@@ -281,12 +302,21 @@ describe("QueryControl", () => {
       root.render(<QueryControl onOpenHistory={vi.fn()} />);
     });
 
-    const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
-      candidate.textContent?.includes("review-sql")
+    const trigger = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("AI Actions")
     );
 
     await act(async () => {
-      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      trigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const reviewItem = Array.from(document.querySelectorAll("[cmdk-item]")).find((candidate) =>
+      candidate.textContent?.includes("/review-sql")
+    );
+
+    await act(async () => {
+      reviewItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
     expect(postMessageMock).not.toHaveBeenCalled();
@@ -304,12 +334,21 @@ describe("QueryControl", () => {
       root.render(<QueryControl onOpenHistory={vi.fn()} />);
     });
 
-    const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
-      candidate.textContent?.includes("review-sql")
+    const trigger = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("AI Actions")
     );
 
     await act(async () => {
-      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      trigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const reviewItem = Array.from(document.querySelectorAll("[cmdk-item]")).find((candidate) =>
+      candidate.textContent?.includes("/review-sql")
+    );
+
+    await act(async () => {
+      reviewItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
     expect(postMessageMock).toHaveBeenCalledWith(
@@ -322,7 +361,7 @@ describe("QueryControl", () => {
     );
   });
 
-  it("does not show commands without a sql editor quick action flag", async () => {
+  it("shows Toggle Agent even when no sql editor quick action commands are available", async () => {
     mockCommands.splice(0, mockCommands.length, {
       name: "review-sql",
       description: "Review SQL.",
@@ -334,15 +373,25 @@ describe("QueryControl", () => {
       root.render(<QueryControl onOpenHistory={vi.fn()} />);
     });
 
-    expect(
-      Array.from(container.querySelectorAll("button")).find((candidate) =>
-        candidate.textContent?.includes("review-sql")
-      )
-    ).toBeFalsy();
-    expect(
-      Array.from(container.querySelectorAll("button")).find((candidate) =>
-        candidate.textContent?.includes("AI Actions")
-      )
-    ).toBeFalsy();
+    const trigger = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("AI Actions")
+    );
+    expect(trigger).toBeTruthy();
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const items = Array.from(document.querySelectorAll("[cmdk-item]"));
+    expect(items).toHaveLength(1);
+    expect(items[0]?.textContent ?? "").toContain("Toggle Agent");
+
+    await act(async () => {
+      items[0]?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(setDisplayModeMock).toHaveBeenCalledWith("panel");
+    expect(postMessageMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/query-tab/query-control/query-control.test.tsx
+++ b/src/components/query-tab/query-control/query-control.test.tsx
@@ -415,6 +415,7 @@ describe("QueryControl", () => {
       description: "Review SQL.",
       skillId: "review-sql",
       template: "Use review-sql: $ARGUMENTS",
+      showInSqlEditorQuickAction: false,
     });
 
     await act(async () => {

--- a/src/components/query-tab/query-control/query-control.test.tsx
+++ b/src/components/query-tab/query-control/query-control.test.tsx
@@ -68,8 +68,8 @@ vi.mock("@/components/chat/view/use-chat-panel", () => ({
   }),
 }));
 
-vi.mock("@/components/chat/agent-command-browser-panel", () => {
-  const React = require("react") as typeof import("react");
+vi.mock("@/components/chat/agent-command-browser-panel", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
 
   return {
     AgentCommandBrowserPanel: ({

--- a/src/components/query-tab/query-control/query-control.test.tsx
+++ b/src/components/query-tab/query-control/query-control.test.tsx
@@ -68,6 +68,54 @@ vi.mock("@/components/chat/view/use-chat-panel", () => ({
   }),
 }));
 
+vi.mock("@/components/chat/agent-command-browser-panel", () => {
+  const React = require("react") as typeof import("react");
+
+  return {
+    AgentCommandBrowserPanel: ({
+      items,
+      onSelectItem,
+    }: {
+      items: Array<{
+        key: string;
+        label: React.ReactNode;
+        description?: string;
+        separatorBefore?: boolean;
+      }>;
+      onSelectItem: (item: {
+        key: string;
+        label: React.ReactNode;
+        description?: string;
+        separatorBefore?: boolean;
+      }) => void;
+    }) => {
+      const [activeIndex, setActiveIndex] = React.useState(0);
+      const activeItem = items[activeIndex];
+
+      return (
+        <div>
+          <div>
+            {items.map((item, index) => (
+              <React.Fragment key={item.key}>
+                {item.separatorBefore ? <div cmdk-separator="" /> : null}
+                <button
+                  type="button"
+                  cmdk-item=""
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onClick={() => onSelectItem(item)}
+                >
+                  {item.label}
+                </button>
+              </React.Fragment>
+            ))}
+          </div>
+          {activeItem?.description ? <div>{activeItem.description}</div> : null}
+        </div>
+      );
+    },
+  };
+});
+
 vi.mock("@/components/shared/use-dialog", () => ({
   Dialog: {
     alert: alertDialogMock,

--- a/src/components/query-tab/query-control/query-control.tsx
+++ b/src/components/query-tab/query-control/query-control.tsx
@@ -167,7 +167,7 @@ export function QueryControl({ onOpenHistory }: { onOpenHistory: () => void }) {
   const isRunPrimaryDisabled = isSqlExecuting || (!hasSelectedText && !hasEditorText);
   const isRunBatchDisabled = isSqlExecuting || !hasEditorText;
   const isExplainDisabled = isSqlExecuting || !hasEditorText;
-  const isSqlEditorActionDisabled = isSqlExecuting || (hasSqlEditorCommands && !hasSqlInput);
+  const isSqlEditorActionDisabled = isSqlExecuting;
   const isSaveDisabled = isSqlExecuting || !hasEditorText;
 
   return (

--- a/src/components/query-tab/query-control/query-control.tsx
+++ b/src/components/query-tab/query-control/query-control.tsx
@@ -159,6 +159,7 @@ export function QueryControl({ onOpenHistory }: { onOpenHistory: () => void }) {
     ],
     [sqlEditorCommands]
   );
+  const hasSqlEditorCommands = sqlEditorCommands.length > 0;
 
   const hasEditorText = text.trim().length > 0;
   const hasSelectedText = selectedText.trim().length > 0;
@@ -166,7 +167,7 @@ export function QueryControl({ onOpenHistory }: { onOpenHistory: () => void }) {
   const isRunPrimaryDisabled = isSqlExecuting || (!hasSelectedText && !hasEditorText);
   const isRunBatchDisabled = isSqlExecuting || !hasEditorText;
   const isExplainDisabled = isSqlExecuting || !hasEditorText;
-  const isSqlEditorActionDisabled = isSqlExecuting || !hasSqlInput;
+  const isSqlEditorActionDisabled = isSqlExecuting || (hasSqlEditorCommands && !hasSqlInput);
   const isSaveDisabled = isSqlExecuting || !hasEditorText;
 
   return (
@@ -229,61 +230,45 @@ export function QueryControl({ onOpenHistory }: { onOpenHistory: () => void }) {
           </DropdownMenuContent>
         </DropdownMenu>
 
-        {sqlEditorCommands.length > 0 && (
-          <>
-            <Separator orientation="vertical" className="h-4" />
-
-            {sqlEditorCommands.length === 1 ? (
+        <>
+          <Separator orientation="vertical" className="h-4" />
+          <Popover open={isAgentActionsOpen} onOpenChange={setIsAgentActionsOpen}>
+            <PopoverTrigger asChild>
               <Button
                 disabled={isSqlEditorActionDisabled}
                 size="sm"
                 variant="ghost"
                 className="h-6 gap-1 px-2 text-xs rounded-sm"
-                onClick={() => handleSqlEditorCommand(sqlEditorCommands[0])}
               >
                 <Sparkles className="h-3 w-3" />
-                {sqlEditorCommands[0].name}
+                AI Actions
+                <ChevronDown className="h-3 w-3" />
               </Button>
-            ) : (
-              <Popover open={isAgentActionsOpen} onOpenChange={setIsAgentActionsOpen}>
-                <PopoverTrigger asChild>
-                  <Button
-                    disabled={isSqlEditorActionDisabled}
-                    size="sm"
-                    variant="ghost"
-                    className="h-6 gap-1 px-2 text-xs rounded-sm"
-                  >
-                    <Sparkles className="h-3 w-3" />
-                    AI Actions
-                    <ChevronDown className="h-3 w-3" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent
-                  align="start"
-                  className="p-0 w-auto flex items-stretch z-50 bg-transparent border-0 pointer-events-auto"
-                  onOpenAutoFocus={(e) => e.preventDefault()}
-                >
-                  <AgentCommandBrowserPanel
-                    items={sqlEditorActionItems}
-                    onSelectItem={(item) => {
-                      setIsAgentActionsOpen(false);
-                      if (item.key === "__toggle-agent__") {
-                        handleOpenAgent();
-                        return;
-                      }
-                      const command = sqlEditorCommands.find(
-                        (candidate) => candidate.name === item.key
-                      );
-                      if (command) {
-                        handleSqlEditorCommand(command);
-                      }
-                    }}
-                  />
-                </PopoverContent>
-              </Popover>
-            )}
-          </>
-        )}
+            </PopoverTrigger>
+            <PopoverContent
+              align="start"
+              className="p-0 w-auto flex items-stretch z-50 bg-transparent border-0 pointer-events-auto"
+              onOpenAutoFocus={(e) => e.preventDefault()}
+            >
+              <AgentCommandBrowserPanel
+                items={sqlEditorActionItems}
+                onSelectItem={(item) => {
+                  setIsAgentActionsOpen(false);
+                  if (item.key === "__toggle-agent__") {
+                    handleOpenAgent();
+                    return;
+                  }
+                  const command = sqlEditorCommands.find(
+                    (candidate) => candidate.name === item.key
+                  );
+                  if (command) {
+                    handleSqlEditorCommand(command);
+                  }
+                }}
+              />
+            </PopoverContent>
+          </Popover>
+        </>
 
         <Separator orientation="vertical" className="h-4" />
 

--- a/src/components/query-tab/query-control/query-control.tsx
+++ b/src/components/query-tab/query-control/query-control.tsx
@@ -1,4 +1,15 @@
+import {
+  AgentCommandBrowserPanel,
+  type AgentCommandBrowserItem,
+} from "@/components/chat/agent-command-browser-panel";
+import { useAgentCommands } from "@/components/chat/agent-command-context";
+import { useChatPanel } from "@/components/chat/view/use-chat-panel";
 import { useConnection } from "@/components/connection/connection-context";
+import {
+  AgentConfigurationManager,
+  normalizeAIResponseLanguage,
+} from "@/components/settings/agent/agent-manager";
+import { Dialog } from "@/components/shared/use-dialog";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -6,11 +17,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import type { CommandDetail } from "@/lib/ai/commands/command-manager";
 import { SqlUtils } from "@/lib/sql-utils";
-import { Bookmark, ChevronDown, History, Play } from "lucide-react";
-import { useCallback } from "react";
+import { Bookmark, ChevronDown, History, MessageSquare, Play, Sparkles } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
 import { useQueryExecutor } from "../query-execution/query-executor";
 import { useQueryInput } from "../query-input/use-query-input";
 import { openSaveSnippetDialog } from "../snippet/save-snippet-dialog";
@@ -19,7 +32,11 @@ import { showMultipleStatementsConfirmDialog } from "./multiple-statements-confi
 export function QueryControl({ onOpenHistory }: { onOpenHistory: () => void }) {
   const { isSqlExecuting, executeQuery, executeBatch } = useQueryExecutor();
   const { connection } = useConnection();
+  const { postMessage, setDisplayMode } = useChatPanel();
+  const { commands } = useAgentCommands();
   const { selectedText, text, cursorRow, cursorColumn } = useQueryInput();
+  const sqlEditorCommands = commands.filter((command) => command.showInSqlEditorQuickAction);
+  const [isAgentActionsOpen, setIsAgentActionsOpen] = useState(false);
 
   const handleRunCurrentLine = useCallback(() => {
     const sql = SqlUtils.resolveExecutionSql({
@@ -82,11 +99,74 @@ export function QueryControl({ onOpenHistory }: { onOpenHistory: () => void }) {
     });
   }, [selectedText, text, executeBatch]);
 
+  const handleSqlEditorCommand = useCallback(
+    (command: CommandDetail) => {
+      const sql = SqlUtils.resolveExecutionSql({
+        selectedText,
+        text,
+        cursorRow,
+        cursorColumn,
+      });
+      const normalizedSql = SqlUtils.removeComments(sql);
+      if (normalizedSql.length === 0) {
+        Dialog.alert({
+          title: "No SQL To Send",
+          description: "Select a SQL statement or place the cursor on a runnable SQL line first.",
+        });
+        return;
+      }
+
+      const statements = SqlUtils.splitSqlStatements(normalizedSql);
+      if (statements.length !== 1) {
+        Dialog.alert({
+          title: "Single Statement Required",
+          description:
+            "AI actions from the SQL editor currently support exactly one SQL statement at a time.",
+        });
+        return;
+      }
+
+      const reviewLanguage = normalizeAIResponseLanguage(
+        AgentConfigurationManager.getConfiguration().aiResponseLanguage
+      );
+
+      postMessage(`/${command.name}\n\n\`\`\`sql\n${statements[0]}\n\`\`\``, {
+        forceNewChat: true,
+        agentContext: { responseLanguage: reviewLanguage },
+      });
+    },
+    [cursorColumn, cursorRow, postMessage, selectedText, text]
+  );
+
+  const handleOpenAgent = useCallback(() => {
+    setDisplayMode("panel");
+  }, [setDisplayMode]);
+
+  const sqlEditorActionItems = useMemo<AgentCommandBrowserItem[]>(
+    () => [
+      ...sqlEditorCommands.map((command) => ({
+        key: command.name,
+        label: `/${command.name}`,
+        description: command.description,
+      })),
+      {
+        key: "__toggle-agent__",
+        label: "Toggle Agent",
+        icon: <MessageSquare className="!h-3.5 !w-3.5" />,
+        separatorBefore: true,
+        itemClassName: "py-1 my-1",
+      },
+    ],
+    [sqlEditorCommands]
+  );
+
   const hasEditorText = text.trim().length > 0;
   const hasSelectedText = selectedText.trim().length > 0;
+  const hasSqlInput = hasSelectedText || hasEditorText;
   const isRunPrimaryDisabled = isSqlExecuting || (!hasSelectedText && !hasEditorText);
   const isRunBatchDisabled = isSqlExecuting || !hasEditorText;
   const isExplainDisabled = isSqlExecuting || !hasEditorText;
+  const isSqlEditorActionDisabled = isSqlExecuting || !hasSqlInput;
   const isSaveDisabled = isSqlExecuting || !hasEditorText;
 
   return (
@@ -148,6 +228,62 @@ export function QueryControl({ onOpenHistory }: { onOpenHistory: () => void }) {
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+
+        {sqlEditorCommands.length > 0 && (
+          <>
+            <Separator orientation="vertical" className="h-4" />
+
+            {sqlEditorCommands.length === 1 ? (
+              <Button
+                disabled={isSqlEditorActionDisabled}
+                size="sm"
+                variant="ghost"
+                className="h-6 gap-1 px-2 text-xs rounded-sm"
+                onClick={() => handleSqlEditorCommand(sqlEditorCommands[0])}
+              >
+                <Sparkles className="h-3 w-3" />
+                {sqlEditorCommands[0].name}
+              </Button>
+            ) : (
+              <Popover open={isAgentActionsOpen} onOpenChange={setIsAgentActionsOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    disabled={isSqlEditorActionDisabled}
+                    size="sm"
+                    variant="ghost"
+                    className="h-6 gap-1 px-2 text-xs rounded-sm"
+                  >
+                    <Sparkles className="h-3 w-3" />
+                    AI Actions
+                    <ChevronDown className="h-3 w-3" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  align="start"
+                  className="p-0 w-auto flex items-stretch z-50 bg-transparent border-0 pointer-events-auto"
+                  onOpenAutoFocus={(e) => e.preventDefault()}
+                >
+                  <AgentCommandBrowserPanel
+                    items={sqlEditorActionItems}
+                    onSelectItem={(item) => {
+                      setIsAgentActionsOpen(false);
+                      if (item.key === "__toggle-agent__") {
+                        handleOpenAgent();
+                        return;
+                      }
+                      const command = sqlEditorCommands.find(
+                        (candidate) => candidate.name === item.key
+                      );
+                      if (command) {
+                        handleSqlEditorCommand(command);
+                      }
+                    }}
+                  />
+                </PopoverContent>
+              </Popover>
+            )}
+          </>
+        )}
 
         <Separator orientation="vertical" className="h-4" />
 

--- a/src/components/query-tab/query-control/query-control.tsx
+++ b/src/components/query-tab/query-control/query-control.tsx
@@ -159,11 +159,8 @@ export function QueryControl({ onOpenHistory }: { onOpenHistory: () => void }) {
     ],
     [sqlEditorCommands]
   );
-  const hasSqlEditorCommands = sqlEditorCommands.length > 0;
-
   const hasEditorText = text.trim().length > 0;
   const hasSelectedText = selectedText.trim().length > 0;
-  const hasSqlInput = hasSelectedText || hasEditorText;
   const isRunPrimaryDisabled = isSqlExecuting || (!hasSelectedText && !hasEditorText);
   const isRunBatchDisabled = isSqlExecuting || !hasEditorText;
   const isExplainDisabled = isSqlExecuting || !hasEditorText;

--- a/src/components/query-tab/query-response/explain-error-prompt.ts
+++ b/src/components/query-tab/query-response/explain-error-prompt.ts
@@ -1,6 +1,6 @@
 import {
-  DEFAULT_AUTO_EXPLAIN_LANGUAGE,
-  type AutoExplainLanguage,
+  DEFAULT_AI_RESPONSE_LANGUAGE,
+  type AIResponseLanguage,
 } from "@/components/settings/agent/agent-manager";
 import { isEnglishLanguageTag } from "@/lib/ai/language-utils";
 
@@ -8,13 +8,13 @@ export function buildExplainErrorPrompt({
   errorMessage,
   errorCode,
   sql,
-  language = DEFAULT_AUTO_EXPLAIN_LANGUAGE,
+  language = DEFAULT_AI_RESPONSE_LANGUAGE,
 }: {
   errorMessage: string;
   errorCode?: string | number;
   sql?: string;
   /** BCP-47 language for prose and headings; English adds no extra instructions. */
-  language?: AutoExplainLanguage;
+  language?: AIResponseLanguage;
 }): string {
   const parts: string[] = [];
   const hasErrorCode = errorCode !== undefined;

--- a/src/components/query-tab/query-response/query-error-ai-explanation.test.tsx
+++ b/src/components/query-tab/query-response/query-error-ai-explanation.test.tsx
@@ -11,7 +11,7 @@ const { createEphemeralMock, sendMessageMock, stopMock, mockAgentSettings } = vi
   createEphemeralMock: vi.fn(),
   sendMessageMock: vi.fn(),
   stopMock: vi.fn(),
-  mockAgentSettings: { autoExplainLanguage: "en" },
+  mockAgentSettings: { aiResponseLanguage: "en" },
 }));
 const testGlobal = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
@@ -32,10 +32,10 @@ vi.mock("@/components/connection/connection-context", () => ({
 vi.mock("@/components/settings/agent/agent-manager", () => ({
   AgentConfigurationManager: {
     getConfiguration: () => ({
-      autoExplainLanguage: mockAgentSettings.autoExplainLanguage,
+      aiResponseLanguage: mockAgentSettings.aiResponseLanguage,
     }),
   },
-  normalizeAutoExplainLanguage: (language: string) => language,
+  normalizeAIResponseLanguage: (language: string) => language,
 }));
 
 vi.mock("@/components/chat/chat-factory", () => ({
@@ -69,7 +69,7 @@ describe("QueryErrorAIExplanation", () => {
 
   beforeEach(() => {
     testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
-    mockAgentSettings.autoExplainLanguage = "en";
+    mockAgentSettings.aiResponseLanguage = "en";
     createEphemeralMock.mockReset();
     createEphemeralMock.mockResolvedValue({ id: "chat-1" });
     sendMessageMock.mockReset();
@@ -115,7 +115,7 @@ describe("QueryErrorAIExplanation", () => {
   });
 
   it("passes non-English response language into agentContext", async () => {
-    mockAgentSettings.autoExplainLanguage = "zh-CN";
+    mockAgentSettings.aiResponseLanguage = "zh-CN";
 
     await act(async () => {
       root.render(

--- a/src/components/query-tab/query-response/query-error-ai-explanation.tsx
+++ b/src/components/query-tab/query-response/query-error-ai-explanation.tsx
@@ -8,7 +8,7 @@ import { useChatPanel } from "@/components/chat/view/use-chat-panel";
 import { useConnection } from "@/components/connection/connection-context";
 import {
   AgentConfigurationManager,
-  normalizeAutoExplainLanguage,
+  normalizeAIResponseLanguage,
 } from "@/components/settings/agent/agent-manager";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -437,8 +437,8 @@ export const QueryErrorAIExplanation = memo(function QueryErrorAIExplanation({
     }
 
     void (async () => {
-      const autoExplainLanguage = normalizeAutoExplainLanguage(
-        AgentConfigurationManager.getConfiguration().autoExplainLanguage
+      const autoExplainLanguage = normalizeAIResponseLanguage(
+        AgentConfigurationManager.getConfiguration().aiResponseLanguage
       );
       const createdChat = await ChatFactory.createEphemeral({
         connection,
@@ -505,8 +505,8 @@ const QueryErrorAIExplanationContent = memo(function QueryErrorAIExplanationCont
     sentKeyRef.current = key;
     setHasRequested(true);
     setFeedbackDismissed(false);
-    const autoExplainLanguage = normalizeAutoExplainLanguage(
-      AgentConfigurationManager.getConfiguration().autoExplainLanguage
+    const autoExplainLanguage = normalizeAIResponseLanguage(
+      AgentConfigurationManager.getConfiguration().aiResponseLanguage
     );
     const prompt = buildExplainErrorPrompt({
       errorMessage,

--- a/src/components/query-tab/query-tab.tsx
+++ b/src/components/query-tab/query-tab.tsx
@@ -1,4 +1,3 @@
-import { AgentCommandProvider } from "@/components/chat/agent-command-context";
 import { useConnection } from "@/components/connection/connection-context";
 import { QueryListView } from "@/components/query-tab/query-list-view";
 import { TabManager } from "@/components/tab-manager";
@@ -177,8 +176,6 @@ const QueryTabContent = ({ initialQuery, initialMode, initialExecute, active }: 
 
 export const QueryTab = memo((props: QueryTabProps) => (
   <QueryExecutionProvider>
-    <AgentCommandProvider>
-      <QueryTabContent {...props} />
-    </AgentCommandProvider>
+    <QueryTabContent {...props} />
   </QueryExecutionProvider>
 ));

--- a/src/components/query-tab/query-tab.tsx
+++ b/src/components/query-tab/query-tab.tsx
@@ -1,3 +1,4 @@
+import { AgentCommandProvider } from "@/components/chat/agent-command-context";
 import { useConnection } from "@/components/connection/connection-context";
 import { QueryListView } from "@/components/query-tab/query-list-view";
 import { TabManager } from "@/components/tab-manager";
@@ -176,6 +177,8 @@ const QueryTabContent = ({ initialQuery, initialMode, initialExecute, active }: 
 
 export const QueryTab = memo((props: QueryTabProps) => (
   <QueryExecutionProvider>
-    <QueryTabContent {...props} />
+    <AgentCommandProvider>
+      <QueryTabContent {...props} />
+    </AgentCommandProvider>
   </QueryExecutionProvider>
 ));

--- a/src/components/settings/agent/agent-edit.tsx
+++ b/src/components/settings/agent/agent-edit.tsx
@@ -1,11 +1,11 @@
 import {
   AgentConfigurationManager,
-  AUTO_EXPLAIN_LANGUAGE_OPTIONS,
+  AI_RESPONSE_LANGUAGE_OPTIONS,
   DEFAULT_AUTO_EXPLAIN_BLACKLIST,
-  normalizeAutoExplainLanguage,
+  normalizeAIResponseLanguage,
   type AgentConfiguration,
   type AgentMode,
-  type AutoExplainLanguage,
+  type AIResponseLanguage,
 } from "@/components/settings/agent/agent-manager";
 import { Button } from "@/components/ui/button";
 import {
@@ -211,17 +211,20 @@ export function AgentEdit() {
       ...configuration,
       autoExplainClickHouseErrors: checked,
       autoExplainBlacklist: configuration.autoExplainBlacklist ?? DEFAULT_AUTO_EXPLAIN_BLACKLIST,
-      autoExplainLanguage:
-        configuration.autoExplainLanguage ?? normalizeAutoExplainLanguage(undefined),
+      aiResponseLanguage:
+        configuration.aiResponseLanguage ??
+        normalizeAIResponseLanguage(
+          configuration.sqlReviewLanguage ?? configuration.autoExplainLanguage
+        ),
     };
     setConfiguration(newConfig);
     AgentConfigurationManager.setConfiguration(newConfig);
   };
 
-  const handleAutoExplainLanguageChange = (value: string) => {
+  const handleAIResponseLanguageChange = (value: string) => {
     const newConfig = {
       ...configuration,
-      autoExplainLanguage: value as AutoExplainLanguage,
+      aiResponseLanguage: value as AIResponseLanguage,
     };
     setConfiguration(newConfig);
     AgentConfigurationManager.setConfiguration(newConfig);
@@ -332,6 +335,52 @@ export function AgentEdit() {
 
           <TableRow className="h-12 hover:bg-transparent">
             <TableCell className="px-0 pl-4 py-1 align-middle">
+              <Label>AI Response Language</Label>
+            </TableCell>
+            <TableCell className="px-0 py-1 align-middle">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" className="h-9 w-[300px] justify-between">
+                    {
+                      AI_RESPONSE_LANGUAGE_OPTIONS.find(
+                        (o) =>
+                          o.value ===
+                          normalizeAIResponseLanguage(
+                            configuration.aiResponseLanguage ??
+                              configuration.sqlReviewLanguage ??
+                              configuration.autoExplainLanguage
+                          )
+                      )?.label
+                    }
+                    <ChevronDown className="ml-2 h-4 w-4 opacity-50" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent container={dropdownContainer} className="w-[300px] z-[10000]">
+                  <DropdownMenuRadioGroup
+                    value={normalizeAIResponseLanguage(
+                      configuration.aiResponseLanguage ??
+                        configuration.sqlReviewLanguage ??
+                        configuration.autoExplainLanguage
+                    )}
+                    onValueChange={handleAIResponseLanguageChange}
+                  >
+                    {AI_RESPONSE_LANGUAGE_OPTIONS.map((opt) => (
+                      <DropdownMenuRadioItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </TableCell>
+            <TableCell className="px-0 py-1 align-middle text-sm text-muted-foreground">
+              Controls the response language for AI actions in the SQL editor, including auto
+              explain and other quick actions.
+            </TableCell>
+          </TableRow>
+
+          <TableRow className="h-12 hover:bg-transparent">
+            <TableCell className="px-0 pl-4 py-1 align-middle">
               <Label>Auto Explain Errors</Label>
             </TableCell>
             <TableCell className="px-0 py-1 align-middle">
@@ -344,44 +393,6 @@ export function AgentEdit() {
             </TableCell>
             <TableCell className="px-0 py-1 align-middle text-sm text-muted-foreground">
               Automatically ask AI to explain eligible ClickHouse errors inline in query results.
-            </TableCell>
-          </TableRow>
-
-          <TableRow className="h-12 hover:bg-transparent">
-            <TableCell className="px-0 pl-4 py-1 align-middle">
-              <Label className="pl-6">Explanation Language</Label>
-            </TableCell>
-            <TableCell className="px-0 py-1 align-middle">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="outline" className="h-9 w-[300px] justify-between">
-                    {
-                      AUTO_EXPLAIN_LANGUAGE_OPTIONS.find(
-                        (o) =>
-                          o.value ===
-                          normalizeAutoExplainLanguage(configuration.autoExplainLanguage)
-                      )?.label
-                    }
-                    <ChevronDown className="ml-2 h-4 w-4 opacity-50" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent container={dropdownContainer} className="w-[300px] z-[10000]">
-                  <DropdownMenuRadioGroup
-                    value={normalizeAutoExplainLanguage(configuration.autoExplainLanguage)}
-                    onValueChange={handleAutoExplainLanguageChange}
-                  >
-                    {AUTO_EXPLAIN_LANGUAGE_OPTIONS.map((opt) => (
-                      <DropdownMenuRadioItem key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </DropdownMenuRadioItem>
-                    ))}
-                  </DropdownMenuRadioGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </TableCell>
-            <TableCell className="px-0 py-1 align-middle text-sm text-muted-foreground">
-              Language for automatic inline error explanations only. Does not change the main AI
-              chat.
             </TableCell>
           </TableRow>
 

--- a/src/components/settings/agent/agent-manager.ts
+++ b/src/components/settings/agent/agent-manager.ts
@@ -11,8 +11,8 @@ export const DEFAULT_AUTO_EXPLAIN_BLACKLIST = [
   "194", // REQUIRED_PASSWORD
 ];
 
-/** BCP-47 tags for inline error AI explanations only (default: English). */
-export const AUTO_EXPLAIN_LANGUAGE_OPTIONS = [
+/** BCP-47 tags supported by AI response-language settings (default: English). */
+export const AI_RESPONSE_LANGUAGE_OPTIONS = [
   { value: "en", label: "English" },
   { value: "zh-CN", label: "简体中文" },
   { value: "zh-TW", label: "繁體中文" },
@@ -23,17 +23,21 @@ export const AUTO_EXPLAIN_LANGUAGE_OPTIONS = [
   { value: "de", label: "Deutsch" },
 ] as const;
 
-export type AutoExplainLanguage = (typeof AUTO_EXPLAIN_LANGUAGE_OPTIONS)[number]["value"];
+export type ResponseLanguage = (typeof AI_RESPONSE_LANGUAGE_OPTIONS)[number]["value"];
+export type AIResponseLanguage = ResponseLanguage;
 
-export const DEFAULT_AUTO_EXPLAIN_LANGUAGE: AutoExplainLanguage = "en";
+export const DEFAULT_AI_RESPONSE_LANGUAGE: AIResponseLanguage = "en";
 
-export function normalizeAutoExplainLanguage(raw: string | undefined): AutoExplainLanguage {
+export function normalizeAIResponseLanguage(raw: string | undefined): AIResponseLanguage {
   if (!raw) {
-    return DEFAULT_AUTO_EXPLAIN_LANGUAGE;
+    return DEFAULT_AI_RESPONSE_LANGUAGE;
   }
-  const option = AUTO_EXPLAIN_LANGUAGE_OPTIONS.find((o) => o.value === raw);
-  return option ? option.value : DEFAULT_AUTO_EXPLAIN_LANGUAGE;
+  const option = AI_RESPONSE_LANGUAGE_OPTIONS.find((o) => o.value === raw);
+  return option ? option.value : DEFAULT_AI_RESPONSE_LANGUAGE;
 }
+
+export const normalizeAutoExplainLanguage = normalizeAIResponseLanguage;
+export const normalizeSqlReviewLanguage = normalizeAIResponseLanguage;
 
 export type AgentConfiguration = {
   mode: AgentMode;
@@ -43,8 +47,12 @@ export type AgentConfiguration = {
   autoExplainClickHouseErrors?: boolean;
   /** ClickHouse error codes that should never auto-trigger inline explanation. */
   autoExplainBlacklist?: string[];
-  /** Language for automatic inline error explanations only (BCP-47). Default English. */
-  autoExplainLanguage?: AutoExplainLanguage;
+  /** Language for AI responses in SQL editor actions (BCP-47). Default English. */
+  aiResponseLanguage?: AIResponseLanguage;
+  /** @deprecated use aiResponseLanguage */
+  autoExplainLanguage?: ResponseLanguage;
+  /** @deprecated use aiResponseLanguage */
+  sqlReviewLanguage?: ResponseLanguage;
 };
 
 export class AgentConfigurationManager {
@@ -57,21 +65,34 @@ export class AgentConfigurationManager {
   public static getConfiguration(): AgentConfiguration {
     if (!this.configuration) {
       const storage = this.getStorage();
-      this.configuration = storage.getAsJSON<AgentConfiguration>(() => {
-        return {
-          mode: "v2",
-          pruneValidateSql: true,
-          autoExplainClickHouseErrors: true,
-          autoExplainBlacklist: DEFAULT_AUTO_EXPLAIN_BLACKLIST,
-          autoExplainLanguage: DEFAULT_AUTO_EXPLAIN_LANGUAGE,
-        };
-      });
+      const stored = storage.getAsJSON<AgentConfiguration>(() => ({
+        mode: "v2",
+        pruneValidateSql: true,
+        autoExplainClickHouseErrors: true,
+        autoExplainBlacklist: DEFAULT_AUTO_EXPLAIN_BLACKLIST,
+        aiResponseLanguage: DEFAULT_AI_RESPONSE_LANGUAGE,
+      }));
+      this.configuration = {
+        ...stored,
+        aiResponseLanguage: normalizeAIResponseLanguage(
+          stored.aiResponseLanguage ?? stored.sqlReviewLanguage ?? stored.autoExplainLanguage
+        ),
+      };
     }
     return this.configuration!;
   }
 
   public static setConfiguration(cfg: AgentConfiguration) {
-    this.configuration = cfg;
-    this.getStorage().setJSON(cfg);
+    const {
+      autoExplainLanguage: _legacyAutoExplain,
+      sqlReviewLanguage: _legacySqlReview,
+      ...rest
+    } = cfg;
+    const normalized = {
+      ...rest,
+      aiResponseLanguage: normalizeAIResponseLanguage(cfg.aiResponseLanguage),
+    };
+    this.configuration = normalized;
+    this.getStorage().setJSON(normalized);
   }
 }

--- a/src/lib/ai/commands/command-manager.ts
+++ b/src/lib/ai/commands/command-manager.ts
@@ -8,6 +8,8 @@ export interface CommandCatalogItem {
   description: string;
   /** Stable skill folder id this command belongs to. */
   skillId: string;
+  /** Whether this command should be shown as a SQL editor quick action. */
+  showInSqlEditorQuickAction?: boolean;
 }
 
 export interface CommandDetail extends CommandCatalogItem {
@@ -40,6 +42,7 @@ export class CommandManager {
             name,
             description: skill.description,
             skillId: skill.id,
+            showInSqlEditorQuickAction: skill.showInSqlEditorQuickAction,
             template: CommandManager.buildSkillCommandTemplate(skill.name),
           } satisfies CommandDetail,
         ];

--- a/src/lib/ai/skills/disk-skill-provider.test.ts
+++ b/src/lib/ai/skills/disk-skill-provider.test.ts
@@ -64,6 +64,33 @@ metadata:
     expect(skills.find((skill) => skill.name === "visualization")?.disableSlashCommand).toBe(true);
   });
 
+  it("loads sql editor quick action metadata for disk-backed skills", async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "skill-manager-test-"));
+    tempDirs.push(rootDir);
+
+    writeSkill(
+      rootDir,
+      "review-sql",
+      `---
+name: review-sql
+description: Review SQL.
+metadata:
+  show-in-sql-editor-quick-action: true
+---
+
+# Review SQL
+`
+    );
+
+    process.env.SKILLS_ROOT_DIR = rootDir;
+    clearDiskSkillProviderCache();
+
+    const skills = await provider.listSkills();
+    expect(skills.find((skill) => skill.name === "review-sql")?.showInSqlEditorQuickAction).toBe(
+      true
+    );
+  });
+
   it("loads metadata url for disk-backed skills", async () => {
     const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "skill-manager-test-"));
     tempDirs.push(rootDir);

--- a/src/lib/ai/skills/disk-skill-provider.ts
+++ b/src/lib/ai/skills/disk-skill-provider.ts
@@ -198,6 +198,9 @@ export class DiskSkillProvider implements SkillProvider {
       const metaName = typeof data.name === "string" ? data.name : dirName;
       const disableSlashCommand =
         data["disable-slash-command"] === true || metadataBlock["disable-slash-command"] === true;
+      const showInSqlEditorQuickAction =
+        data["show-in-sql-editor-quick-action"] === true ||
+        metadataBlock["show-in-sql-editor-quick-action"] === true;
       const requiredTools = parseRequiredTools(metadataBlock.tools);
       const meta: SkillMetadata = {
         name: metaName,
@@ -235,6 +238,7 @@ export class DiskSkillProvider implements SkillProvider {
         summary: this.extractSummary(parsed.content),
         hasResources: skillResources.paths.length > 0,
         disableSlashCommand,
+        showInSqlEditorQuickAction,
         requiredTools,
       };
       catalog.set(catalogItem.id, catalogItem);

--- a/src/lib/ai/skills/skill-types.ts
+++ b/src/lib/ai/skills/skill-types.ts
@@ -36,6 +36,8 @@ export interface SkillCatalogItem {
   hasResources?: boolean;
   /** Whether this skill is excluded from slash command registration. */
   disableSlashCommand?: boolean;
+  /** Whether this skill should be shown as a SQL editor quick action. */
+  showInSqlEditorQuickAction?: boolean;
   /** Tool names required for this skill to be usable at runtime. */
   requiredTools?: string[];
 }

--- a/src/lib/ai/tools/server/skill-tool.ts
+++ b/src/lib/ai/tools/server/skill-tool.ts
@@ -28,8 +28,8 @@ Use the available skill names and descriptions below to choose the best matching
 
 Usage:
   - Pass skill name(s) in the 'names' array.
-  - Example: { "names": ["optimize-clickhouse-queries"] }
-  - Example: { "names": ["optimize-clickhouse-queries", "visualization"] }
+  - Example: { "names": ["optimize-clickhouse-sql"] }
+  - Example: { "names": ["optimize-clickhouse-sql", "visualization"] }
 
 After loading a manual, if it tells you to "read rules/...md" or other reference files, use the separate 'skill_resource' tool to load them. Do NOT call this tool again for the same skill.
 


### PR DESCRIPTION
## Summary
- generalize SQL editor AI actions to use shared agent command metadata and browser UI
- unify AI response language handling and move the agent command provider up to main-page
- refine chat/sidebar/query control interactions and add focused test coverage

## Validation
- npm run test -- src/components/query-tab/query-control/query-control.test.tsx src/components/chat/input/chat-input.test.ts src/components/chat/input/chat-input.resize.test.tsx src/components/chat/input/chat-input.images.test.tsx src/components/app-sidebar.test.tsx
- npm run format

## Known issue
- npm run build currently fails in a vendored prebuild step with TS2688: Cannot find type definition file for `@vitest/browser/providers/playwright`