### PR TITLE
Improve SQL editor and chat-panel integration

### DIFF
--- a/.codex/hooks/after_change.sh
+++ b/.codex/hooks/after_change.sh
@@ -8,6 +8,25 @@ state_dir="$repo_root/.codex/tmp"
 stamp_file="$state_dir/after-change.sha256"
 mkdir -p "$state_dir"
 
+collect_candidate_files() {
+  {
+    git diff --name-only HEAD -- .
+    git ls-files --others --exclude-standard
+  } | awk 'NF' | sort -u
+}
+
+run_direct_tool_for_files() {
+  local tool="$1"
+  shift
+  local -a files=("$@")
+
+  if [ "${#files[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  npx "$tool" "${files[@]}"
+}
+
 hash_stream() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum | awk '{print $1}'
@@ -58,6 +77,7 @@ compute_fingerprint() {
 
 current_fingerprint="$(compute_fingerprint)"
 untracked_listing="$(git ls-files --others --exclude-standard)"
+mapfile -t candidate_files < <(collect_candidate_files)
 
 if git diff --quiet && git diff --cached --quiet && [ -z "$untracked_listing" ]; then
   rm -f "$stamp_file"
@@ -70,9 +90,23 @@ if [ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$current_fingerprint" ]; 
   exit 0
 fi
 
-npm run format
+format_files=()
+lint_files=()
+for path in "${candidate_files[@]}"; do
+  case "$path" in
+    src/*.ts|src/*.tsx|src/**/*.ts|src/**/*.tsx)
+      format_files+=("$path")
+      lint_files+=("$path")
+      ;;
+    *.js|*.jsx|*.mjs|*.cjs|*.ts|*.tsx)
+      lint_files+=("$path")
+      ;;
+  esac
+done
+
+run_direct_tool_for_files prettier --write "${format_files[@]}"
 npm run typecheck
-npm run lint
+run_direct_tool_for_files eslint "${lint_files[@]}"
 
 if git diff --quiet && git diff --cached --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
   rm -f "$stamp_file"

--- a/src/components/chat/input/chat-input.test.ts
+++ b/src/components/chat/input/chat-input.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatInput } from "./chat-input";
 import { removeLeadingCommand, replaceLeadingCommand } from "./command-utils";
 import { getTableMentionMatches, removeTableMentionAt } from "./mention-utils";
