### PR TITLE
Handle non-200 release notes responses

### DIFF
--- a/src/components/release-note/release-notes-view.tsx
+++ b/src/components/release-note/release-notes-view.tsx
@@ -91,9 +91,15 @@ export function ReleaseNotesView() {
 
   useEffect(() => {
     fetch(BasePath.getURL("/release-notes.json"))
-      .then((res) => res.json())
-      .then((data) => {
-        const list = Array.isArray(data) ? data : [data];
+      .then(async (res) => {
+        if (res.status !== 200) {
+          return [];
+        }
+
+        const data = await res.json();
+        return Array.isArray(data) ? data : [data];
+      })
+      .then((list: Release[]) => {
         setReleases(list);
         if (list.length > 0) setExpandedId(list[0].id);
         setLoading(false);

--- a/src/components/release-note/release-notes-view.tsx
+++ b/src/components/release-note/release-notes-view.tsx
@@ -92,7 +92,12 @@ export function ReleaseNotesView() {
   useEffect(() => {
     fetch(BasePath.getURL("/release-notes.json"))
       .then(async (res) => {
-        if (res.status !== 200) {
+        if (res.status === 204 || res.status === 205) {
+          return [];
+        }
+
+        if (!res.ok) {
+          console.error(`Failed to load release notes: ${res.status} ${res.statusText}`);
           return [];
         }
 


### PR DESCRIPTION
## Summary
- avoid parsing release notes responses unless the fetch returns HTTP 200
- treat missing or unavailable release notes as an empty list in the dialog

## Validation
- npm run format
- npm run typecheck
- npm run lint
- npm run build (fails in this worktree because external/number-flow/packages/number-flow is missing)