### PR TITLE
Refine dashboard metadata tabs

### DIFF
--- a/.codex/hooks/after_change.sh
+++ b/.codex/hooks/after_change.sh
@@ -18,13 +18,21 @@ collect_candidate_files() {
 run_direct_tool_for_files() {
   local tool="$1"
   shift
+  local -a tool_args=()
+  while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do
+    tool_args+=("$1")
+    shift
+  done
+  if [ "$#" -gt 0 ] && [ "$1" = "--" ]; then
+    shift
+  fi
   local -a files=("$@")
 
   if [ "${#files[@]}" -eq 0 ]; then
     return 0
   fi
 
-  npx "$tool" "${files[@]}"
+  npx "$tool" "${tool_args[@]}" "${files[@]}"
 }
 
 hash_stream() {
@@ -104,9 +112,9 @@ for path in "${candidate_files[@]}"; do
   esac
 done
 
-run_direct_tool_for_files prettier --write "${format_files[@]}"
+run_direct_tool_for_files prettier --write -- "${format_files[@]}"
 npm run typecheck
-run_direct_tool_for_files eslint "${lint_files[@]}"
+run_direct_tool_for_files eslint -- "${lint_files[@]}"
 
 if git diff --quiet && git diff --cached --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
   rm -f "$stamp_file"

--- a/src/components/database-tab/database-metadata.tsx
+++ b/src/components/database-tab/database-metadata.tsx
@@ -1,0 +1,53 @@
+import type {
+  Dashboard,
+  TransposeTableDescriptor,
+} from "@/components/shared/dashboard/dashboard-model";
+import DashboardPanelContainer, {
+  type DashboardPanelContainerRef,
+} from "@/components/shared/dashboard/dashboard-panel-container";
+import { forwardRef, useMemo } from "react";
+
+export interface DatabaseMetadataProps {
+  database: string;
+}
+
+export const DatabaseMetadata = forwardRef<DashboardPanelContainerRef, DatabaseMetadataProps>(
+  ({ database }, ref) => {
+    const dashboard = useMemo<Dashboard>(
+      () => ({
+        version: 3,
+        filter: {
+          showTimeSpanSelector: false,
+          showRefresh: false,
+          showAutoRefresh: false,
+        },
+        charts: [
+          {
+            type: "transpose-table",
+            titleOption: {
+              title: "Database Metadata",
+              align: "left",
+            },
+            gridPos: {
+              w: 24,
+              h: 9,
+            },
+            datasource: {
+              sql: `
+select 
+  *
+from system.databases
+where database = '${database}'
+`,
+            },
+          } as TransposeTableDescriptor,
+        ],
+      }),
+      [database]
+    );
+
+    return <DashboardPanelContainer ref={ref} dashboard={dashboard} />;
+  }
+);
+
+DatabaseMetadata.displayName = "DatabaseMetadata";

--- a/src/components/database-tab/database-metadata.tsx
+++ b/src/components/database-tab/database-metadata.tsx
@@ -5,6 +5,7 @@ import type {
 import DashboardPanelContainer, {
   type DashboardPanelContainerRef,
 } from "@/components/shared/dashboard/dashboard-panel-container";
+import { SqlUtils } from "@/lib/sql-utils";
 import { forwardRef, useMemo } from "react";
 
 export interface DatabaseMetadataProps {
@@ -13,6 +14,7 @@ export interface DatabaseMetadataProps {
 
 export const DatabaseMetadata = forwardRef<DashboardPanelContainerRef, DatabaseMetadataProps>(
   ({ database }, ref) => {
+    const escapedDatabase = useMemo(() => SqlUtils.escapeSqlString(database), [database]);
     const dashboard = useMemo<Dashboard>(
       () => ({
         version: 3,
@@ -37,13 +39,13 @@ export const DatabaseMetadata = forwardRef<DashboardPanelContainerRef, DatabaseM
 select 
   *
 from system.databases
-where database = '${database}'
+where database = '${escapedDatabase}'
 `,
             },
           } as TransposeTableDescriptor,
         ],
       }),
-      [database]
+      [escapedDatabase]
     );
 
     return <DashboardPanelContainer ref={ref} dashboard={dashboard} />;

--- a/src/components/database-tab/database-overview.tsx
+++ b/src/components/database-tab/database-overview.tsx
@@ -4,7 +4,6 @@ import type {
   DashboardGroup,
   StatDescriptor,
   TableDescriptor,
-  TransposeTableDescriptor,
 } from "@/components/shared/dashboard/dashboard-model";
 import DashboardPanelContainer, {
   type DashboardPanelContainerRef,
@@ -43,29 +42,6 @@ export const DatabaseOverview = forwardRef<DashboardPanelContainerRef, DatabaseO
         },
         charts: [
           //
-          // Database metadata
-          //
-          {
-            type: "transpose-table",
-            titleOption: {
-              title: "Database Metadata",
-              align: "left",
-            },
-            gridPos: {
-              w: 24,
-              h: 9,
-            },
-            datasource: {
-              sql: `
-select 
-  *
-from system.databases
-where database = '${database}'
-`,
-            },
-          } as TransposeTableDescriptor,
-
-          //
           // Node overview section
           //
           {
@@ -80,12 +56,12 @@ where database = '${database}'
                 collapsed: false,
                 gridPos: {
                   w: 4,
-                  h: 4,
+                  h: 3,
                 },
                 datasource: {
                   sql: `
 SELECT
-  sum(total_bytes)
+  COALESCE(sum(total_bytes), 0)
 FROM
   system.tables 
 WHERE
@@ -107,7 +83,7 @@ WHERE
                 collapsed: false,
                 gridPos: {
                   w: 4,
-                  h: 4,
+                  h: 3,
                 },
                 datasource: {
                   sql: `
@@ -131,7 +107,7 @@ WHERE
                 collapsed: false,
                 gridPos: {
                   w: 4,
-                  h: 4,
+                  h: 3,
                 },
                 datasource: {
                   sql: `
@@ -158,7 +134,7 @@ WHERE
                 collapsed: false,
                 gridPos: {
                   w: 4,
-                  h: 4,
+                  h: 3,
                 },
                 datasource: {
                   sql: `
@@ -185,7 +161,7 @@ FROM (
                 },
                 gridPos: {
                   w: 4,
-                  h: 4,
+                  h: 3,
                 },
                 description: "The number of ongoing merges",
                 datasource: {
@@ -288,7 +264,7 @@ ORDER BY elapsed DESC`,
                 },
                 gridPos: {
                   w: 4,
-                  h: 4,
+                  h: 3,
                 },
                 description: "The number of ongoing mutations",
                 datasource: {
@@ -357,10 +333,9 @@ ORDER BY create_time DESC`,
                   title: "Size by Tables",
                   align: "left",
                 },
-                collapsed: true,
                 gridPos: {
                   w: 24,
-                  h: 12,
+                  h: 9,
                 },
                 headOption: {
                   isSticky: true,
@@ -396,7 +371,7 @@ WHERE database = '${database}'
 AND active
 GROUP BY table
 ) AS part
-ON T.table = part.table
+ON T.name = part.table
 WHERE T.database = '${database}' AND endsWith(T.engine , 'MergeTree')
 ORDER BY on_disk_size DESC
     `,
@@ -494,9 +469,9 @@ ORDER BY on_disk_size DESC
                 datasource: {
                   sql: `
 SELECT
-  sum(total_bytes)
+  COALESCE(sum(total_bytes), 0)
 FROM
-  clusterAllReplicas('{cluster}', system.tables) 
+  {clusterAllReplicas:system.tables} 
 WHERE
   database = '${database}'
     `,
@@ -518,7 +493,7 @@ WHERE
                 collapsed: false,
                 gridPos: {
                   w: 24,
-                  h: 12,
+                  h: 9,
                 },
                 miscOption: { enableIndexColumn: true },
                 headOption: {
@@ -559,7 +534,7 @@ SELECT
     sum(data_compressed_bytes) AS compressed_size,
     sum(data_uncompressed_bytes) AS uncompressed_size,
     round(uncompressed_size / compressed_size, 0) AS compressed_ratio
-FROM clusterAllReplicas('${connection?.cluster}', system.parts)
+FROM {clusterAllReplicas:system.parts}
 WHERE database = '${database}'
 AND active
 GROUP BY host

--- a/src/components/database-tab/database-tab.tsx
+++ b/src/components/database-tab/database-tab.tsx
@@ -10,6 +10,7 @@ import { RefreshCw } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DependencyView } from "../dependency-view/dependency-view";
 import type { RefreshableTabViewRef } from "../table-tab/table-tab";
+import { DatabaseMetadata } from "./database-metadata";
 import { DatabaseOverview } from "./database-overview";
 
 export interface DatabaseTabProps {
@@ -34,6 +35,7 @@ const DatabaseTabComponent = ({ database }: DatabaseTabProps) => {
 
   // Refs for each tab view
   const overviewRef = useRef<DashboardPanelContainerRef>(null);
+  const metadataRef = useRef<DashboardPanelContainerRef>(null);
   const dependencyRef = useRef<RefreshableTabViewRef>(null);
 
   // Helper function to get the current ref based on active tab
@@ -44,6 +46,8 @@ const DatabaseTabComponent = ({ database }: DatabaseTabProps) => {
     switch (activeTab) {
       case "overview":
         return overviewRef.current;
+      case "metadata":
+        return metadataRef.current;
       case "dependency":
         return dependencyRef.current;
       default:
@@ -123,6 +127,12 @@ const DatabaseTabComponent = ({ database }: DatabaseTabProps) => {
               Database Overview
             </TabsTrigger>
             <TabsTrigger
+              value="metadata"
+              className="border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:rounded-b-none data-[state=active]:bg-transparent"
+            >
+              Metadata
+            </TabsTrigger>
+            <TabsTrigger
               value="dependency"
               className="border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:rounded-b-none data-[state=active]:bg-transparent"
             >
@@ -166,6 +176,16 @@ const DatabaseTabComponent = ({ database }: DatabaseTabProps) => {
                 database={database}
                 selectedTimeSpan={calculatedTimeSpan}
               />
+            )}
+          </div>
+          {/* Metadata tab */}
+          <div
+            className={`absolute inset-0 overflow-auto px-2 ${activeTab === "metadata" ? "block" : "hidden"}`}
+            role="tabpanel"
+            aria-hidden={activeTab !== "metadata"}
+          >
+            {tabsMetadata.get("metadata")?.loaded && (
+              <DatabaseMetadata ref={metadataRef} database={database} />
             )}
           </div>
           {/* Database Dependency tab */}

--- a/src/components/database-tab/database-tab.tsx
+++ b/src/components/database-tab/database-tab.tsx
@@ -184,7 +184,7 @@ const DatabaseTabComponent = ({ database }: DatabaseTabProps) => {
             role="tabpanel"
             aria-hidden={activeTab !== "metadata"}
           >
-            {tabsMetadata.get("metadata")?.loaded && (
+            {(tabsMetadata.get("metadata")?.loaded || activeTab === "metadata") && (
               <DatabaseMetadata ref={metadataRef} database={database} />
             )}
           </div>

--- a/src/components/main-page-tab-list.tsx
+++ b/src/components/main-page-tab-list.tsx
@@ -343,9 +343,12 @@ export const MainPageTabList = memo(function MainPageTabList({
     }
 
     if (!activeTab) {
+      // Notify listeners after commit when the last tab closes to avoid setState-during-render.
+      TabManager.sendActiveTabChange("", null);
       return;
     }
 
+    // Dispatch from an effect so cross-component listeners update after React finishes rendering.
     const tabInfo = tabs.find((t) => t.id === activeTab) || null;
     TabManager.sendActiveTabChange(activeTab, tabInfo);
   }, [activeTab, tabs, pendingTabId]);
@@ -451,8 +454,6 @@ export const MainPageTabList = memo(function MainPageTabList({
         setTabs((prevTabs) => {
           // Find the next/previous tab before removing the closed tab
           const nextTabId = getNextOrPreviousTabId(tabId, prevTabs);
-          // Emit event for tab closure (tabInfo: null) - SchemaTreeView will ignore this
-          TabManager.sendActiveTabChange(tabId, null);
           if (nextTabId) {
             setActiveTab(nextTabId);
           } else {
@@ -554,8 +555,6 @@ export const MainPageTabList = memo(function MainPageTabList({
     // Close all tabs including the query tab
     setTabs([]);
     setActiveTab("");
-    // Emit event for tab closure (tabInfo: null) - SchemaTreeView will ignore this
-    TabManager.sendActiveTabChange("", null);
 
     // If chat panel is visible (panel mode), switch to tabWidth mode when all tabs are closed
     if (displayMode === "panel") {

--- a/src/components/query-tab/query-input/query-input-view.tsx
+++ b/src/components/query-tab/query-input/query-input-view.tsx
@@ -760,7 +760,7 @@ Press ${keyBindings.autocomplete} to show suggestions.
                     : "translateX(-50%)",
             }}
           >
-            <div className="pointer-events-auto flex items-center gap-0 rounded-sm border border-border bg-background/95 px-1 py-1 shadow-md backdrop-blur supports-[backdrop-filter]:bg-background/85">
+            <div className="pointer-events-auto flex items-center gap-0 rounded-sm border border-border bg-background px-1 py-1 shadow-md">
               <Button
                 type="button"
                 size="sm"

--- a/src/components/settings/agent/agent-edit.tsx
+++ b/src/components/settings/agent/agent-edit.tsx
@@ -374,8 +374,8 @@ export function AgentEdit() {
               </DropdownMenu>
             </TableCell>
             <TableCell className="px-0 py-1 align-middle text-sm text-muted-foreground">
-              Controls the response language for AI actions in the SQL editor, including auto
-              explain and other quick actions.
+              Controls the response language for AI commands in the SQL editor, including auto
+              explain and other quick commands.
             </TableCell>
           </TableRow>
 

--- a/src/components/shared/dashboard/dashboard-visualization-transpose-table.tsx
+++ b/src/components/shared/dashboard/dashboard-visualization-transpose-table.tsx
@@ -157,7 +157,7 @@ export const TransposeTableVisualization = React.forwardRef<
     return (
       <TableRow>
         <TableCell colSpan={2} className="text-center text-muted-foreground p-8">
-          <div className="flex items-center justify-center h-[72px]">No data found</div>
+          <div className="flex items-center justify-center h-[72px]">No data</div>
         </TableCell>
       </TableRow>
     );

--- a/src/components/shared/dashboard/data-table.tsx
+++ b/src/components/shared/dashboard/data-table.tsx
@@ -1079,7 +1079,7 @@ export const DataTable = forwardRef<DataTableRef, DataTableProps>(function DataT
       </div>
       {isNoData && (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center pt-10 text-muted-foreground">
-          No data found
+          No data
         </div>
       )}
     </div>

--- a/src/components/table-tab/open-table-tab-button.tsx
+++ b/src/components/table-tab/open-table-tab-button.tsx
@@ -80,7 +80,7 @@ export const OpenTableTabButton = memo(
     return (
       <Button
         variant="link"
-        className={`font-semibold h-auto p-0 text-left inline-flex items-center ${className}`}
+        className={`gap-1 font-normal h-auto p-0 text-left inline-flex items-center ${className}`}
         onClick={handleClick}
         title={title}
       >

--- a/src/components/table-tab/table-metadata-view.tsx
+++ b/src/components/table-tab/table-metadata-view.tsx
@@ -125,7 +125,7 @@ const TableMetadataViewComponent = forwardRef<RefreshableTabViewRef, TableMetada
             collapsed: false,
             gridPos: {
               w: 24,
-              h: 24,
+              h: 16,
             },
             datasource: {
               sql: `
@@ -144,11 +144,10 @@ SELECT * FROM system.tables WHERE database = '${escapedDatabase}' AND name = '${
               title: "Table Columns",
               align: "center",
             },
-            collapsed: true,
             miscOption: { enableIndexColumn: true },
             gridPos: {
               w: 24,
-              h: 12,
+              h: 8,
             },
             datasource: {
               sql: `SELECT * FROM system.columns WHERE database = '${escapedDatabase}' AND table = '${escapedTable}'`,
@@ -170,11 +169,10 @@ SELECT * FROM system.tables WHERE database = '${escapedDatabase}' AND name = '${
             title: "Table Metadata On Cluster",
             align: "center",
           },
-          collapsed: true,
           miscOption: { enableIndexColumn: true },
           gridPos: {
             w: 24,
-            h: 12,
+            h: 8,
           },
           sortOption: {
             initialSort: {

--- a/src/components/table-tab/table-overview-view.tsx
+++ b/src/components/table-tab/table-overview-view.tsx
@@ -174,10 +174,10 @@ WHERE
     SELECT 
       COALESCE(
         round(
-            sum(bytes_on_disk) / NULLIF(sum(rows), 0), 
-            2
-        ), 
-        2
+          sum(bytes_on_disk) / NULLIF(sum(rows), 0), 
+          2
+        ),
+        0
       ) AS avg_row_size
     FROM
         system.parts

--- a/src/components/table-tab/table-overview-view.tsx
+++ b/src/components/table-tab/table-overview-view.tsx
@@ -172,7 +172,13 @@ WHERE
             datasource: {
               sql: `
     SELECT 
-        round(sum(bytes_on_disk) / nullIf(sum(rows), 0), 0) AS avg_row_size
+      COALESCE(
+        round(
+            sum(bytes_on_disk) / NULLIF(sum(rows), 0), 
+            2
+        ), 
+        2
+      ) AS avg_row_size
     FROM
         system.parts
     WHERE 


### PR DESCRIPTION
## Summary
- move database metadata into its own database sub-tab and keep metadata tables loading correctly
- fix active-tab change dispatch timing and make the SQL editor floating actions use an opaque surface
- carry over the after-change hook fix so prettier is not invoked without file arguments

## Validation
- `npm run typecheck` is still blocked by an existing error in `external/number-flow/packages/react/src/NumberFlow.tsx` (`TS2554: Expected 1 arguments, but got 0`)
- `npm run build` is also blocked by the same external dependency issue