+import { sqlSnippetTokenCodec } from "./sql-snippet-token";
 
 vi.mock("@/components/connection/connection-context", () => ({
   useConnection: () => ({
@@ -120,6 +121,39 @@ describe("table mention helpers", () => {
   });
 });
 
+describe("SQL snippet token helpers", () => {
+  it("creates and expands SQL snippet tokens", () => {
+    const token = sqlSnippetTokenCodec.createToken("SELECT *\nFROM system.query_log");
+
+    expect(sqlSnippetTokenCodec.getMatches(`Explain ${token}`)).toEqual([
+      expect.objectContaining({
+        text: token,
+        sql: "SELECT *\nFROM system.query_log",
+        start: 8,
+        end: 8 + token.length,
+      }),
+    ]);
+    expect(sqlSnippetTokenCodec.expand(token)).toBe("```sql\nSELECT *\nFROM system.query_log\n```");
+  });
+
+  it("expands SQL snippet tokens into fenced blocks separated from surrounding prose", () => {
+    const token = sqlSnippetTokenCodec.createToken(
+      "admin_de_presto_prod_.presto_alb_jdbc_access_log_view.big_data_account"
+    );
+
+    expect(sqlSnippetTokenCodec.expand(`what's the type of this column ${token}`)).toBe(
+      "what's the type of this column\n\n```sql\nadmin_de_presto_prod_.presto_alb_jdbc_access_log_view.big_data_account\n```"
+    );
+  });
+
+  it("removes SQL snippet tokens without leaving double spaces behind", () => {
+    const token = sqlSnippetTokenCodec.createToken("SELECT 1");
+    expect(sqlSnippetTokenCodec.removeAt(`Explain ${token} now`, 8, 8 + token.length)).toBe(
+      "Explain now"
+    );
+  });
+});
+
 describe("ChatInput inline tokens", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -146,7 +180,7 @@ describe("ChatInput inline tokens", () => {
         React.createElement(ChatInput, {
           onSubmit: vi.fn(),
           isRunning: false,
-          externalInput: "/review check @system.query_log now",
+          externalInput: { text: "/review check @system.query_log now", mode: "replace", nonce: 1 },
         })
       );
     });
@@ -187,13 +221,79 @@ describe("ChatInput inline tokens", () => {
     expect(editor?.textContent).not.toContain("system.query_log");
   });
 
+  it("renders SQL snippet tokens inline and expands them on submit", () => {
+    const onSubmit = vi.fn();
+    const externalInput = sqlSnippetTokenCodec.createToken("SELECT 1");
+
+    act(() => {
+      root.render(
+        React.createElement(ChatInput, {
+          onSubmit,
+          isRunning: false,
+          externalInput: { text: externalInput, mode: "replace", nonce: 1 },
+        })
+      );
+    });
+
+    expect(container.textContent).toContain("SELECT 1");
+
+    const removeSnippetButton = container.querySelector(
+      'button[aria-label="Remove SQL selection SELECT 1"]'
+    ) as HTMLButtonElement | null;
+    expect(removeSnippetButton).not.toBeNull();
+
+    const sendButton = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.getAttribute("aria-label")?.includes("Send")
+    );
+    expect(sendButton).toBeTruthy();
+
+    act(() => {
+      sendButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      text: "```sql\nSELECT 1\n```",
+      files: [],
+    });
+  });
+
+  it("appends external input chips to the existing composer content", () => {
+    act(() => {
+      root.render(
+        React.createElement(ChatInput, {
+          onSubmit: vi.fn(),
+          isRunning: false,
+          externalInput: { text: "Explain", mode: "replace", nonce: 1 },
+        })
+      );
+    });
+
+    act(() => {
+      root.render(
+        React.createElement(ChatInput, {
+          onSubmit: vi.fn(),
+          isRunning: false,
+          externalInput: {
+            text: sqlSnippetTokenCodec.createToken("SELECT count() FROM events"),
+            mode: "append",
+            nonce: 2,
+          },
+        })
+      );
+    });
+
+    const editor = container.querySelector('[role="textbox"]') as HTMLDivElement | null;
+    expect(editor?.textContent).toContain("Explain");
+    expect(editor?.textContent).toContain("SELECT count() FROM events");
+  });
+
   it("does not intercept Enter while IME composition is active", () => {
     act(() => {
       root.render(
         React.createElement(ChatInput, {
           onSubmit: vi.fn(),
           isRunning: false,
-          externalInput: "ni",
+          externalInput: { text: "ni", mode: "replace", nonce: 1 },
         })
       );
     });

--- a/src/components/chat/input/chat-input.test.ts
+++ b/src/components/chat/input/chat-input.test.ts
@@ -200,7 +200,7 @@ describe("ChatInput inline tokens", () => {
     expect(removeCommandButton).not.toBeNull();
 
     act(() => {
-      removeCommandButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      removeCommandButton?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
     });
 
     expect(editor?.textContent).not.toContain("review");
@@ -213,7 +213,7 @@ describe("ChatInput inline tokens", () => {
     expect(removeMentionButton).not.toBeNull();
 
     act(() => {
-      removeMentionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      removeMentionButton?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
     });
 
     expect(editor?.textContent).toContain("check");

--- a/src/components/chat/input/chat-input.tsx
+++ b/src/components/chat/input/chat-input.tsx
@@ -1498,6 +1498,7 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
                   size="icon"
                   variant="destructive"
                   className="h-6 w-6 rounded-md shadow-sm"
+                  aria-label="Stop generating"
                   title="Stop generating"
                 >
                   <Square className="h-3.5 w-3.5" />
@@ -1508,6 +1509,7 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
                   disabled={!canSubmit}
                   size="icon"
                   className="h-6 w-6 rounded-md shadow-sm"
+                  aria-label="Send message"
                   title={`Send (${typeof navigator !== "undefined" && navigator.platform.includes("Mac") ? "Cmd" : "Ctrl"}+Enter)`}
                 >
                   <Send className="h-3.5 w-3.5" />

--- a/src/components/chat/input/chat-input.tsx
+++ b/src/components/chat/input/chat-input.tsx
@@ -17,6 +17,7 @@ import { ImagePlus, MessageSquarePlus, Plus, Send, Square, X } from "lucide-reac
 import * as React from "react";
 import { useAgentCommands } from "../agent-command-context";
 import { ChatTokenStatus } from "../message/chat-token-status";
+import type { ChatComposerInput } from "../view/use-chat-panel";
 import { ChatInputCommands, type ChatInputCommandsType } from "./chat-input-commands";
 import {
   ChatInputSuggestions,
@@ -26,6 +27,7 @@ import {
 import { getLeadingCommand, removeLeadingCommand, replaceLeadingCommand } from "./command-utils";
 import { getTableMentionMatches, removeTableMentionAt } from "./mention-utils";
 import { ModelSelector } from "./model-selector";
+import { sqlSnippetTokenCodec } from "./sql-snippet-token";
 
 export { replaceLeadingCommand } from "./command-utils";
 
@@ -42,7 +44,8 @@ const MAX_TOTAL_IMAGE_FILE_SIZE_BYTES = 7 * 1024 * 1024;
 const UNSUPPORTED_IMAGE_MODEL_MESSAGE = "Select a vision-capable model before sending images.";
 const REMOVED_IMAGE_ATTACHMENTS_MESSAGE =
   "Attached images were removed because the selected model does not support image input.";
-
+const TOKEN_HOVER_CARD_OPEN_DELAY_MS = 180;
+const TOKEN_HOVER_CARD_CLOSE_DELAY_MS = 120;
 export type ChatInputImageAttachment = {
   id: string;
   mediaType: string;
@@ -58,7 +61,7 @@ interface ChatInputProps {
   hasMessages?: boolean;
   tokenUsage?: LanguageModelUsage;
   onNewChat?: () => void;
-  externalInput?: string;
+  externalInput?: ChatComposerInput;
 }
 
 export interface ChatInputHandle {
@@ -80,9 +83,21 @@ type TokenSegment =
       start: number;
       end: number;
       label: string;
+    }
+  | {
+      kind: "sqlSnippet";
+      rawText: string;
+      start: number;
+      end: number;
+      label: string;
+      sql: string;
     };
 
 type RenderSegment = { kind: "text"; text: string; start: number; end: number } | TokenSegment;
+type HoveredCodeToken = {
+  code: string;
+  rect: { top: number; left: number; width: number; height: number };
+};
 
 function createTextNodeSegment(documentRef: Document, text: string) {
   return documentRef.createTextNode(text);
@@ -130,7 +145,11 @@ function createAttachmentId(): string {
 function createTokenNodeSegment(
   documentRef: Document,
   segment: TokenSegment,
-  onRemove: () => void
+  onRemove: () => void,
+  options?: {
+    onHoverStart?: (element: HTMLElement, segment: TokenSegment) => void;
+    onHoverEnd?: (segment: TokenSegment) => void;
+  }
 ) {
   const token = documentRef.createElement("span");
   token.dataset.rawText = segment.rawText;
@@ -139,12 +158,15 @@ function createTokenNodeSegment(
     "mx-[1px] inline-flex max-w-full items-center gap-1 rounded-md border px-1.5 py-0.5 align-baseline text-xs",
     segment.kind === "command"
       ? "border-cyan-200 bg-cyan-50 text-cyan-900 dark:border-cyan-900/60 dark:bg-cyan-950/50 dark:text-cyan-100"
-      : "border-sky-200 bg-sky-50 text-sky-900 dark:border-sky-900/60 dark:bg-sky-950/50 dark:text-sky-100"
+      : segment.kind === "sqlSnippet"
+        ? "border-slate-200 bg-slate-100 text-slate-900 dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-100"
+        : "border-sky-200 bg-sky-50 text-sky-900 dark:border-sky-900/60 dark:bg-sky-950/50 dark:text-sky-100"
   );
 
   const icon = documentRef.createElement("span");
   icon.className = "shrink-0";
-  icon.textContent = segment.kind === "command" ? "/" : "@";
+  icon.textContent =
+    segment.kind === "command" ? "/" : segment.kind === "sqlSnippet" ? "SQL:" : "@";
 
   const label = documentRef.createElement("span");
   label.className = "max-w-[240px] truncate font-medium";
@@ -153,12 +175,27 @@ function createTokenNodeSegment(
   const remove = documentRef.createElement("button");
   remove.setAttribute("type", "button");
   remove.setAttribute("tabindex", "-1");
-  remove.setAttribute("aria-label", `Remove ${segment.kind} ${segment.label}`);
+  remove.setAttribute(
+    "aria-label",
+    `Remove ${segment.kind === "sqlSnippet" ? "SQL selection" : segment.kind} ${segment.label}`
+  );
   remove.className =
     "inline-flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-sm border-0 bg-transparent p-0 text-current/70 hover:bg-black/5 hover:text-current dark:hover:bg-white/10";
   remove.textContent = "×";
-  remove.addEventListener("mousedown", (event) => event.preventDefault());
-  remove.addEventListener("click", onRemove);
+  remove.addEventListener("pointerdown", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onRemove();
+  });
+  remove.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  });
+
+  if (segment.kind === "sqlSnippet" && options?.onHoverStart && options?.onHoverEnd) {
+    token.addEventListener("pointerenter", () => options.onHoverStart?.(token, segment));
+    token.addEventListener("pointerleave", () => options.onHoverEnd?.(segment));
+  }
 
   token.append(icon, label, remove);
   return token;
@@ -328,6 +365,45 @@ function isKeyboardEventComposing(event: React.KeyboardEvent<HTMLDivElement>) {
   return event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229;
 }
 
+function TokenHoverCard({
+  hoveredToken,
+  containerWidth,
+  onPointerEnter,
+  onPointerLeave,
+}: {
+  hoveredToken: HoveredCodeToken | null;
+  containerWidth: number | undefined;
+  onPointerEnter: () => void;
+  onPointerLeave: () => void;
+}) {
+  if (!hoveredToken) {
+    return null;
+  }
+
+  const hoverCardWidth = 360;
+  const hoverCardLeft = Math.max(
+    12,
+    Math.min(hoveredToken.rect.left, (containerWidth ?? hoverCardWidth + 24) - hoverCardWidth - 12)
+  );
+
+  return (
+    <div
+      className="absolute z-30 w-[360px] rounded-md border bg-popover p-3 text-popover-foreground shadow-md"
+      style={{
+        top: Math.max(hoveredToken.rect.top - 8, 8),
+        left: hoverCardLeft,
+        transform: "translateY(-100%)",
+      }}
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
+    >
+      <pre className="max-h-48 overflow-auto rounded-sm bg-muted/50 p-2 text-xs text-foreground">
+        <code>{hoveredToken.code}</code>
+      </pre>
+    </div>
+  );
+}
+
 function buildRenderSegments(input: string, command: CommandDetail | null): RenderSegment[] {
   const tokenSegments: TokenSegment[] = [];
 
@@ -349,6 +425,17 @@ function buildRenderSegments(input: string, command: CommandDetail | null): Rend
       start: mention.start,
       end: mention.end,
       label: mention.value,
+    });
+  }
+
+  for (const snippet of sqlSnippetTokenCodec.getMatches(input)) {
+    tokenSegments.push({
+      kind: "sqlSnippet",
+      rawText: snippet.text,
+      start: snippet.start,
+      end: snippet.end,
+      label: snippet.label,
+      sql: snippet.sql,
     });
   }
 
@@ -412,7 +499,11 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
     const [attachmentError, setAttachmentError] = React.useState<string | null>(null);
     const [resizedHeight, setResizedHeight] = React.useState<number | null>(null);
     const [isDraggingResizeHandle, setIsDraggingResizeHandle] = React.useState(false);
-    const prevExternalInputRef = React.useRef<string | undefined>(undefined);
+    const [hoveredCodeToken, setHoveredCodeToken] = React.useState<HoveredCodeToken | null>(null);
+    const hoveredCodeTokenOpenTimeoutRef = React.useRef<number | null>(null);
+    const hoveredCodeTokenCloseTimeoutRef = React.useRef<number | null>(null);
+    const prevExternalInputNonceRef = React.useRef<number | undefined>(undefined);
+    const inputRef = React.useRef(input);
 
     // Mention state
     const [suggestionStartPos, setSuggestionStartPos] = React.useState(0);
@@ -438,6 +529,10 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
     React.useEffect(() => {
       attachmentsRef.current = attachments;
     }, [attachments]);
+
+    React.useEffect(() => {
+      inputRef.current = input;
+    }, [input]);
 
     const resetFileInput = React.useCallback(() => {
       if (fileInputRef.current) {
@@ -679,15 +774,19 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
     }, [cleanupResizeDrag]);
 
     React.useEffect(() => {
-      if (externalInput && externalInput !== prevExternalInputRef.current) {
-        prevExternalInputRef.current = externalInput;
-        pendingSelectionOffsetRef.current = externalInput.length;
-        setInput(externalInput);
-        updateSuggestions(externalInput, externalInput.length);
-        if (editorRef.current) {
-          editorRef.current.focus();
-        }
+      if (!externalInput || externalInput.nonce === prevExternalInputNonceRef.current) {
+        return;
       }
+
+      prevExternalInputNonceRef.current = externalInput.nonce;
+      const nextText =
+        externalInput.mode === "append" && inputRef.current.trim().length > 0
+          ? `${inputRef.current}${/\s$/.test(inputRef.current) ? "" : " "}${externalInput.text}`
+          : externalInput.text;
+      pendingSelectionOffsetRef.current = nextText.length;
+      setInput(nextText);
+      updateSuggestions(nextText, nextText.length);
+      editorRef.current?.focus();
     }, [externalInput, updateSuggestions]);
 
     const handleNewChat = React.useCallback(() => {
@@ -763,9 +862,11 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
 
     const handleSelectCommand = React.useCallback(
       (command: CommandDetail) => {
-        const newText = replaceLeadingCommand(input, command.name);
+        const newText = replaceLeadingCommand(input, command.name, cursorOffsetRef.current);
         commandRef.current?.close();
-        setInputAndSelection(newText, newText.length);
+        const nextCursor =
+          newText === `/${command.name} ` ? newText.length : `/${command.name}`.length;
+        setInputAndSelection(newText, nextCursor);
         editorRef.current?.focus();
       },
       [input, setInputAndSelection]
@@ -788,6 +889,100 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
       [input, setInputAndSelection]
     );
 
+    const clearHoveredCodeTokenOpenTimeout = React.useCallback(() => {
+      if (hoveredCodeTokenOpenTimeoutRef.current !== null) {
+        window.clearTimeout(hoveredCodeTokenOpenTimeoutRef.current);
+        hoveredCodeTokenOpenTimeoutRef.current = null;
+      }
+    }, []);
+
+    const clearHoveredCodeTokenCloseTimeout = React.useCallback(() => {
+      if (hoveredCodeTokenCloseTimeoutRef.current !== null) {
+        window.clearTimeout(hoveredCodeTokenCloseTimeoutRef.current);
+        hoveredCodeTokenCloseTimeoutRef.current = null;
+      }
+    }, []);
+
+    const scheduleHoveredCodeTokenClose = React.useCallback(() => {
+      clearHoveredCodeTokenCloseTimeout();
+      hoveredCodeTokenCloseTimeoutRef.current = window.setTimeout(() => {
+        setHoveredCodeToken(null);
+        hoveredCodeTokenCloseTimeoutRef.current = null;
+      }, TOKEN_HOVER_CARD_CLOSE_DELAY_MS);
+    }, [clearHoveredCodeTokenCloseTimeout]);
+
+    const handleDismissSqlSnippet = React.useCallback(
+      (start: number, end: number) => {
+        clearHoveredCodeTokenOpenTimeout();
+        clearHoveredCodeTokenCloseTimeout();
+        setHoveredCodeToken(null);
+        const newText = sqlSnippetTokenCodec.removeAt(input, start, end);
+        suggestionRef.current?.close();
+        setInputAndSelection(newText, Math.min(start, newText.length));
+        editorRef.current?.focus();
+      },
+      [
+        clearHoveredCodeTokenCloseTimeout,
+        clearHoveredCodeTokenOpenTimeout,
+        input,
+        setInputAndSelection,
+      ]
+    );
+
+    const handleCodeTokenHoverStart = React.useCallback(
+      (element: HTMLElement, segment: TokenSegment) => {
+        if (segment.kind !== "sqlSnippet" || !containerRef.current) {
+          return;
+        }
+
+        clearHoveredCodeTokenOpenTimeout();
+        clearHoveredCodeTokenCloseTimeout();
+        const tokenRect = element.getBoundingClientRect();
+        const containerRect = containerRef.current.getBoundingClientRect();
+        const nextHoveredCodeToken = {
+          code: segment.sql,
+          rect: {
+            top: tokenRect.top - containerRect.top,
+            left: tokenRect.left - containerRect.left,
+            width: tokenRect.width,
+            height: tokenRect.height,
+          },
+        };
+
+        hoveredCodeTokenOpenTimeoutRef.current = window.setTimeout(() => {
+          setHoveredCodeToken(nextHoveredCodeToken);
+          hoveredCodeTokenOpenTimeoutRef.current = null;
+        }, TOKEN_HOVER_CARD_OPEN_DELAY_MS);
+      },
+      [clearHoveredCodeTokenCloseTimeout, clearHoveredCodeTokenOpenTimeout]
+    );
+
+    const handleCodeTokenHoverEnd = React.useCallback(
+      (_segment: TokenSegment) => {
+        clearHoveredCodeTokenOpenTimeout();
+        if (!hoveredCodeToken) {
+          return;
+        }
+        scheduleHoveredCodeTokenClose();
+      },
+      [clearHoveredCodeTokenOpenTimeout, hoveredCodeToken, scheduleHoveredCodeTokenClose]
+    );
+
+    const handleHoverCardPointerEnter = React.useCallback(() => {
+      clearHoveredCodeTokenCloseTimeout();
+    }, [clearHoveredCodeTokenCloseTimeout]);
+
+    const handleHoverCardPointerLeave = React.useCallback(() => {
+      scheduleHoveredCodeTokenClose();
+    }, [scheduleHoveredCodeTokenClose]);
+
+    React.useEffect(() => {
+      return () => {
+        clearHoveredCodeTokenOpenTimeout();
+        clearHoveredCodeTokenCloseTimeout();
+      };
+    }, [clearHoveredCodeTokenCloseTimeout, clearHoveredCodeTokenOpenTimeout]);
+
     React.useLayoutEffect(() => {
       const editor = editorRef.current;
       if (!editor) return;
@@ -802,14 +997,27 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
         }
 
         fragment.appendChild(
-          createTokenNodeSegment(document, segment, () => {
-            if (segment.kind === "command") {
-              handleDismissCommand();
-              return;
-            }
+          createTokenNodeSegment(
+            document,
+            segment,
+            () => {
+              if (segment.kind === "command") {
+                handleDismissCommand();
+                return;
+              }
 
-            handleDismissMention(segment.start, segment.end);
-          })
+              if (segment.kind === "mention") {
+                handleDismissMention(segment.start, segment.end);
+                return;
+              }
+
+              handleDismissSqlSnippet(segment.start, segment.end);
+            },
+            {
+              onHoverStart: handleCodeTokenHoverStart,
+              onHoverEnd: handleCodeTokenHoverEnd,
+            }
+          )
         );
       }
 
@@ -831,10 +1039,19 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
           });
         }
       }
-    }, [handleDismissCommand, handleDismissMention, input, isComposing, renderSegments]);
+    }, [
+      handleDismissCommand,
+      handleDismissMention,
+      handleDismissSqlSnippet,
+      handleCodeTokenHoverEnd,
+      handleCodeTokenHoverStart,
+      input,
+      isComposing,
+      renderSegments,
+    ]);
 
     const handleSubmit = React.useCallback(() => {
-      const message = input.trim();
+      const message = sqlSnippetTokenCodec.expand(input).trim();
       if (!message && attachments.length === 0) return;
       if (attachments.length > 0 && !selectedModelSupportsImages) {
         setAttachmentError(UNSUPPORTED_IMAGE_MODEL_MESSAGE);
@@ -1015,6 +1232,17 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
           }
         }
 
+        for (const snippet of sqlSnippetTokenCodec.getMatches(input)) {
+          if (
+            (key === "Backspace" && snippet.end === selection.start) ||
+            (key === "Delete" && snippet.start === selection.start)
+          ) {
+            const newText = sqlSnippetTokenCodec.removeAt(input, snippet.start, snippet.end);
+            setInputAndSelection(newText, Math.min(snippet.start, newText.length));
+            return true;
+          }
+        }
+
         return false;
       },
       [input, leadingCommand, selectedCommand, setInputAndSelection]
@@ -1101,6 +1329,13 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
             onMouseDown={handleResizeStart}
             onDoubleClick={handleResizeReset}
           ></div>
+
+          <TokenHoverCard
+            hoveredToken={hoveredCodeToken}
+            containerWidth={containerRef.current?.clientWidth}
+            onPointerEnter={handleHoverCardPointerEnter}
+            onPointerLeave={handleHoverCardPointerLeave}
+          />
 
           <div
             className={cn("flex flex-col overflow-hidden", isResizable ? "h-full" : "")}

--- a/src/components/chat/input/chat-input.tsx
+++ b/src/components/chat/input/chat-input.tsx
@@ -903,6 +903,12 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
       }
     }, []);
 
+    const clearHoveredCodeTokenState = React.useCallback(() => {
+      clearHoveredCodeTokenOpenTimeout();
+      clearHoveredCodeTokenCloseTimeout();
+      setHoveredCodeToken(null);
+    }, [clearHoveredCodeTokenCloseTimeout, clearHoveredCodeTokenOpenTimeout]);
+
     const scheduleHoveredCodeTokenClose = React.useCallback(() => {
       clearHoveredCodeTokenCloseTimeout();
       hoveredCodeTokenCloseTimeoutRef.current = window.setTimeout(() => {
@@ -913,20 +919,13 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
 
     const handleDismissSqlSnippet = React.useCallback(
       (start: number, end: number) => {
-        clearHoveredCodeTokenOpenTimeout();
-        clearHoveredCodeTokenCloseTimeout();
-        setHoveredCodeToken(null);
+        clearHoveredCodeTokenState();
         const newText = sqlSnippetTokenCodec.removeAt(input, start, end);
         suggestionRef.current?.close();
         setInputAndSelection(newText, Math.min(start, newText.length));
         editorRef.current?.focus();
       },
-      [
-        clearHoveredCodeTokenCloseTimeout,
-        clearHoveredCodeTokenOpenTimeout,
-        input,
-        setInputAndSelection,
-      ]
+      [clearHoveredCodeTokenState, input, setInputAndSelection]
     );
 
     const handleCodeTokenHoverStart = React.useCallback(
@@ -1059,6 +1058,7 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
       }
 
       onSubmit({ text: message, files: attachments });
+      clearHoveredCodeTokenState();
       pendingSelectionOffsetRef.current = 0;
       setInput("");
       setAttachments([]);
@@ -1067,6 +1067,7 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
       resetFileInput();
     }, [
       attachments,
+      clearHoveredCodeTokenState,
       input,
       onSubmit,
       resetFileInput,
@@ -1202,6 +1203,12 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
         if (!selection) return false;
 
         if (selection.start !== selection.end) {
+          const removedSqlSnippet = sqlSnippetTokenCodec
+            .getMatches(input)
+            .some((snippet) => snippet.start < selection.end && snippet.end > selection.start);
+          if (removedSqlSnippet) {
+            clearHoveredCodeTokenState();
+          }
           const newText = input.slice(0, selection.start) + input.slice(selection.end);
           setInputAndSelection(newText, selection.start);
           return true;
@@ -1237,6 +1244,7 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
             (key === "Backspace" && snippet.end === selection.start) ||
             (key === "Delete" && snippet.start === selection.start)
           ) {
+            clearHoveredCodeTokenState();
             const newText = sqlSnippetTokenCodec.removeAt(input, snippet.start, snippet.end);
             setInputAndSelection(newText, Math.min(snippet.start, newText.length));
             return true;
@@ -1245,7 +1253,7 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
 
         return false;
       },
-      [input, leadingCommand, selectedCommand, setInputAndSelection]
+      [clearHoveredCodeTokenState, input, leadingCommand, selectedCommand, setInputAndSelection]
     );
 
     const handleKeyDown = React.useCallback(

--- a/src/components/chat/input/command-utils.test.ts
+++ b/src/components/chat/input/command-utils.test.ts
@@ -25,4 +25,10 @@ describe("command-utils", () => {
       "/diagnose-clickhouse-errors error code: 115"
     );
   });
+
+  it("preserves text after the cursor when replacing the leading command", () => {
+    expect(replaceLeadingCommand("/rev keep this suffix", "review", 4)).toBe(
+      "/review keep this suffix"
+    );
+  });
 });

--- a/src/components/chat/input/command-utils.test.ts
+++ b/src/components/chat/input/command-utils.test.ts
@@ -31,4 +31,10 @@ describe("command-utils", () => {
       "/review keep this suffix"
     );
   });
+
+  it("replaces the full partially typed command when the cursor is inside it", () => {
+    expect(replaceLeadingCommand("/revw keep this suffix", "review", 4)).toBe(
+      "/review keep this suffix"
+    );
+  });
 });

--- a/src/components/chat/input/command-utils.ts
+++ b/src/components/chat/input/command-utils.ts
@@ -27,10 +27,10 @@ export function replaceLeadingCommand(
 ): string {
   const safeCursorOffset = Math.max(0, Math.min(cursorOffset, input.length));
   const beforeCursor = input.slice(0, safeCursorOffset);
-  const afterCursor = input.slice(safeCursorOffset);
+  const leadingCommand = getLeadingCommand(input);
   const match = LEADING_COMMAND_PREFIX_RE.exec(beforeCursor);
-  const argsStart = match ? match[0].length : beforeCursor.length;
-  const existingArgs = `${beforeCursor.slice(argsStart)}${afterCursor}`;
+  const commandEnd = leadingCommand?.commandText.length ?? match?.[0].length ?? beforeCursor.length;
+  const existingArgs = input.slice(commandEnd);
   return `/${commandName}${existingArgs || " "}`;
 }
 

--- a/src/components/chat/input/command-utils.ts
+++ b/src/components/chat/input/command-utils.ts
@@ -20,10 +20,17 @@ export function getLeadingCommand(text: string): LeadingCommandMatch | null {
   };
 }
 
