### PR TITLE
Update the table-tab dashboard panels

### DIFF
--- a/src/components/shared/dashboard/__tests__/dashboard-panel-container.test.tsx
+++ b/src/components/shared/dashboard/__tests__/dashboard-panel-container.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Dashboard } from "../dashboard-model";
+import DashboardPanelContainer from "../dashboard-panel-container";
+
+const testGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+const renderedSections: Array<{ isCollapsed: boolean; title: string | null }> = [];
+
+vi.mock("echarts", () => ({
+  connect: vi.fn(),
+}));
+
+vi.mock("../dashboard-layout-storage", () => ({
+  invalidateLegacySectionLayoutKeys: vi.fn(),
+}));
+
+vi.mock("../dashboard-section", () => ({
+  DashboardSection: ({
+    isCollapsed,
+    group,
+  }: {
+    isCollapsed: boolean;
+    group: { title?: string } | null;
+  }) => {
+    renderedSections.push({
+      isCollapsed,
+      title: group?.title ?? null,
+    });
+    return <div>{group?.title ?? "Ungrouped"}</div>;
+  },
+}));
+
+describe("DashboardPanelContainer", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+    renderedSections.length = 0;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await import("react").then(({ act }) =>
+      act(() => {
+        root.unmount();
+      })
+    );
+    container.remove();
+  });
+
+  it("uses the group's configured collapsed state on initial render", async () => {
+    const dashboard: Dashboard = {
+      version: 3,
+      filter: {},
+      charts: [
+        {
+          title: "Overall Size",
+          collapsed: true,
+          charts: [
+            {
+              type: "table",
+              titleOption: { title: "Table Size" },
+              datasource: { sql: "select 1" },
+              gridPos: { w: 24, h: 6 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const { act } = await import("react");
+
+    act(() => {
+      root.render(<DashboardPanelContainer dashboard={dashboard} />);
+    });
+
+    expect(renderedSections).toEqual([
+      {
+        isCollapsed: true,
+        title: "Overall Size",
+      },
+    ]);
+  });
+});

--- a/src/components/shared/dashboard/dashboard-panel-container.tsx
+++ b/src/components/shared/dashboard/dashboard-panel-container.tsx
@@ -436,8 +436,11 @@ const DashboardPanelContainer = forwardRef<
         <div className="h-full flex flex-col overflow-hidden">
           <div className="flex-1 overflow-y-auto overflow-x-hidden">
             {sections.map((section) => {
-              // Use local state for collapse only (no persistence)
-              const isCollapsed = sectionCollapseStates.get(section.sectionIndex) ?? false;
+              // Default to the group's configured state until the user toggles locally.
+              const isCollapsed =
+                sectionCollapseStates.get(section.sectionIndex) ??
+                section.group?.collapsed ??
+                false;
 
               return (
                 <DashboardSection

--- a/src/components/shared/dashboard/dashboard-section-header.tsx
+++ b/src/components/shared/dashboard/dashboard-section-header.tsx
@@ -95,12 +95,7 @@ export function SectionHeader({
   }, []);
 
   return (
-    <div
-      className={cn(
-        "flex items-center gap-2 py-1.5 bg-muted/30 select-none group",
-        className
-      )}
-    >
+    <div className={cn("flex items-center gap-2 py-1.5 bg-muted/30 select-none group", className)}>
       {/* Collapse toggle */}
       <button
         type="button"

--- a/src/components/shared/dashboard/dashboard-section-header.tsx
+++ b/src/components/shared/dashboard/dashboard-section-header.tsx
@@ -98,8 +98,7 @@ export function SectionHeader({
     <div
       className={cn(
         "flex items-center gap-2 py-1.5 bg-muted/30 select-none group",
-        className,
-        isCollapsed && "border-b"
+        className
       )}
     >
       {/* Collapse toggle */}

--- a/src/components/table-tab/table-overview-view.tsx
+++ b/src/components/table-tab/table-overview-view.tsx
@@ -81,12 +81,12 @@ const TableOverviewViewComponent = forwardRef<RefreshableTabViewRef, TableOvervi
             },
             datasource: {
               sql: `
-SELECT sum(total_rows) as total_bytes
+SELECT sum(total_rows) as total_rows
 FROM
     system.tables
 WHERE 
     database = '${escapedDatabase}' 
-    AND table = '${escapedTable}'
+    AND name = '${escapedTable}'
 `,
             },
           } as StatDescriptor,
@@ -105,7 +105,7 @@ FROM
     system.tables
 WHERE 
     database = '${escapedDatabase}' 
-    AND table = '${escapedTable}'
+    AND name = '${escapedTable}'
 `,
             },
             valueOption: {
@@ -147,7 +147,11 @@ WHERE
             datasource: {
               sql: `
     SELECT 
-        toString(round(sum(data_uncompressed_bytes) / sum(data_compressed_bytes), 0)) || ' : 1' AS compress_ratio
+        if(
+            sum(data_compressed_bytes) = 0,
+            '-',
+            toString(round(sum(data_uncompressed_bytes) / nullIf(sum(data_compressed_bytes), 0), 0)) || ' : 1'
+        ) AS compress_ratio
     FROM
         system.parts
     WHERE 
@@ -168,7 +172,7 @@ WHERE
             datasource: {
               sql: `
     SELECT 
-        round(sum(bytes_on_disk) / sum(rows), 0) AS avg_row_size
+        round(sum(bytes_on_disk) / nullIf(sum(rows), 0), 0) AS avg_row_size
     FROM
         system.parts
     WHERE 
@@ -176,6 +180,9 @@ WHERE
         AND table = '${escapedTable}'
         AND active = 1
 `,
+            },
+            valueOption: {
+              format: "binary_size",
             },
           },
           {
@@ -212,8 +219,10 @@ WHERE
               title: "Replication Queue",
               align: "center",
             },
-            collapsed: true,
             gridPos: { w: 3, h: 3 },
+            valueOption: {
+              format: "comma_number",
+            },
             datasource: {
               sql: `
 SELECT count(*)
@@ -258,7 +267,7 @@ LIMIT 1
                       gridPos: { w: 3, h: 3 },
                       datasource: {
                         sql: `
-SELECT sum(total_rows) as total_bytes
+SELECT sum(total_rows) as total_rows
 FROM cluster('{cluster}', system.tables)
 WHERE database = '${escapedDatabase}' AND name = '${escapedTable}'
 `,

--- a/src/components/table-tab/table-overview-view.tsx
+++ b/src/components/table-tab/table-overview-view.tsx
@@ -71,33 +71,11 @@ const TableOverviewViewComponent = forwardRef<RefreshableTabViewRef, TableOvervi
           {
             type: "stat",
             titleOption: {
-              title: "Total Size",
-              align: "center",
-            },
-            collapsed: false,
-            gridPos: { w: 5, h: 4 },
-            datasource: {
-              sql: `
-SELECT sum(total_bytes) as total_bytes
-FROM
-    system.tables
-WHERE 
-    database = '${escapedDatabase}' 
-    AND table = '${escapedTable}'
-`,
-            },
-            valueOption: {
-              format: "binary_size",
-            },
-          },
-          {
-            type: "stat",
-            titleOption: {
               title: "Total Rows",
               align: "center",
             },
             collapsed: false,
-            gridPos: { w: 5, h: 4 },
+            gridPos: { w: 3, h: 3 },
             valueOption: {
               format: "comma_number",
             },
@@ -115,11 +93,99 @@ WHERE
           {
             type: "stat",
             titleOption: {
+              title: "Total Size",
+              align: "center",
+            },
+            collapsed: false,
+            gridPos: { w: 3, h: 3 },
+            datasource: {
+              sql: `
+SELECT sum(total_bytes) as total_bytes
+FROM
+    system.tables
+WHERE 
+    database = '${escapedDatabase}' 
+    AND table = '${escapedTable}'
+`,
+            },
+            valueOption: {
+              format: "binary_size",
+            },
+          },
+          {
+            type: "stat",
+            titleOption: {
+              title: "Uncompressed Size",
+              align: "center",
+            },
+            collapsed: false,
+            gridPos: { w: 3, h: 3 },
+            datasource: {
+              sql: `
+    SELECT 
+        sum(data_uncompressed_bytes)
+    FROM
+        system.parts
+    WHERE 
+        database = '${escapedDatabase}' 
+        AND table = '${escapedTable}'
+        AND active = 1
+`,
+            },
+            valueOption: {
+              format: "binary_size",
+            },
+          },
+          {
+            type: "stat",
+            titleOption: {
+              title: "Compress Ratio",
+              align: "center",
+            },
+            collapsed: false,
+            gridPos: { w: 3, h: 3 },
+            datasource: {
+              sql: `
+    SELECT 
+        toString(round(sum(data_uncompressed_bytes) / sum(data_compressed_bytes), 0)) || ' : 1' AS compress_ratio
+    FROM
+        system.parts
+    WHERE 
+        database = '${escapedDatabase}' 
+        AND table = '${escapedTable}'
+        AND active = 1
+`,
+            }
+          } as StatDescriptor,
+          {
+            type: "stat",
+            titleOption: {
+              title: "Avg Row Size",
+              align: "center",
+            },
+            collapsed: false,
+            gridPos: { w: 3, h: 3 },
+            datasource: {
+              sql: `
+    SELECT 
+        round(sum(bytes_on_disk) / sum(rows), 0) AS avg_row_size
+    FROM
+        system.parts
+    WHERE 
+        database = '${escapedDatabase}' 
+        AND table = '${escapedTable}'
+        AND active = 1
+`,
+            },
+          },
+          {
+            type: "stat",
+            titleOption: {
               title: "Part Count",
               align: "center",
             },
             collapsed: false,
-            gridPos: { w: 5, h: 4 },
+            gridPos: { w: 3, h: 3 },
             valueOption: {
               format: "comma_number",
             },
@@ -143,25 +209,19 @@ WHERE
           {
             type: "stat",
             titleOption: {
-              title: "Size Percentage of All Disks",
+              title: "Replication Queue",
               align: "center",
             },
-            collapsed: false,
-            gridPos: { w: 5, h: 4 },
+            collapsed: true,
+            gridPos: { w: 3, h: 3 },
             datasource: {
               sql: `
-SELECT sum(total_bytes) / (SELECT sum(total_space - keep_free_space) from system.disks) as bytes_on_disk
-FROM
-    system.tables
-WHERE 
-    database = '${escapedDatabase}' 
-    AND table = '${escapedTable}'
+SELECT count(*)
+FROM system.replication_queue
+WHERE database = '${escapedDatabase}' AND table = '${escapedTable}'
 `,
             },
-            valueOption: {
-              format: "percentage_0_1",
-            },
-          },
+          } as StatDescriptor,
           {
             type: "stat",
             titleOption: {
@@ -169,7 +229,7 @@ WHERE
               align: "center",
             },
             collapsed: false,
-            gridPos: { w: 4, h: 4 },
+            gridPos: { w: 3, h: 3 },
             datasource: {
               sql: `
 SELECT modification_time
@@ -186,69 +246,70 @@ LIMIT 1
           //
           ...(isClusterMode
             ? [
-                {
-                  title: "Cluster",
-                  charts: [
-                    {
-                      type: "stat",
-                      titleOption: {
-                        title: "Cluster Size",
-                      },
-                      gridPos: { w: 5, h: 4 },
-                      datasource: {
-                        sql: `
-SELECT sum(total_bytes) as total_bytes
-FROM cluster('{cluster}', system.tables)
-WHERE database = '${escapedDatabase}' AND name = '${escapedTable}'
-`,
-                      },
-                      valueOption: {
-                        format: "binary_size",
-                      },
-                    } as StatDescriptor,
-                    {
-                      type: "stat",
-                      titleOption: {
-                        title: "Cluster Size(All Replicas)",
-                      },
-                      gridPos: { w: 5, h: 4 },
-                      datasource: {
-                        sql: `
-SELECT sum(total_bytes) as total_bytes
-FROM clusterAllReplicas('{cluster}', system.tables)
-WHERE database = '${escapedDatabase}' AND name = '${escapedTable}'
-`,
-                      },
-                      valueOption: {
-                        format: "binary_size",
-                      },
-                    } as StatDescriptor,
-                    {
-                      type: "stat",
-                      titleOption: {
-                        title: "Total Rows",
-                      },
-                      gridPos: { w: 5, h: 4 },
-                      datasource: {
-                        sql: `
+              {
+                title: "Cluster",
+                collapsed: true,
+                charts: [
+                  {
+                    type: "stat",
+                    titleOption: {
+                      title: "Total Rows",
+                    },
+                    gridPos: { w: 3, h: 3 },
+                    datasource: {
+                      sql: `
 SELECT sum(total_rows) as total_bytes
 FROM cluster('{cluster}', system.tables)
 WHERE database = '${escapedDatabase}' AND name = '${escapedTable}'
 `,
-                      },
-                      valueOption: {
-                        format: "comma_number",
-                      },
-                    } as StatDescriptor,
-                    {
-                      type: "table",
-                      titleOption: {
-                        title: "Table Size On Cluster",
-                        align: "center",
-                      },
-                      gridPos: { w: 24, h: 12 },
-                      datasource: {
-                        sql: `
+                    },
+                    valueOption: {
+                      format: "comma_number",
+                    },
+                  } as StatDescriptor,
+                  {
+                    type: "stat",
+                    titleOption: {
+                      title: "Cluster Size",
+                    },
+                    gridPos: { w: 3, h: 3 },
+                    datasource: {
+                      sql: `
+SELECT sum(total_bytes) as total_bytes
+FROM cluster('{cluster}', system.tables)
+WHERE database = '${escapedDatabase}' AND name = '${escapedTable}'
+`,
+                    },
+                    valueOption: {
+                      format: "binary_size",
+                    },
+                  } as StatDescriptor,
+                  {
+                    type: "stat",
+                    titleOption: {
+                      title: "Cluster Size(All Replicas)",
+                    },
+                    gridPos: { w: 3, h: 3 },
+                    datasource: {
+                      sql: `
+SELECT sum(total_bytes) as total_bytes
+FROM clusterAllReplicas('{cluster}', system.tables)
+WHERE database = '${escapedDatabase}' AND name = '${escapedTable}'
+`,
+                    },
+                    valueOption: {
+                      format: "binary_size",
+                    },
+                  } as StatDescriptor,
+                  {
+                    type: "table",
+                    titleOption: {
+                      title: "Table Size Per Node",
+                      align: "center",
+                    },
+                    gridPos: { w: 24, h: 6 },
+                    datasource: {
+                      sql: `
 SELECT
   FQDN() as host, 
   count() as part_count, 
@@ -260,131 +321,86 @@ AND active
 GROUP BY host
 ORDER BY host
 `,
+                    },
+                    miscOption: {
+                      enableIndexColumn: true,
+                    },
+                    fieldOptions: {
+                      bytes_on_disk: {
+                        format: "binary_size",
                       },
-                      miscOption: {
-                        enableIndexColumn: true,
+                      rows: {
+                        format: "comma_number",
                       },
-                      fieldOptions: {
-                        bytes_on_disk: {
-                          format: "binary_size",
-                        },
-                        rows: {
-                          format: "comma_number",
-                        },
+                    },
+                    sortOption: {
+                      initialSort: {
+                        column: "host",
+                        direction: "asc",
                       },
-                      sortOption: {
-                        initialSort: {
-                          column: "host",
-                          direction: "asc",
-                        },
-                      },
-                    } as TableDescriptor,
-                  ],
-                } as DashboardGroup,
-              ]
+                    },
+                  } as TableDescriptor,
+                ],
+              } as DashboardGroup,
+            ]
             : []),
 
-          //
-          // Sizes
-          //
           {
-            title: "Sizes",
+            title: "Replication Queue",
             collapsed: true,
             charts: [
               {
                 type: "table",
                 titleOption: {
-                  title: "Overall Size",
+                  title: "",
                   align: "center",
                 },
-                gridPos: {
-                  w: 24,
-                  h: 4,
-                },
+                gridPos: { w: 24, h: 6 },
                 datasource: {
                   sql: `
-SELECT 
-    count(1) as part_count,
-    sum(rows) as rows,
-    sum(bytes_on_disk) AS disk_size,
-    sum(data_uncompressed_bytes) AS uncompressed_size,
-    round(sum(data_uncompressed_bytes) / sum(data_compressed_bytes), 2) AS compress_ratio,
-    round(disk_size / rows, 2) AS avg_row_size
-FROM
-    system.parts
-WHERE 
-    database = '${escapedDatabase}' 
-    AND table = '${escapedTable}'
-    AND active = 1
-ORDER BY 
-    disk_size DESC`,
+SELECT
+hostName() as host, 
+count() as queued_count
+FROM {clusterAllReplicas:system.replication_queue}
+WHERE database = '${escapedDatabase}' AND table = '${escapedTable}'
+GROUP BY 1
+ORDER BY 1
+`,
+                },
+                miscOption: {
+                  enableIndexColumn: true,
+                },
+                fieldOptions: {
+                  queued_count: {
+                    format: "comma_number",
+                  },
                 },
                 sortOption: {
                   initialSort: {
-                    column: "disk_size",
-                    direction: "desc",
-                  },
-                  serverSideSorting: true,
-                },
-                fieldOptions: {
-                  part_count: {
-                    title: "Part Count",
-                    sortable: true,
-                    align: "center",
-                    format: "comma_number",
-                    position: 3,
-                  },
-                  rows: {
-                    title: "Rows",
-                    sortable: true,
-                    align: "center",
-                    format: "comma_number",
-                    position: 4,
-                  },
-                  avg_row_size: {
-                    title: "Avg Row Size",
-                    sortable: true,
-                    align: "center",
-                    format: "binary_size",
-                    position: 5,
-                  },
-                  disk_size: {
-                    title: "On Disk Size",
-                    sortable: true,
-                    align: "center",
-                    format: "binary_size",
-                    position: 6,
-                  },
-                  uncompressed_size: {
-                    title: "Uncompressed Size",
-                    sortable: true,
-                    align: "center",
-                    format: "binary_size",
-                    position: 7,
-                  },
-                  compress_ratio: {
-                    title: "Compress Ratio",
-                    sortable: true,
-                    align: "center",
-                    position: 8,
-                    format: (value: unknown) => {
-                      if (value === null || value === undefined) {
-                        return "-";
-                      }
-                      return `${value} : 1`;
-                    },
+                    column: "host",
+                    direction: "asc",
                   },
                 },
               } as TableDescriptor,
+            ],
+          } as DashboardGroup,
+          
+          //
+          // Sizes
+          //
+          {
+            title: "Column Size",
+            collapsed: true,
+            charts: [
               {
                 type: "table",
                 titleOption: {
-                  title: "Column Size",
+                  title: "",
                   align: "center",
                 },
                 gridPos: {
                   w: 24,
-                  h: 18,
+                  h: 6,
                 },
                 datasource: {
                   sql: `
@@ -463,13 +479,19 @@ ORDER BY
                   },
                 },
               } as TableDescriptor,
+            ],
+          } as DashboardGroup,
+          {
+            title: "Index Size",
+            collapsed: true,
+            charts: [
               {
                 type: "table",
                 titleOption: {
-                  title: "Index Size",
+                  title: "",
                   align: "center",
                 },
-                gridPos: { w: 24, h: 10 },
+                gridPos: { w: 24, h: 6 },
                 fieldOptions: {
                   database: {
                     position: -1,
@@ -490,11 +512,11 @@ ORDER BY
                 },
                 datasource: {
                   sql: `
-SELECT *
-FROM system.data_skipping_indices
-WHERE
-    database = '${escapedDatabase}'
-    AND table = '${escapedTable}'`,
+    SELECT *
+    FROM system.data_skipping_indices
+    WHERE
+        database = '${escapedDatabase}'
+        AND table = '${escapedTable}'`,
                 },
                 sortOption: {
                   initialSort: {
@@ -503,47 +525,53 @@ WHERE
                   },
                 },
               } as TableDescriptor,
+            ],
+          } as DashboardGroup,
+          {
+            title: "Projection Size",
+            collapsed: true,
+            charts: [
               {
                 type: "table",
                 titleOption: {
-                  title: "Projection Size",
+                  title: "",
                   align: "center",
                 },
-                gridPos: { w: 24, h: 10 },
+                gridPos: { w: 24, h: 6 },
                 datasource: {
                   sql: `
-SELECT A.database, 
-  A.table, 
-  A.name, 
-  A.type,
-  B.part_count, 
-  B.rows, 
-  B.bytes_on_disk,
-  B.parent_bytes_on_disk,
-  B.bytes_on_disk * 100 / B.parent_bytes_on_disk as percentage_of_parent,
-  B.last_modified_time,
-  A.query
-FROM (
-    SELECT * FROM system.projections WHERE database = '${escapedDatabase}' AND table = '${escapedTable}' 
-) AS A
-LEFT JOIN
-(
-    SELECT 
-        name, 
-        count() as part_count, 
-        sum(bytes_on_disk) as bytes_on_disk,
-        sum(rows) as rows,
-        sum(parent_bytes_on_disk) as  parent_bytes_on_disk,
-        max(modification_time)  as last_modified_time
-    FROM system.projection_parts
-    WHERE
-        database = '${escapedDatabase}'
-        AND table = '${escapedTable}'
-        AND active
-    GROUP BY name
-) AS B
-ON A.name = B.name
-ORDER BY 1, 2, 3`,
+    SELECT A.database, 
+      A.table, 
+      A.name, 
+      A.type,
+      B.part_count, 
+      B.rows, 
+      B.bytes_on_disk,
+      B.parent_bytes_on_disk,
+      B.bytes_on_disk * 100 / B.parent_bytes_on_disk as percentage_of_parent,
+      B.last_modified_time,
+      A.query
+    FROM (
+        SELECT * FROM system.projections WHERE database = '${escapedDatabase}' AND table = '${escapedTable}' 
+    ) AS A
+    LEFT JOIN
+    (
+        SELECT 
+            name, 
+            count() as part_count, 
+            sum(bytes_on_disk) as bytes_on_disk,
+            sum(rows) as rows,
+            sum(parent_bytes_on_disk) as  parent_bytes_on_disk,
+            max(modification_time)  as last_modified_time
+        FROM system.projection_parts
+        WHERE
+            database = '${escapedDatabase}'
+            AND table = '${escapedTable}'
+            AND active
+        GROUP BY name
+    ) AS B
+    ON A.name = B.name
+    ORDER BY 1, 2, 3`,
                 },
                 sortOption: {
                   initialSort: {

--- a/src/components/table-tab/table-overview-view.tsx
+++ b/src/components/table-tab/table-overview-view.tsx
@@ -155,7 +155,7 @@ WHERE
         AND table = '${escapedTable}'
         AND active = 1
 `,
-            }
+            },
           } as StatDescriptor,
           {
             type: "stat",
@@ -246,70 +246,70 @@ LIMIT 1
           //
           ...(isClusterMode
             ? [
-              {
-                title: "Cluster",
-                collapsed: true,
-                charts: [
-                  {
-                    type: "stat",
-                    titleOption: {
-                      title: "Total Rows",
-                    },
-                    gridPos: { w: 3, h: 3 },
-                    datasource: {
-                      sql: `
+                {
+                  title: "Cluster",
+                  collapsed: true,
+                  charts: [
+                    {
+                      type: "stat",
+                      titleOption: {
+                        title: "Total Rows",
+                      },
+                      gridPos: { w: 3, h: 3 },
+                      datasource: {
+                        sql: `
 SELECT sum(total_rows) as total_bytes
 FROM cluster('{cluster}', system.tables)
 WHERE database = '${escapedDatabase}' AND name = '${escapedTable}'
 `,
-                    },
-                    valueOption: {
-                      format: "comma_number",
-                    },
-                  } as StatDescriptor,
-                  {
-                    type: "stat",
-                    titleOption: {
-                      title: "Cluster Size",
-                    },
-                    gridPos: { w: 3, h: 3 },
-                    datasource: {
-                      sql: `
+                      },
+                      valueOption: {
+                        format: "comma_number",
+                      },
+                    } as StatDescriptor,
+                    {
+                      type: "stat",
+                      titleOption: {
+                        title: "Cluster Size",
+                      },
+                      gridPos: { w: 3, h: 3 },
+                      datasource: {
+                        sql: `
 SELECT sum(total_bytes) as total_bytes
 FROM cluster('{cluster}', system.tables)
 WHERE database = '${escapedDatabase}' AND name = '${escapedTable}'
 `,
-                    },
-                    valueOption: {
-                      format: "binary_size",
-                    },
-                  } as StatDescriptor,
-                  {
-                    type: "stat",
-                    titleOption: {
-                      title: "Cluster Size(All Replicas)",
-                    },
-                    gridPos: { w: 3, h: 3 },
-                    datasource: {
-                      sql: `
+                      },
+                      valueOption: {
+                        format: "binary_size",
+                      },
+                    } as StatDescriptor,
+                    {
+                      type: "stat",
+                      titleOption: {
+                        title: "Cluster Size(All Replicas)",
+                      },
+                      gridPos: { w: 3, h: 3 },
+                      datasource: {
+                        sql: `
 SELECT sum(total_bytes) as total_bytes
 FROM clusterAllReplicas('{cluster}', system.tables)
 WHERE database = '${escapedDatabase}' AND name = '${escapedTable}'
 `,
-                    },
-                    valueOption: {
-                      format: "binary_size",
-                    },
-                  } as StatDescriptor,
-                  {
-                    type: "table",
-                    titleOption: {
-                      title: "Table Size Per Node",
-                      align: "center",
-                    },
-                    gridPos: { w: 24, h: 6 },
-                    datasource: {
-                      sql: `
+                      },
+                      valueOption: {
+                        format: "binary_size",
+                      },
+                    } as StatDescriptor,
+                    {
+                      type: "table",
+                      titleOption: {
+                        title: "Table Size Per Node",
+                        align: "center",
+                      },
+                      gridPos: { w: 24, h: 6 },
+                      datasource: {
+                        sql: `
 SELECT
   FQDN() as host, 
   count() as part_count, 
@@ -321,28 +321,28 @@ AND active
 GROUP BY host
 ORDER BY host
 `,
-                    },
-                    miscOption: {
-                      enableIndexColumn: true,
-                    },
-                    fieldOptions: {
-                      bytes_on_disk: {
-                        format: "binary_size",
                       },
-                      rows: {
-                        format: "comma_number",
+                      miscOption: {
+                        enableIndexColumn: true,
                       },
-                    },
-                    sortOption: {
-                      initialSort: {
-                        column: "host",
-                        direction: "asc",
+                      fieldOptions: {
+                        bytes_on_disk: {
+                          format: "binary_size",
+                        },
+                        rows: {
+                          format: "comma_number",
+                        },
                       },
-                    },
-                  } as TableDescriptor,
-                ],
-              } as DashboardGroup,
-            ]
+                      sortOption: {
+                        initialSort: {
+                          column: "host",
+                          direction: "asc",
+                        },
+                      },
+                    } as TableDescriptor,
+                  ],
+                } as DashboardGroup,
+              ]
             : []),
 
           {
@@ -384,7 +384,7 @@ ORDER BY 1
               } as TableDescriptor,
             ],
           } as DashboardGroup,
-          
+
           //
           // Sizes
           //


### PR DESCRIPTION
## Summary
- tighten dashboard panel container layout and section header behavior
- update the table overview view to match the new dashboard presentation
- add regression coverage for dashboard panel container interactions

## Validation
- npm run typecheck
- npm run lint

## Build
- npm run build currently fails in this worktree before app compilation because required local vendor directories under external/ are missing (external/number-flow plus skill sync sources under external/clickhouse/skills and external/vizlayer/skills)