-export function replaceLeadingCommand(input: string, commandName: string): string {
-  const match = LEADING_COMMAND_PREFIX_RE.exec(input);
-  const argsStart = match ? match[0].length : input.length;
-  const existingArgs = input.slice(argsStart);
+export function replaceLeadingCommand(
+  input: string,
+  commandName: string,
+  cursorOffset: number = input.length
+): string {
+  const safeCursorOffset = Math.max(0, Math.min(cursorOffset, input.length));
+  const beforeCursor = input.slice(0, safeCursorOffset);
+  const afterCursor = input.slice(safeCursorOffset);
+  const match = LEADING_COMMAND_PREFIX_RE.exec(beforeCursor);
+  const argsStart = match ? match[0].length : beforeCursor.length;
+  const existingArgs = `${beforeCursor.slice(argsStart)}${afterCursor}`;
   return `/${commandName}${existingArgs || " "}`;
 }
 

--- a/src/components/chat/input/inline-token.test.ts
+++ b/src/components/chat/input/inline-token.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { InlineToken, type InlineTokenMatch } from "./inline-token";
+
+interface TestTokenMatch extends InlineTokenMatch {
+  value: string;
+}
+
+class TestToken extends InlineToken<string, TestTokenMatch> {
+  constructor() {
+    super("<<test:", ">>", /<<test:([^>]+)>>/g);
+  }
+
+  protected decode(encodedPayload: string): string {
+    return decodeURIComponent(encodedPayload);
+  }
+
+  protected createMatch(text: string, start: number, end: number, payload: string): TestTokenMatch {
+    return {
+      text,
+      start,
+      end,
+      value: payload,
+    };
+  }
+}
+
+const testToken = new TestToken();
+
+describe("token utils", () => {
+  it("creates and parses encoded inline tokens through a shared codec", () => {
+    const token = testToken.createToken("hello world");
+
+    expect(testToken.getMatches(`Use ${token} now`)).toEqual([
+      {
+        text: token,
+        start: 4,
+        end: 4 + token.length,
+        value: "hello world",
+      },
+    ]);
+  });
+
+  it("replaces encoded inline tokens with a codec-specific renderer", () => {
+    const token = testToken.createToken("hello world");
+
+    expect(testToken.replace(token, (value) => `[${value}]`)).toBe("[hello world]");
+  });
+
+  it("removes inline tokens without leaving double spaces behind", () => {
+    const token = testToken.createToken("hello world");
+
+    expect(testToken.removeAt(`Use ${token} now`, 4, 4 + token.length)).toBe("Use now");
+  });
+});

--- a/src/components/chat/input/inline-token.test.ts
+++ b/src/components/chat/input/inline-token.test.ts
@@ -51,4 +51,10 @@ describe("token utils", () => {
 
     expect(testToken.removeAt(`Use ${token} now`, 4, 4 + token.length)).toBe("Use now");
   });
+
+  it("removes inline tokens without inserting stray spaces between lines", () => {
+    const token = testToken.createToken("hello world");
+
+    expect(testToken.removeAt(`Use\n${token}\nnow`, 4, 4 + token.length)).toBe("Use\nnow");
+  });
 });

--- a/src/components/chat/input/inline-token.ts
+++ b/src/components/chat/input/inline-token.ts
@@ -52,6 +52,14 @@ export abstract class InlineToken<TPayload, TMatch extends InlineTokenMatch = In
       return before;
     }
 
+    if (before.endsWith("\n") && after.startsWith("\n")) {
+      return `${before}${after.slice(1)}`;
+    }
+
+    if (before.endsWith("\n") || after.startsWith("\n")) {
+      return `${before}${after}`;
+    }
+
     return `${before} ${after}`;
   }
 

--- a/src/components/chat/input/inline-token.ts
+++ b/src/components/chat/input/inline-token.ts
@@ -1,0 +1,65 @@
+export interface InlineTokenMatch {
+  text: string;
+  start: number;
+  end: number;
+}
+
+export abstract class InlineToken<TPayload, TMatch extends InlineTokenMatch = InlineTokenMatch> {
+  protected constructor(
+    readonly prefix: string,
+    readonly suffix: string,
+    readonly pattern: RegExp
+  ) {}
+
+  createToken(payload: string): string {
+    return `${this.prefix}${encodeURIComponent(payload)}${this.suffix}`;
+  }
+
+  getMatches(input: string): TMatch[] {
+    const matches: TMatch[] = [];
+
+    for (const match of input.matchAll(this.pattern)) {
+      const tokenText = match[0];
+      const encodedPayload = match[1];
+      const start = match.index ?? -1;
+      if (start < 0 || encodedPayload === undefined) {
+        continue;
+      }
+
+      const payload = this.decode(encodedPayload);
+      matches.push(this.createMatch(tokenText, start, start + tokenText.length, payload));
+    }
+
+    return matches;
+  }
+
+  replace(input: string, render: (payload: TPayload, match: TMatch) => string): string {
+    return input.replaceAll(this.pattern, (tokenText: string, encodedPayload: string) => {
+      const payload = this.decode(encodedPayload);
+      return render(payload, this.createMatch(tokenText, -1, -1, payload));
+    });
+  }
+
+  removeAt(input: string, start: number, end: number): string {
+    const before = input.slice(0, start).replace(/[ \t]+$/, "");
+    const after = input.slice(end).replace(/^[ \t]+/, "");
+
+    if (!before.length) {
+      return after;
+    }
+
+    if (!after.length) {
+      return before;
+    }
+
+    return `${before} ${after}`;
+  }
+
+  protected abstract decode(encodedPayload: string): TPayload;
+  protected abstract createMatch(
+    text: string,
+    start: number,
+    end: number,
+    payload: TPayload
+  ): TMatch;
+}

--- a/src/components/chat/input/sql-snippet-token.test.ts
+++ b/src/components/chat/input/sql-snippet-token.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { sqlSnippetTokenCodec } from "./sql-snippet-token";
+
+describe("sql snippet token helpers", () => {
+  it("creates parseable snippet tokens and expands them to fenced sql", () => {
+    const token = sqlSnippetTokenCodec.createToken("SELECT *\nFROM system.query_log");
+
+    expect(sqlSnippetTokenCodec.getMatches(`Explain ${token}`)).toEqual([
+      expect.objectContaining({
+        text: token,
+        sql: "SELECT *\nFROM system.query_log",
+        start: 8,
+        end: 8 + token.length,
+      }),
+    ]);
+    expect(sqlSnippetTokenCodec.expand(token)).toBe("```sql\nSELECT *\nFROM system.query_log\n```");
+  });
+
+  it("expands snippet tokens into fenced sql blocks separated from surrounding prose", () => {
+    const token = sqlSnippetTokenCodec.createToken(
+      "admin_de_presto_prod_.presto_alb_jdbc_access_log_view.big_data_account"
+    );
+
+    expect(sqlSnippetTokenCodec.expand(`what's the type of this column ${token}`)).toBe(
+      "what's the type of this column\n\n```sql\nadmin_de_presto_prod_.presto_alb_jdbc_access_log_view.big_data_account\n```"
+    );
+  });
+
+  it("removes snippet tokens without leaving double spaces behind", () => {
+    const token = sqlSnippetTokenCodec.createToken("SELECT 1");
+    expect(sqlSnippetTokenCodec.removeAt(`Explain ${token} now`, 8, 8 + token.length)).toBe(
+      "Explain now"
+    );
+  });
+});

--- a/src/components/chat/input/sql-snippet-token.ts
+++ b/src/components/chat/input/sql-snippet-token.ts
@@ -1,0 +1,83 @@
+import { InlineToken, type InlineTokenMatch } from "./inline-token";
+
+const SQL_SNIPPET_TOKEN_PREFIX = "<<sql:";
+const SQL_SNIPPET_TOKEN_SUFFIX = ">>";
+const SQL_SNIPPET_TOKEN_REGEX = /<<sql:([^>]+)>>/g;
+
+export interface SqlSnippetMatch extends InlineTokenMatch {
+  sql: string;
+  label: string;
+}
+
+export class SqlSnippetToken extends InlineToken<string, SqlSnippetMatch> {
+  constructor() {
+    super(SQL_SNIPPET_TOKEN_PREFIX, SQL_SNIPPET_TOKEN_SUFFIX, SQL_SNIPPET_TOKEN_REGEX);
+  }
+
+  expand(input: string): string {
+    let cursor = 0;
+    let output = "";
+
+    for (const match of this.getMatches(input)) {
+      const before = input.slice(cursor, match.start);
+      const after = input.slice(match.end);
+      const needsLeadingBlankLine = before.length > 0 && !before.endsWith("\n\n");
+      const needsTrailingBlankLine = after.length > 0 && !after.startsWith("\n");
+
+      output += needsLeadingBlankLine ? before.replace(/[ \t]+$/, "") : before;
+      if (needsLeadingBlankLine) {
+        output += before.endsWith("\n") ? "\n" : "\n\n";
+      }
+      output += `\`\`\`sql\n${match.sql}\n\`\`\``;
+      if (needsTrailingBlankLine) {
+        output += "\n";
+      }
+      cursor = match.end;
+    }
+
+    output += input.slice(cursor);
+    return output;
+  }
+
+  protected decode(encodedPayload: string): string {
+    try {
+      return decodeURIComponent(encodedPayload);
+    } catch {
+      return encodedPayload;
+    }
+  }
+
+  protected createMatch(
+    text: string,
+    start: number,
+    end: number,
+    payload: string
+  ): SqlSnippetMatch {
+    return {
+      text,
+      start,
+      end,
+      sql: payload,
+      label: this.normalizeLabel(payload),
+    };
+  }
+
+  private normalizeLabel(sql: string): string {
+    const lines = sql
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    const firstLine = (lines[0] ?? "SQL selection").replace(/\s+/g, " ");
+    const truncated = firstLine.length > 36 ? `${firstLine.slice(0, 33)}...` : firstLine;
+    const extraLineCount = Math.max(lines.length - 1, 0);
+
+    if (extraLineCount === 0) {
+      return truncated;
+    }
+
+    return `${truncated} (+${extraLineCount} line${extraLineCount === 1 ? "" : "s"})`;
+  }
+}
+
+export const sqlSnippetTokenCodec = new SqlSnippetToken();

--- a/src/components/chat/message/message-user.test.tsx
+++ b/src/components/chat/message/message-user.test.tsx
@@ -75,4 +75,18 @@ describe("MessageUser", () => {
 
     expect(props.text).toBe("/unknown check this query");
   });
+
+  it("keeps fenced sql blocks separated from leading prose", () => {
+    act(() => {
+      root.render(
+        <MessageUser text={"what's the type of this column\n```sql\nselect version()\n```"} />
+      );
+    });
+
+    const props = messageMarkdownSpy.mock.calls[0]?.[0] as {
+      text: string;
+    };
+
+    expect(props.text).toBe("what's the type of this column\n\n```sql\nselect version()\n\n```");
+  });
 });

--- a/src/components/chat/message/message-user.test.tsx
+++ b/src/components/chat/message/message-user.test.tsx
@@ -87,6 +87,18 @@ describe("MessageUser", () => {
       text: string;
     };
 
-    expect(props.text).toBe("what's the type of this column\n\n```sql\nselect version()\n\n```");
+    expect(props.text).toBe("what's the type of this column\n\n```sql\nselect version()\n```");
+  });
+
+  it("does not rewrite content inside fenced code blocks", () => {
+    act(() => {
+      root.render(<MessageUser text={"```sql\nselect\nfrom system.query_log\n```"} />);
+    });
+
+    const props = messageMarkdownSpy.mock.calls[0]?.[0] as {
+      text: string;
+    };
+
+    expect(props.text).toBe("```sql\nselect\nfrom system.query_log\n```");
   });
 });

--- a/src/components/chat/message/message-user.tsx
+++ b/src/components/chat/message/message-user.tsx
@@ -5,6 +5,16 @@ import { TABLE_MENTION_REGEX } from "../input/mention-utils";
 import { MessageMarkdown } from "./message-markdown";
 import { SkillLink } from "./skill-link";
 
+const FENCED_CODE_BLOCK_RE = /(```[\s\S]*?```)/g;
+
+function processUserMessageProse(text: string) {
+  return text
+    .replace(TABLE_MENTION_REGEX, (match) => {
+      return `@\`${match.substring(1)}\``;
+    })
+    .replace(/\n/g, "\n\n");
+}
+
 /**
  * Component to render user message with table mention support
  * We use markdown component to render the user message.
@@ -21,25 +31,9 @@ export const MessageUser = memo(function MessageUser({ text }: { text: string })
 
     const baseText = command && matchedCommand ? matchedCommand.remainder.replace(/^ /, "") : text;
     const processedBaseText = baseText
-      // Replace @xxx.yyy with @`xxx.yyy` so markdown treats it as inline code
-      // This allows MessageMarkdown to detect and render it as a table button
-      // Uses the shared TABLE_MENTION_REGEX to match table mentions including
-      // those followed by punctuation (e.g., @system.query_log?)
-      .replace(TABLE_MENTION_REGEX, (match) => {
-        // Keep the @ symbol and wrap the rest in backticks
-        return `@\`${match.substring(1)}\``;
-      })
-      // Replace newlines with double newlines for proper paragraph breaks,
-      // but skip content inside fenced code blocks (```...```)
-      .replace(/(```[\s\S]*?```)|(\n)/g, (_match, codeBlock, _newline) => {
-        // If it's a code block, return it unchanged
-        if (codeBlock) return codeBlock;
-        // If it's a newline outside code block, double it
-        return "\n\n";
-      })
-      // Fenced code blocks must start after a blank line, otherwise markdown may render
-      // the opening backticks inline when prose appears immediately before the fence.
-      .replace(/([^\n])\n(```)/g, "$1\n\n$2");
+      .split(FENCED_CODE_BLOCK_RE)
+      .map((segment) => (segment.startsWith("```") ? segment : processUserMessageProse(segment)))
+      .join("");
 
     if (!command || !matchedCommand) {
       return processedBaseText;

--- a/src/components/chat/message/message-user.tsx
+++ b/src/components/chat/message/message-user.tsx
@@ -36,7 +36,10 @@ export const MessageUser = memo(function MessageUser({ text }: { text: string })
         if (codeBlock) return codeBlock;
         // If it's a newline outside code block, double it
         return "\n\n";
-      });
+      })
+      // Fenced code blocks must start after a blank line, otherwise markdown may render
+      // the opening backticks inline when prose appears immediately before the fence.
+      .replace(/([^\n])\n(```)/g, "$1\n\n$2");
 
     if (!command || !matchedCommand) {
       return processedBaseText;
@@ -50,7 +53,13 @@ export const MessageUser = memo(function MessageUser({ text }: { text: string })
       })
     );
 
-    return processedBaseText ? `${commandLink} ${processedBaseText}` : commandLink;
+    if (!processedBaseText) {
+      return commandLink;
+    }
+
+    // Fenced blocks must start on their own line or markdown will render the backticks inline.
+    const separator = processedBaseText.startsWith("```") ? "\n\n" : " ";
+    return `${commandLink}${separator}${processedBaseText}`;
   }, [command, matchedCommand, text]);
 
   return (

--- a/src/components/chat/view/chat-panel.tsx
+++ b/src/components/chat/view/chat-panel.tsx
@@ -592,7 +592,7 @@ export function ChatPanel({ currentDatabase, availableTables, onClose }: ChatPan
           availableTables={availableTables}
           externalInput={
             initialInput && (!initialInput.chatId || initialInput.chatId === chat.id)
-              ? initialInput.text
+              ? initialInput
               : undefined
           }
           onStreamingChange={setIsRunning}

--- a/src/components/chat/view/chat-view.tsx
+++ b/src/components/chat/view/chat-view.tsx
@@ -47,6 +47,7 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
   const { connection } = useConnection();
   const chatInputRef = useRef<ChatInputHandle | null>(null);
   const [promptInput, setPromptInput] = useState<ChatComposerInput | undefined>(externalInput);
+  const promptInputNonceRef = useRef(0);
 
   // Update promptInput when externalInput changes
   useEffect(() => {
@@ -131,6 +132,10 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
 
   const isEmpty = !messages || messages.length === 0;
 
+  const createPromptInput = useCallback((text: string): ChatComposerInput => {
+    return { text, mode: "replace", nonce: ++promptInputNonceRef.current };
+  }, []);
+
   const handleQuestionClick = useCallback(
     (question: { text: string; autoRun?: boolean }) => {
       if (question.autoRun) {
@@ -138,10 +143,10 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
         handleSubmit({ text: question.text });
       } else {
         // Default: set the input for user to review/edit
-        setPromptInput({ text: question.text, mode: "replace", nonce: Date.now() });
+        setPromptInput(createPromptInput(question.text));
       }
     },
-    [handleSubmit]
+    [createPromptInput, handleSubmit]
   );
 
   const handleUserAction = useCallback(
@@ -150,9 +155,9 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
         handleSubmit({ text: input.text });
         return;
       }
-      setPromptInput({ text: input.text, mode: "replace", nonce: Date.now() });
+      setPromptInput(createPromptInput(input.text));
     },
-    [handleSubmit]
+    [createPromptInput, handleSubmit]
   );
 
   const handleStop = useCallback(() => {

--- a/src/components/chat/view/chat-view.tsx
+++ b/src/components/chat/view/chat-view.tsx
@@ -18,6 +18,7 @@ import {
 import { getTableContextByMentions } from "../input/mention-utils";
 import { ChatMessageList } from "../message/chat-message-list";
 import { SampleQuestions } from "./sample-questions";
+import { type ChatComposerInput } from "./use-chat-panel";
 import { useTokenUsage } from "./use-token-usage";
 
 interface ChatViewProps {
@@ -29,7 +30,7 @@ interface ChatViewProps {
     name: string;
     columns: Array<{ name: string; type: string }> | string[];
   }>;
-  externalInput?: string;
+  externalInput?: ChatComposerInput;
   onStreamingChange?: (isRunning: boolean) => void;
 }
 
@@ -45,7 +46,7 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
 ) {
   const { connection } = useConnection();
   const chatInputRef = useRef<ChatInputHandle | null>(null);
-  const [promptInput, setPromptInput] = useState<string | undefined>(externalInput);
+  const [promptInput, setPromptInput] = useState<ChatComposerInput | undefined>(externalInput);
 
   // Update promptInput when externalInput changes
   useEffect(() => {
@@ -54,7 +55,7 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
       return;
     }
     setPromptInput(undefined);
-  }, [externalInput, chat.id]);
+  }, [chat.id, externalInput]);
   const { messages, error, sendMessage, status, stop } = useChat({ chat });
 
   // Focus input when ChatView is mounted
@@ -137,7 +138,7 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
         handleSubmit({ text: question.text });
       } else {
         // Default: set the input for user to review/edit
-        setPromptInput(question.text);
+        setPromptInput({ text: question.text, mode: "replace", nonce: Date.now() });
       }
     },
     [handleSubmit]
@@ -149,7 +150,7 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
         handleSubmit({ text: input.text });
         return;
       }
-      setPromptInput(input.text);
+      setPromptInput({ text: input.text, mode: "replace", nonce: Date.now() });
     },
     [handleSubmit]
   );

--- a/src/components/chat/view/use-chat-panel.test.tsx
+++ b/src/components/chat/view/use-chat-panel.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatPanelProvider, useChatPanel } from "./use-chat-panel";
+
+describe("ChatPanelProvider", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latestPanel: ReturnType<typeof useChatPanel> | null = null;
+
+  function Probe() {
+    latestPanel = useChatPanel();
+    return null;
+  }
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    latestPanel = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("generates unique composer nonces even when Date.now() is constant", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1234567890);
+
+    act(() => {
+      root.render(
+        <ChatPanelProvider>
+          <Probe />
+        </ChatPanelProvider>
+      );
+    });
+
+    act(() => {
+      latestPanel?.setInitialInput("first");
+    });
+    const firstNonce = latestPanel?.initialInput?.nonce;
+
+    act(() => {
+      latestPanel?.setInitialInput("second");
+    });
+    const secondNonce = latestPanel?.initialInput?.nonce;
+
+    expect(firstNonce).toBe(1);
+    expect(secondNonce).toBe(2);
+  });
+});

--- a/src/components/chat/view/use-chat-panel.tsx
+++ b/src/components/chat/view/use-chat-panel.tsx
@@ -10,6 +10,14 @@ export type SelectedChatTarget = {
   connectionId?: string;
 };
 
+export type ChatComposerInputMode = "replace" | "append";
+export type ChatComposerInput = {
+  text: string;
+  chatId?: string;
+  mode: ChatComposerInputMode;
+  nonce: number;
+};
+
 interface ChatPanelContextType {
   displayMode: ChatPanelDisplayMode;
   setDisplayMode: (mode: ChatPanelDisplayMode) => void;
@@ -36,8 +44,8 @@ interface ChatPanelContextType {
     agentContext?: Partial<AgentContext>;
   } | null;
   consumeCommand: () => void;
-  setInitialInput: (text: string, chatId?: string) => void;
-  initialInput: { text: string; chatId?: string } | null;
+  setInitialInput: (text: string, chatId?: string, mode?: ChatComposerInputMode) => void;
+  initialInput: ChatComposerInput | null;
   clearInitialInput: () => void;
 }
 
@@ -103,9 +111,7 @@ export function ChatPanelProvider({ children }: { children: React.ReactNode }) {
     forceNewChat?: boolean;
     agentContext?: Partial<AgentContext>;
   } | null>(null);
-  const [initialInput, setInitialInputState] = useState<{ text: string; chatId?: string } | null>(
-    null
-  );
+  const [initialInput, setInitialInputState] = useState<ChatComposerInput | null>(null);
 
   const toggleDisplayMode = () => {
     setDisplayMode((prev) => {
@@ -164,8 +170,12 @@ export function ChatPanelProvider({ children }: { children: React.ReactNode }) {
     setPendingCommand(null);
   };
 
-  const setInitialInput = (text: string, chatId?: string) => {
-    setInitialInputState({ text, chatId });
+  const setInitialInput = (
+    text: string,
+    chatId?: string,
+    mode: ChatComposerInputMode = "replace"
+  ) => {
+    setInitialInputState({ text, chatId, mode, nonce: Date.now() });
     setDisplayMode((prev) => (prev === "hidden" ? "panel" : prev));
   };
 

--- a/src/components/chat/view/use-chat-panel.tsx
+++ b/src/components/chat/view/use-chat-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { AgentContext } from "@/lib/ai/chat-types";
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useRef, useState } from "react";
 
 export type ChatPanelDisplayMode = "hidden" | "panel" | "tabWidth" | "fullscreen";
 export type SidebarTab = "database" | "snippets" | "history";
@@ -112,6 +112,7 @@ export function ChatPanelProvider({ children }: { children: React.ReactNode }) {
     agentContext?: Partial<AgentContext>;
   } | null>(null);
   const [initialInput, setInitialInputState] = useState<ChatComposerInput | null>(null);
+  const initialInputNonceRef = useRef(0);
 
   const toggleDisplayMode = () => {
     setDisplayMode((prev) => {
@@ -175,7 +176,7 @@ export function ChatPanelProvider({ children }: { children: React.ReactNode }) {
     chatId?: string,
     mode: ChatComposerInputMode = "replace"
   ) => {
-    setInitialInputState({ text, chatId, mode, nonce: Date.now() });
+    setInitialInputState({ text, chatId, mode, nonce: ++initialInputNonceRef.current });
     setDisplayMode((prev) => (prev === "hidden" ? "panel" : prev));
   };
 

--- a/src/components/query-tab/query-control/query-control.test.tsx
+++ b/src/components/query-tab/query-control/query-control.test.tsx
@@ -8,38 +8,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryControl } from "./query-control";
 
 const {
-  postMessageMock,
   setDisplayModeMock,
+  mockChatPanelState,
   executeQueryMock,
   executeBatchMock,
-  alertDialogMock,
-  mockCommands,
   mockQueryInput,
-  mockAgentSettings,
   mockConnection,
 } = vi.hoisted(() => ({
-  postMessageMock: vi.fn(),
   setDisplayModeMock: vi.fn(),
+  mockChatPanelState: {
+    displayMode: "hidden" as "hidden" | "panel" | "tabWidth" | "fullscreen",
+  },
   executeQueryMock: vi.fn(),
   executeBatchMock: vi.fn(),
-  alertDialogMock: vi.fn(),
-  mockCommands: [
-    {
-      name: "review-sql",
-      description: "Review SQL.",
-      skillId: "review-sql",
-      template: "Use review-sql: $ARGUMENTS",
-      showInSqlEditorQuickAction: true,
-    },
-  ],
   mockQueryInput: {
     selectedText: "",
     text: "SELECT 1",
     cursorRow: 0,
     cursorColumn: 0,
-  },
-  mockAgentSettings: {
-    aiResponseLanguage: "en",
   },
   mockConnection: {
     connectionId: "connection-1",
@@ -63,69 +49,8 @@ if (!HTMLElement.prototype.scrollIntoView) {
 
 vi.mock("@/components/chat/view/use-chat-panel", () => ({
   useChatPanel: () => ({
-    postMessage: postMessageMock,
+    displayMode: mockChatPanelState.displayMode,
     setDisplayMode: setDisplayModeMock,
-  }),
-}));
-
-vi.mock("@/components/chat/agent-command-browser-panel", async () => {
-  const React = await vi.importActual<typeof import("react")>("react");
-
-  return {
-    AgentCommandBrowserPanel: ({
-      items,
-      onSelectItem,
-    }: {
-      items: Array<{
-        key: string;
-        label: React.ReactNode;
-        description?: string;
-        separatorBefore?: boolean;
-      }>;
-      onSelectItem: (item: {
-        key: string;
-        label: React.ReactNode;
-        description?: string;
-        separatorBefore?: boolean;
-      }) => void;
-    }) => {
-      const [activeIndex, setActiveIndex] = React.useState(0);
-      const activeItem = items[activeIndex];
-
-      return (
-        <div>
-          <div>
-            {items.map((item, index) => (
-              <React.Fragment key={item.key}>
-                {item.separatorBefore ? <div cmdk-separator="" /> : null}
-                <button
-                  type="button"
-                  cmdk-item=""
-                  onMouseEnter={() => setActiveIndex(index)}
-                  onClick={() => onSelectItem(item)}
-                >
-                  {item.label}
-                </button>
-              </React.Fragment>
-            ))}
-          </div>
-          {activeItem?.description ? <div>{activeItem.description}</div> : null}
-        </div>
-      );
-    },
-  };
-});
-
-vi.mock("@/components/shared/use-dialog", () => ({
-  Dialog: {
-    alert: alertDialogMock,
-  },
-}));
-
-vi.mock("@/components/chat/agent-command-context", () => ({
-  useAgentCommands: () => ({
-    commands: mockCommands,
-    loading: false,
   }),
 }));
 
@@ -134,16 +59,6 @@ vi.mock("@/components/connection/connection-context", () => ({
     connection: mockConnection,
   }),
 }));
-
-vi.mock("@/components/settings/agent/agent-manager", async () => {
-  const actual = await vi.importActual("@/components/settings/agent/agent-manager");
-  return {
-    ...actual,
-    AgentConfigurationManager: {
-      getConfiguration: () => mockAgentSettings,
-    },
-  };
-});
 
 vi.mock("../query-execution/query-executor", () => ({
   useQueryExecutor: () => ({
@@ -164,23 +79,14 @@ describe("QueryControl", () => {
   beforeEach(() => {
     testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
     testGlobal.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
-    postMessageMock.mockReset();
     setDisplayModeMock.mockReset();
+    mockChatPanelState.displayMode = "hidden";
     executeQueryMock.mockReset();
     executeBatchMock.mockReset();
-    alertDialogMock.mockReset();
-    mockCommands.splice(0, mockCommands.length, {
-      name: "review-sql",
-      description: "Review SQL.",
-      skillId: "review-sql",
-      template: "Use review-sql: $ARGUMENTS",
-      showInSqlEditorQuickAction: true,
-    });
     mockQueryInput.selectedText = "";
     mockQueryInput.text = "SELECT 1";
     mockQueryInput.cursorRow = 0;
     mockQueryInput.cursorColumn = 0;
-    mockAgentSettings.aiResponseLanguage = "en";
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -193,254 +99,70 @@ describe("QueryControl", () => {
     container.remove();
   });
 
-  it("renders a single popover trigger when exactly one sql editor command is available", async () => {
+  it("renders Toggle Agent and omits AI Actions", async () => {
     await act(async () => {
       root.render(<QueryControl onOpenHistory={vi.fn()} />);
     });
 
-    const trigger = Array.from(container.querySelectorAll("button")).find((candidate) =>
-      candidate.textContent?.includes("AI Actions")
-    );
-
-    expect(trigger).toBeTruthy();
-
-    await act(async () => {
-      trigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
-      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    const reviewItem = Array.from(document.querySelectorAll("[cmdk-item]")).find((candidate) =>
-      candidate.textContent?.includes("/review-sql")
-    );
-    expect(reviewItem).toBeTruthy();
-    const items = Array.from(document.querySelectorAll("[cmdk-item]"));
-    expect(items.at(-1)?.textContent ?? "").toContain("Toggle Agent");
-
-    await act(async () => {
-      reviewItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    expect(postMessageMock).toHaveBeenCalledWith(
-      expect.stringContaining("/review-sql"),
-      expect.objectContaining({
-        forceNewChat: true,
-        agentContext: expect.objectContaining({
-          responseLanguage: "en",
-        }),
-      })
-    );
-    expect(postMessageMock).toHaveBeenCalledWith(
-      expect.stringContaining("```sql\nSELECT 1\n```"),
-      expect.any(Object)
-    );
+    expect(container.textContent).toContain("Toggle Agent");
+    expect(container.textContent).not.toContain("AI Actions");
   });
 
-  it("renders a dropdown when multiple sql editor commands are available", async () => {
-    mockCommands.push({
-      name: "diagnose-sql",
-      description: "Diagnose SQL.",
-      skillId: "diagnose-sql",
-      template: "Use diagnose-sql: $ARGUMENTS",
-      showInSqlEditorQuickAction: true,
-    });
-
+  it("opens the chat panel in panel mode when it is hidden", async () => {
     await act(async () => {
       root.render(<QueryControl onOpenHistory={vi.fn()} />);
     });
 
-    const trigger = Array.from(container.querySelectorAll("button")).find((candidate) =>
-      candidate.textContent?.includes("AI Actions")
+    const toggleButton = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("Toggle Agent")
     );
 
-    expect(trigger).toBeTruthy();
+    expect(toggleButton).toBeTruthy();
 
     await act(async () => {
-      trigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
-      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    const reviewItem = Array.from(document.querySelectorAll("[cmdk-item]")).find((candidate) =>
-      candidate.textContent?.includes("/review-sql")
-    );
-
-    expect(reviewItem).toBeTruthy();
-    expect(document.body.textContent).toContain("Review SQL.");
-
-    await act(async () => {
-      reviewItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    expect(postMessageMock).toHaveBeenCalledWith(
-      expect.stringContaining("/review-sql"),
-      expect.any(Object)
-    );
-  });
-
-  it("adds a Toggle Agent item as the last dropdown action", async () => {
-    mockCommands.push({
-      name: "diagnose-sql",
-      description: "Diagnose SQL.",
-      skillId: "diagnose-sql",
-      template: "Use diagnose-sql: $ARGUMENTS",
-      showInSqlEditorQuickAction: true,
-    });
-
-    await act(async () => {
-      root.render(<QueryControl onOpenHistory={vi.fn()} />);
-    });
-
-    const trigger = Array.from(container.querySelectorAll("button")).find((candidate) =>
-      candidate.textContent?.includes("AI Actions")
-    );
-
-    await act(async () => {
-      trigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
-      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    const items = Array.from(document.querySelectorAll("[cmdk-item]"));
-    expect(items.at(-1)?.textContent).toContain("Toggle Agent");
-    const separators = Array.from(document.querySelectorAll("[cmdk-separator]"));
-    expect(separators.length).toBeGreaterThan(0);
-
-    await act(async () => {
-      items.at(-1)?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      toggleButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
     expect(setDisplayModeMock).toHaveBeenCalledWith("panel");
-    expect(postMessageMock).not.toHaveBeenCalled();
   });
 
-  it("does not launch sql editor commands for obvious multi-statement input", async () => {
-    mockQueryInput.text = "SELECT 1; SELECT 2";
+  it("closes the chat panel when it is already visible", async () => {
+    mockChatPanelState.displayMode = "tabWidth";
 
     await act(async () => {
       root.render(<QueryControl onOpenHistory={vi.fn()} />);
     });
 
-    const trigger = Array.from(container.querySelectorAll("button")).find((candidate) =>
-      candidate.textContent?.includes("AI Actions")
+    const toggleButton = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("Toggle Agent")
     );
+
+    expect(toggleButton).toBeTruthy();
 
     await act(async () => {
-      trigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
-      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      toggleButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    const reviewItem = Array.from(document.querySelectorAll("[cmdk-item]")).find((candidate) =>
-      candidate.textContent?.includes("/review-sql")
-    );
-
-    await act(async () => {
-      reviewItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    expect(postMessageMock).not.toHaveBeenCalled();
-    expect(alertDialogMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        title: "Single Statement Required",
-      })
-    );
+    expect(setDisplayModeMock).toHaveBeenCalledWith("hidden");
   });
 
-  it("shows an information dialog when no runnable sql is available", async () => {
-    mockQueryInput.text = "-- only comments";
+  it("runs the selected text when selection exists", async () => {
+    mockQueryInput.selectedText = "SELECT version()";
 
     await act(async () => {
       root.render(<QueryControl onOpenHistory={vi.fn()} />);
     });
 
-    const trigger = Array.from(container.querySelectorAll("button")).find((candidate) =>
-      candidate.textContent?.includes("AI Actions")
+    const runButton = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes("Run Selected Text")
     );
 
-    await act(async () => {
-      trigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
-      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    const reviewItem = Array.from(document.querySelectorAll("[cmdk-item]")).find((candidate) =>
-      candidate.textContent?.includes("/review-sql")
-    );
+    expect(runButton).toBeTruthy();
 
     await act(async () => {
-      reviewItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      runButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    expect(postMessageMock).not.toHaveBeenCalled();
-    expect(alertDialogMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        title: "No SQL To Send",
-      })
-    );
-  });
-
-  it("uses the dedicated sql review language setting for sql editor commands", async () => {
-    mockAgentSettings.aiResponseLanguage = "ja";
-
-    await act(async () => {
-      root.render(<QueryControl onOpenHistory={vi.fn()} />);
-    });
-
-    const trigger = Array.from(container.querySelectorAll("button")).find((candidate) =>
-      candidate.textContent?.includes("AI Actions")
-    );
-
-    await act(async () => {
-      trigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
-      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    const reviewItem = Array.from(document.querySelectorAll("[cmdk-item]")).find((candidate) =>
-      candidate.textContent?.includes("/review-sql")
-    );
-
-    await act(async () => {
-      reviewItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    expect(postMessageMock).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        agentContext: expect.objectContaining({
-          responseLanguage: "ja",
-        }),
-      })
-    );
-  });
-
-  it("shows Toggle Agent even when no sql editor quick action commands are available", async () => {
-    mockCommands.splice(0, mockCommands.length, {
-      name: "review-sql",
-      description: "Review SQL.",
-      skillId: "review-sql",
-      template: "Use review-sql: $ARGUMENTS",
-      showInSqlEditorQuickAction: false,
-    });
-
-    await act(async () => {
-      root.render(<QueryControl onOpenHistory={vi.fn()} />);
-    });
-
-    const trigger = Array.from(container.querySelectorAll("button")).find((candidate) =>
-      candidate.textContent?.includes("AI Actions")
-    );
-    expect(trigger).toBeTruthy();
-
-    await act(async () => {
-      trigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
-      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    const items = Array.from(document.querySelectorAll("[cmdk-item]"));
-    expect(items).toHaveLength(1);
-    expect(items[0]?.textContent ?? "").toContain("Toggle Agent");
-
-    await act(async () => {
-      items[0]?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    expect(setDisplayModeMock).toHaveBeenCalledWith("panel");
-    expect(postMessageMock).not.toHaveBeenCalled();
+    expect(executeQueryMock).toHaveBeenCalledWith("SELECT version()");
   });
 });

--- a/src/components/query-tab/query-control/query-control.tsx
+++ b/src/components/query-tab/query-control/query-control.tsx
@@ -1,15 +1,5 @@
-import {
-  AgentCommandBrowserPanel,
-  type AgentCommandBrowserItem,
-} from "@/components/chat/agent-command-browser-panel";
-import { useAgentCommands } from "@/components/chat/agent-command-context";
 import { useChatPanel } from "@/components/chat/view/use-chat-panel";
 import { useConnection } from "@/components/connection/connection-context";
-import {
-  AgentConfigurationManager,
-  normalizeAIResponseLanguage,
-} from "@/components/settings/agent/agent-manager";
-import { Dialog } from "@/components/shared/use-dialog";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -17,13 +7,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import type { CommandDetail } from "@/lib/ai/commands/command-manager";
 import { SqlUtils } from "@/lib/sql-utils";
-import { Bookmark, ChevronDown, History, MessageSquare, Play, Sparkles } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { Bookmark, ChevronDown, History, MessageSquare, Play } from "lucide-react";
+import { useCallback } from "react";
 import { useQueryExecutor } from "../query-execution/query-executor";
 import { useQueryInput } from "../query-input/use-query-input";
 import { openSaveSnippetDialog } from "../snippet/save-snippet-dialog";
@@ -32,11 +20,8 @@ import { showMultipleStatementsConfirmDialog } from "./multiple-statements-confi
 export function QueryControl({ onOpenHistory }: { onOpenHistory: () => void }) {
   const { isSqlExecuting, executeQuery, executeBatch } = useQueryExecutor();
   const { connection } = useConnection();
-  const { postMessage, setDisplayMode } = useChatPanel();
-  const { commands } = useAgentCommands();
+  const { displayMode, setDisplayMode } = useChatPanel();
   const { selectedText, text, cursorRow, cursorColumn } = useQueryInput();
-  const sqlEditorCommands = commands.filter((command) => command.showInSqlEditorQuickAction);
-  const [isAgentActionsOpen, setIsAgentActionsOpen] = useState(false);
 
   const handleRunCurrentLine = useCallback(() => {
     const sql = SqlUtils.resolveExecutionSql({
@@ -99,72 +84,11 @@ export function QueryControl({ onOpenHistory }: { onOpenHistory: () => void }) {
     });
   }, [selectedText, text, executeBatch]);
 
-  const handleSqlEditorCommand = useCallback(
-    (command: CommandDetail) => {
-      const sql = SqlUtils.resolveExecutionSql({
-        selectedText,
-        text,
-        cursorRow,
-        cursorColumn,
-      });
-      const normalizedSql = SqlUtils.removeComments(sql);
-      if (normalizedSql.length === 0) {
-        Dialog.alert({
-          title: "No SQL To Send",
-          description: "Select a SQL statement or place the cursor on a runnable SQL line first.",
-        });
-        return;
-      }
-
-      const statements = SqlUtils.splitSqlStatements(normalizedSql);
-      if (statements.length !== 1) {
-        Dialog.alert({
-          title: "Single Statement Required",
-          description:
-            "AI actions from the SQL editor currently support exactly one SQL statement at a time.",
-        });
-        return;
-      }
-
-      const reviewLanguage = normalizeAIResponseLanguage(
-        AgentConfigurationManager.getConfiguration().aiResponseLanguage
-      );
-
-      postMessage(`/${command.name}\n\n\`\`\`sql\n${statements[0]}\n\`\`\``, {
-        forceNewChat: true,
-        agentContext: { responseLanguage: reviewLanguage },
-      });
-    },
-    [cursorColumn, cursorRow, postMessage, selectedText, text]
-  );
-
-  const handleOpenAgent = useCallback(() => {
-    setDisplayMode("panel");
-  }, [setDisplayMode]);
-
-  const sqlEditorActionItems = useMemo<AgentCommandBrowserItem[]>(
-    () => [
-      ...sqlEditorCommands.map((command) => ({
-        key: command.name,
-        label: `/${command.name}`,
-        description: command.description,
-      })),
-      {
-        key: "__toggle-agent__",
-        label: "Toggle Agent",
-        icon: <MessageSquare className="!h-3.5 !w-3.5" />,
-        separatorBefore: true,
-        itemClassName: "py-1 my-1",
-      },
-    ],
-    [sqlEditorCommands]
-  );
   const hasEditorText = text.trim().length > 0;
   const hasSelectedText = selectedText.trim().length > 0;
   const isRunPrimaryDisabled = isSqlExecuting || (!hasSelectedText && !hasEditorText);
   const isRunBatchDisabled = isSqlExecuting || !hasEditorText;
   const isExplainDisabled = isSqlExecuting || !hasEditorText;
-  const isSqlEditorActionDisabled = isSqlExecuting;
   const isSaveDisabled = isSqlExecuting || !hasEditorText;
 
   return (
@@ -227,46 +151,6 @@ export function QueryControl({ onOpenHistory }: { onOpenHistory: () => void }) {
           </DropdownMenuContent>
         </DropdownMenu>
 
-        <>
-          <Separator orientation="vertical" className="h-4" />
-          <Popover open={isAgentActionsOpen} onOpenChange={setIsAgentActionsOpen}>
-            <PopoverTrigger asChild>
-              <Button
-                disabled={isSqlEditorActionDisabled}
-                size="sm"
-                variant="ghost"
-                className="h-6 gap-1 px-2 text-xs rounded-sm"
-              >
-                <Sparkles className="h-3 w-3" />
-                AI Actions
-                <ChevronDown className="h-3 w-3" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent
-              align="start"
-              className="p-0 w-auto flex items-stretch z-50 bg-transparent border-0 pointer-events-auto"
-              onOpenAutoFocus={(e) => e.preventDefault()}
-            >
-              <AgentCommandBrowserPanel
-                items={sqlEditorActionItems}
-                onSelectItem={(item) => {
-                  setIsAgentActionsOpen(false);
-                  if (item.key === "__toggle-agent__") {
-                    handleOpenAgent();
-                    return;
-                  }
-                  const command = sqlEditorCommands.find(
-                    (candidate) => candidate.name === item.key
-                  );
-                  if (command) {
-                    handleSqlEditorCommand(command);
-                  }
-                }}
-              />
-            </PopoverContent>
-          </Popover>
-        </>
-
         <Separator orientation="vertical" className="h-4" />
 
         <Button
@@ -290,6 +174,20 @@ export function QueryControl({ onOpenHistory }: { onOpenHistory: () => void }) {
         >
           <History className="h-3 w-3" />
           History
+        </Button>
+
+        <Separator orientation="vertical" className="h-4" />
+
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-6 gap-1 px-2 text-xs rounded-sm"
+          onClick={() => {
+            setDisplayMode(displayMode === "hidden" ? "panel" : "hidden");
+          }}
+        >
+          <MessageSquare className="h-3 w-3" />
+          Toggle Agent
         </Button>
       </div>
     </TooltipProvider>

--- a/src/components/query-tab/query-input/query-input-view.tsx
+++ b/src/components/query-tab/query-input/query-input-view.tsx
@@ -1,7 +1,29 @@
+import {
+  AgentCommandBrowserPanel,
+  type AgentCommandBrowserItem,
+} from "@/components/chat/agent-command-browser-panel";
+import { useAgentCommands } from "@/components/chat/agent-command-context";
+import { sqlSnippetTokenCodec } from "@/components/chat/input/sql-snippet-token";
+import { useChatPanel } from "@/components/chat/view/use-chat-panel";
 import { useConnection } from "@/components/connection/connection-context";
+import {
+  AgentConfigurationManager,
+  normalizeAIResponseLanguage,
+} from "@/components/settings/agent/agent-manager";
 import { useTheme } from "@/components/shared/theme-provider";
+import { Dialog } from "@/components/shared/use-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import type { CommandDetail } from "@/lib/ai/commands/command-manager";
 import { SqlUtils } from "@/lib/sql-utils";
 import type { Ace } from "ace-builds";
+import { ChevronDown, Play, Sparkles } from "lucide-react";
 import dynamic from "next/dynamic";
 import {
   forwardRef,
@@ -13,6 +35,7 @@ import {
   useState,
 } from "react";
 import { useDebouncedCallback } from "use-debounce";
+import { useQueryExecutor } from "../query-execution/query-executor";
 import { QueryInputLocalStorage } from "../query-input/query-input-local-storage";
 import { QuerySuggestionManager } from "./completion/query-suggestion-manager";
 import "./query-input-view.css";
@@ -56,6 +79,18 @@ interface QueryInputViewProps {
   language?: string;
   onRun?: (sql: string) => void;
 }
+
+type SelectionActionState = {
+  sql: string;
+  top: number;
+  left: number;
+  placement: "above" | "below";
+  align: "start" | "center" | "end";
+};
+
+const FLOATING_ACTION_HEIGHT = 28;
+const FLOATING_ACTION_GAP = 8;
+const FLOATING_ACTION_ESTIMATED_WIDTH = 420;
 
 // Logic to apply query to editor
 const applyQueryToEditor = (
@@ -124,13 +159,20 @@ export const QueryInputView = forwardRef<QueryInputViewRef, QueryInputViewProps>
     ref
   ) => {
     const { connection } = useConnection();
+    const { postMessage, setDisplayMode, setInitialInput } = useChatPanel();
+    const { commands } = useAgentCommands();
+    const { isSqlExecuting, executeQuery } = useQueryExecutor();
     const { theme } = useTheme();
     const editorRef = useRef<ExtendedEditor | undefined>(undefined);
     const containerRef = useRef<HTMLDivElement>(null);
     const [editorHeight, setEditorHeight] = useState(200);
     const [editorWidth, setEditorWidth] = useState(800);
+    const [selectionAction, setSelectionAction] = useState<SelectionActionState | null>(null);
+    const [isAgentActionsOpen, setIsAgentActionsOpen] = useState(false);
     const lastConnectionRef = useRef<string | null>(null);
     const latestOnRun = useRef(onRun);
+    const isMouseSelectingRef = useRef(false);
+    const sqlEditorCommands = commands.filter((command) => command.showInSqlEditorQuickAction);
 
     useEffect(() => {
       latestOnRun.current = onRun;
@@ -280,6 +322,76 @@ export const QueryInputView = forwardRef<QueryInputViewRef, QueryInputViewProps>
       };
     }, []);
 
+    const updateSelectionAction = useCallback(() => {
+      if (isMouseSelectingRef.current) {
+        setSelectionAction(null);
+        return;
+      }
+
+      const editor = editorRef.current;
+      const container = containerRef.current;
+
+      if (!editor || !container) {
+        setSelectionAction(null);
+        return;
+      }
+
+      const selectedSql = editor.getSelectedText().trim();
+      if (selectedSql.length === 0) {
+        setSelectionAction(null);
+        return;
+      }
+
+      const range = editor.getSelectionRange();
+      if (
+        !range ||
+        (range.start.row === range.end.row && range.start.column === range.end.column)
+      ) {
+        setSelectionAction(null);
+        return;
+      }
+
+      const startCoords = editor.renderer.textToScreenCoordinates(
+        range.start.row,
+        range.start.column
+      );
+      const endCoords =
+        range.start.row === range.end.row
+          ? editor.renderer.textToScreenCoordinates(range.end.row, range.end.column)
+          : startCoords;
+      const containerRect = container.getBoundingClientRect();
+      const rawLeft =
+        (startCoords.pageX + endCoords.pageX) / 2 - window.scrollX - containerRect.left;
+      const lineHeight = editor.renderer.lineHeight ?? 16;
+      const anchorTop = startCoords.pageY - window.scrollY - containerRect.top;
+      const canRenderAbove = anchorTop >= FLOATING_ACTION_HEIGHT + FLOATING_ACTION_GAP + 4;
+      const placement = canRenderAbove ? "above" : "below";
+      const top = canRenderAbove
+        ? anchorTop - FLOATING_ACTION_HEIGHT - FLOATING_ACTION_GAP
+        : anchorTop + lineHeight + FLOATING_ACTION_GAP;
+      const minCenteredLeft = FLOATING_ACTION_ESTIMATED_WIDTH / 2 + 8;
+      const maxCenteredLeft = containerRect.width - FLOATING_ACTION_ESTIMATED_WIDTH / 2 - 8;
+      const align =
+        rawLeft < minCenteredLeft ? "start" : rawLeft > maxCenteredLeft ? "end" : "center";
+      const left =
+        align === "start"
+          ? Math.max(startCoords.pageX - window.scrollX - containerRect.left, 8)
+          : align === "end"
+            ? Math.min(
+                endCoords.pageX - window.scrollX - containerRect.left,
+                containerRect.width - 8
+              )
+            : rawLeft;
+
+      setSelectionAction({
+        sql: selectedSql,
+        top: Math.max(top, 8),
+        left,
+        placement,
+        align,
+      });
+    }, []);
+
     // Cleanup scroll event listeners when component unmounts
     useEffect(() => {
       return () => {
@@ -295,6 +407,7 @@ export const QueryInputView = forwardRef<QueryInputViewRef, QueryInputViewProps>
     const handleEditorLoad = useCallback(
       (editor: Ace.Editor) => {
         const extendedEditor = editor as ExtendedEditor;
+        const session = editor.getSession();
         editor.setValue(QueryInputLocalStorage.getInput(storageKey));
         editor.renderer.setScrollMargin(5, 10, 0, 0);
 
@@ -335,12 +448,45 @@ export const QueryInputView = forwardRef<QueryInputViewRef, QueryInputViewProps>
         const existingDivs = document.querySelectorAll(".ace-tooltip-scrollable");
         existingDivs.forEach((div) => attachScrollPrevention(div as HTMLElement));
 
+        const syncSelectionAction = () => {
+          updateSelectionAction();
+        };
+
+        const handleMouseDown = (event: MouseEvent) => {
+          if (event.button !== 0) {
+            return;
+          }
+
+          isMouseSelectingRef.current = true;
+          setSelectionAction(null);
+        };
+
+        const handleMouseUp = () => {
+          if (!isMouseSelectingRef.current) {
+            return;
+          }
+
+          isMouseSelectingRef.current = false;
+          requestAnimationFrame(() => {
+            updateSelectionAction();
+          });
+        };
+
+        session.on("changeScrollTop", syncSelectionAction);
+        session.on("changeScrollLeft", syncSelectionAction);
+        extendedEditor.selection.on("changeSelection", syncSelectionAction);
+        editor.container.addEventListener("mousedown", handleMouseDown);
+        window.addEventListener("mouseup", handleMouseUp);
+
         // Store cleanup function
         (extendedEditor as { __scrollCleanup?: () => void }).__scrollCleanup = () => {
           observer.disconnect();
+          session.off("changeScrollTop", syncSelectionAction);
+          session.off("changeScrollLeft", syncSelectionAction);
+          extendedEditor.selection.off("changeSelection", syncSelectionAction);
+          editor.container.removeEventListener("mousedown", handleMouseDown);
+          window.removeEventListener("mouseup", handleMouseUp);
         };
-
-        const session = editor.getSession();
 
         // Only valid for SQL
         if (language === "dsql") {
@@ -406,8 +552,9 @@ export const QueryInputView = forwardRef<QueryInputViewRef, QueryInputViewProps>
         // });
 
         editorRef.current = extendedEditor;
+        updateSelectionAction();
       },
-      [initialQuery, initialMode, language, storageKey]
+      [initialQuery, initialMode, language, storageKey, updateSelectionAction]
     );
 
     // Handle switching modes (storage key / language changes) without unmounting
@@ -475,8 +622,9 @@ export const QueryInputView = forwardRef<QueryInputViewRef, QueryInputViewProps>
           cursorRow: cursor.row,
           cursorColumn: cursor.column,
         });
+        updateSelectionAction();
       }
-    }, []);
+    }, [updateSelectionAction]);
 
     const handleCursorChange = useCallback(() => {
       if (editorRef.current) {
@@ -489,8 +637,105 @@ export const QueryInputView = forwardRef<QueryInputViewRef, QueryInputViewProps>
           cursorRow: cursor.row,
           cursorColumn: cursor.column,
         });
+        updateSelectionAction();
       }
-    }, []);
+    }, [updateSelectionAction]);
+
+    const handleAddSelectionToChat = useCallback(() => {
+      if (!selectionAction?.sql) {
+        return;
+      }
+
+      setSelectionAction(null);
+      setInitialInput(
+        `${sqlSnippetTokenCodec.createToken(selectionAction.sql)} `,
+        undefined,
+        "append"
+      );
+      setDisplayMode("panel");
+    }, [selectionAction, setDisplayMode, setInitialInput]);
+
+    const handleRunSelectedText = useCallback(() => {
+      const sql = selectionAction?.sql?.trim();
+      if (!sql) {
+        return;
+      }
+      setSelectionAction(null);
+      executeQuery(sql);
+    }, [executeQuery, selectionAction?.sql]);
+
+    const handleExplain = useCallback(
+      (type: string) => {
+        const sql = selectionAction?.sql?.trim();
+        if (!sql) {
+          return;
+        }
+
+        const { explainSQL, rawSQL } = SqlUtils.toExplainSQL(type, sql);
+        if (rawSQL.length === 0) {
+          return;
+        }
+
+        const viewType = type === "plan" ? "plan" : type;
+        setSelectionAction(null);
+        executeQuery(explainSQL, rawSQL, { view: viewType });
+      },
+      [executeQuery, selectionAction?.sql]
+    );
+
+    const handleSqlEditorCommand = useCallback(
+      (command: CommandDetail) => {
+        const sql = selectionAction?.sql?.trim();
+        if (!sql) {
+          Dialog.alert({
+            title: "No SQL To Send",
+            description: "Select a SQL statement before running an AI action.",
+          });
+          return;
+        }
+
+        const normalizedSql = SqlUtils.removeComments(sql);
+        if (normalizedSql.length === 0) {
+          Dialog.alert({
+            title: "No SQL To Send",
+            description: "Select a SQL statement before running an AI action.",
+          });
+          return;
+        }
+
+        const statements = SqlUtils.splitSqlStatements(normalizedSql);
+        if (statements.length !== 1) {
+          Dialog.alert({
+            title: "Single Statement Required",
+            description:
+              "AI actions from the SQL editor currently support exactly one SQL statement at a time.",
+          });
+          return;
+        }
+
+        const reviewLanguage = normalizeAIResponseLanguage(
+          AgentConfigurationManager.getConfiguration().aiResponseLanguage
+        );
+
+        setSelectionAction(null);
+        setIsAgentActionsOpen(false);
+        postMessage(`/${command.name}\n\n\`\`\`sql\n${statements[0]}\n\`\`\``, {
+          forceNewChat: true,
+          agentContext: { responseLanguage: reviewLanguage },
+        });
+      },
+      [postMessage, selectionAction?.sql]
+    );
+
+    const sqlEditorActionItems = useMemo<AgentCommandBrowserItem[]>(
+      () =>
+        sqlEditorCommands.map((command) => ({
+          key: command.name,
+          label: `/${command.name}`,
+          description: command.description,
+        })),
+      [sqlEditorCommands]
+    );
 
     // Get OS-specific key bindings
     const keyBindings = useMemo(() => getKeyBindings(), []);
@@ -503,7 +748,120 @@ Press ${keyBindings.autocomplete} to show suggestions.
     }
 
     return (
-      <div ref={containerRef} className="query-editor-container h-full w-full">
+      <div ref={containerRef} className="query-editor-container relative h-full w-full">
+        {selectionAction ? (
+          <div
+            className="pointer-events-none absolute z-20"
+            style={{
+              top: selectionAction.top,
+              left: selectionAction.left,
+              transform:
+                selectionAction.align === "start"
+                  ? "translateX(0)"
+                  : selectionAction.align === "end"
+                    ? "translateX(-100%)"
+                    : "translateX(-50%)",
+            }}
+          >
+            <div className="pointer-events-auto flex items-center gap-0 rounded-sm border border-border bg-background/95 px-1 py-1 shadow-md backdrop-blur supports-[backdrop-filter]:bg-background/85">
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                className="h-6 rounded-sm px-2 text-[11px]"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={handleRunSelectedText}
+                disabled={isSqlExecuting}
+              >
+                <Play className="h-3 w-3" />
+                Run
+              </Button>
+              <div className="mx-1 h-4 w-px bg-border" />
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    className="h-6 gap-0.5 rounded-sm px-2 text-[11px]"
+                    onMouseDown={(event) => event.preventDefault()}
+                    disabled={isSqlExecuting}
+                  >
+                    Explain
+                    <ChevronDown className="h-3 w-3" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start">
+                  <DropdownMenuItem onClick={() => handleExplain("ast")}>
+                    Explain AST
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => handleExplain("syntax")}>
+                    Explain Syntax
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => handleExplain("plan")}>
+                    Explain Plan
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => handleExplain("pipeline")}>
+                    Explain Pipeline
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => handleExplain("estimate")}>
+                    Explain Estimate
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <div className="mx-1 h-4 w-px bg-border" />
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                className="h-6 rounded-sm px-2 text-[11px]"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={handleAddSelectionToChat}
+              >
+                Add to Chat
+              </Button>
+              {sqlEditorActionItems.length > 0 ? (
+                <>
+                  <div className="mx-1 h-4 w-px bg-border" />
+                  <Popover open={isAgentActionsOpen} onOpenChange={setIsAgentActionsOpen}>
+                    <PopoverTrigger asChild>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        className="h-6 gap-0.5 rounded-sm px-2 text-[11px]"
+                        onMouseDown={(event) => event.preventDefault()}
+                        disabled={isSqlExecuting}
+                      >
+                        <Sparkles className="h-3 w-3" />
+                        AI Commands
+                        <ChevronDown className="h-3 w-3" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent
+                      align="start"
+                      className="z-30 w-auto border-0 bg-transparent p-0"
+                      onOpenAutoFocus={(event) => event.preventDefault()}
+                    >
+                      <AgentCommandBrowserPanel
+                        items={sqlEditorActionItems}
+                        onSelectItem={(item) => {
+                          setIsAgentActionsOpen(false);
+                          const command = sqlEditorCommands.find(
+                            (candidate) => candidate.name === item.key
+                          );
+                          if (command) {
+                            handleSqlEditorCommand(command);
+                          }
+                        }}
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
         <AceEditor
           mode={language}
           theme={aceTheme}

--- a/src/components/query-tab/query-input/query-input-view.tsx
+++ b/src/components/query-tab/query-input/query-input-view.tsx
@@ -84,7 +84,6 @@ type SelectionActionState = {
   sql: string;
   top: number;
   left: number;
-  placement: "above" | "below";
   align: "start" | "center" | "end";
 };
 
@@ -365,7 +364,6 @@ export const QueryInputView = forwardRef<QueryInputViewRef, QueryInputViewProps>
       const lineHeight = editor.renderer.lineHeight ?? 16;
       const anchorTop = startCoords.pageY - window.scrollY - containerRect.top;
       const canRenderAbove = anchorTop >= FLOATING_ACTION_HEIGHT + FLOATING_ACTION_GAP + 4;
-      const placement = canRenderAbove ? "above" : "below";
       const top = canRenderAbove
         ? anchorTop - FLOATING_ACTION_HEIGHT - FLOATING_ACTION_GAP
         : anchorTop + lineHeight + FLOATING_ACTION_GAP;
@@ -387,7 +385,6 @@ export const QueryInputView = forwardRef<QueryInputViewRef, QueryInputViewProps>
         sql: selectedSql,
         top: Math.max(top, 8),
         left,
-        placement,
         align,
       });
     }, []);


### PR DESCRIPTION
## Summary
- add floating SQL-selection actions in the editor for run, explain, add to chat, and AI commands
- add inline SQL snippet tokens in the chat composer with hover preview and correct fenced-markdown expansion on send
- simplify query control agent actions into a toggle button and fix token hover/removal edge cases

## Validation
- npm run format
- npm run typecheck
- npm run lint
- npm run test -- src/components/chat/input/inline-token.test.ts src/components/chat/input/sql-snippet-token.test.ts src/components/chat/message/message-user.test.tsx

## Notes
- npm run build is blocked in this worktree because vendored directories are missing here: external/number-flow/packages/number-flow, external/clickhouse/skills, and external/vizlayer/skills