### PR TITLE
Render sample questions with markdown

### DIFF
--- a/src/components/chat/message/message-markdown-sql.tsx
+++ b/src/components/chat/message/message-markdown-sql.tsx
@@ -22,6 +22,7 @@ interface MessageMarkdownSqlProps {
   className?: string;
   customStyle?: React.CSSProperties;
   showExecuteButton?: boolean;
+  showActions?: boolean;
   showLineNumbers?: boolean;
   expandable?: boolean;
 }
@@ -32,6 +33,7 @@ export const MessageMarkdownSql = memo(function MessageMarkdownSql({
   className,
   customStyle,
   showExecuteButton = false,
+  showActions = true,
   showLineNumbers,
   expandable = false,
 }: MessageMarkdownSqlProps) {
@@ -115,51 +117,52 @@ export const MessageMarkdownSql = memo(function MessageMarkdownSql({
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >
-        {/* Floating Actions */}
-        <div
-          className={`absolute top-1 right-2 flex items-center gap-1 z-10 transition-opacity duration-200`}
-        >
-          {showExecuteButton && (
+        {showActions && (
+          <div
+            className={`absolute top-1 right-2 flex items-center gap-1 z-10 transition-opacity duration-200`}
+          >
+            {showExecuteButton && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  "h-5 w-5 opacity-60 hover:opacity-100 transition-all",
+                  isHovered || isExecuting ? "opacity-100" : "opacity-0 pointer-events-none"
+                )}
+                onClick={handleRun}
+                title={executionMode === "inline" ? "Run in place" : "Run in Query Tab"}
+                disabled={isExecuting}
+              >
+                {isExecuting ? (
+                  <Loader2 className="!h-3 !w-3 animate-spin" />
+                ) : (
+                  <Play className="!h-3 !w-3" />
+                )}
+              </Button>
+            )}
+            <CopyButton
+              value={code}
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "relative !top-auto !right-auto h-5 w-5 opacity-60 hover:opacity-100 transition-all",
+                isHovered ? "opacity-100" : "opacity-0 pointer-events-none"
+              )}
+            />
             <Button
               variant="ghost"
               size="icon"
               className={cn(
                 "h-5 w-5 opacity-60 hover:opacity-100 transition-all",
-                isHovered || isExecuting ? "opacity-100" : "opacity-0 pointer-events-none"
+                isHovered ? "opacity-100" : "opacity-0 pointer-events-none"
               )}
-              onClick={handleRun}
-              title={executionMode === "inline" ? "Run in place" : "Run in Query Tab"}
-              disabled={isExecuting}
+              onClick={() => openSaveSnippetDialog({ initialSql: code })}
+              title="Save as snippet"
             >
-              {isExecuting ? (
-                <Loader2 className="!h-3 !w-3 animate-spin" />
-              ) : (
-                <Play className="!h-3 !w-3" />
-              )}
+              <Bookmark className="!h-3 !w-3" />
             </Button>
-          )}
-          <CopyButton
-            value={code}
-            variant="ghost"
-            size="icon"
-            className={cn(
-              "relative !top-auto !right-auto h-5 w-5 opacity-60 hover:opacity-100 transition-all",
-              isHovered ? "opacity-100" : "opacity-0 pointer-events-none"
-            )}
-          />
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn(
-              "h-5 w-5 opacity-60 hover:opacity-100 transition-all",
-              isHovered ? "opacity-100" : "opacity-0 pointer-events-none"
-            )}
-            onClick={() => openSaveSnippetDialog({ initialSql: code })}
-            title="Save as snippet"
-          >
-            <Bookmark className="!h-3 !w-3" />
-          </Button>
-        </div>
+          </div>
+        )}
 
         <ThemedSyntaxHighlighter
           language={language}

--- a/src/components/chat/message/message-markdown.tsx
+++ b/src/components/chat/message/message-markdown.tsx
@@ -342,7 +342,14 @@ export const MessageMarkdown = memo(function MessageMarkdown({
         </h6>
       ),
     }),
-    [codeBlockStyle, customStyle, expandable, resolveMetadataLinks, showExecuteButton, showSqlActions]
+    [
+      codeBlockStyle,
+      customStyle,
+      expandable,
+      resolveMetadataLinks,
+      showExecuteButton,
+      showSqlActions,
+    ]
   );
 
   return (

--- a/src/components/chat/message/message-markdown.tsx
+++ b/src/components/chat/message/message-markdown.tsx
@@ -35,6 +35,7 @@ interface MessageMarkdownProps {
   messageId?: string;
   customStyle?: React.CSSProperties;
   showExecuteButton?: boolean;
+  showSqlActions?: boolean;
   resolveMetadataLinks?: boolean;
   /**
    * Allow expandable SQL blocks inside markdown. Default: false.
@@ -46,6 +47,7 @@ export const MessageMarkdown = memo(function MessageMarkdown({
   text,
   customStyle,
   showExecuteButton = true,
+  showSqlActions = true,
   resolveMetadataLinks = true,
   expandable = false,
 }: MessageMarkdownProps) {
@@ -88,6 +90,7 @@ export const MessageMarkdown = memo(function MessageMarkdown({
               language="sql"
               customStyle={customStyle}
               showExecuteButton={showExecuteButton}
+              showActions={showSqlActions}
               showLineNumbers={false}
               expandable={expandable}
             />
@@ -339,7 +342,7 @@ export const MessageMarkdown = memo(function MessageMarkdown({
         </h6>
       ),
     }),
-    [codeBlockStyle, customStyle, expandable, showExecuteButton]
+    [codeBlockStyle, customStyle, expandable, resolveMetadataLinks, showExecuteButton, showSqlActions]
   );
 
   return (

--- a/src/components/chat/message/message-markdown.tsx
+++ b/src/components/chat/message/message-markdown.tsx
@@ -35,6 +35,7 @@ interface MessageMarkdownProps {
   messageId?: string;
   customStyle?: React.CSSProperties;
   showExecuteButton?: boolean;
+  resolveMetadataLinks?: boolean;
   /**
    * Allow expandable SQL blocks inside markdown. Default: false.
    */
@@ -45,6 +46,7 @@ export const MessageMarkdown = memo(function MessageMarkdown({
   text,
   customStyle,
   showExecuteButton = true,
+  resolveMetadataLinks = true,
   expandable = false,
 }: MessageMarkdownProps) {
   const { connection } = useConnection();
@@ -118,7 +120,7 @@ export const MessageMarkdown = memo(function MessageMarkdown({
           const codeText = String(children).trim();
 
           // First check if it's a table name
-          const tableNames = tableNamesRef.current;
+          const tableNames = resolveMetadataLinks ? tableNamesRef.current : undefined;
           if (tableNames && codeText) {
             const tableInfo = tableNames.get(codeText);
             if (tableInfo) {
@@ -138,7 +140,7 @@ export const MessageMarkdown = memo(function MessageMarkdown({
           }
 
           // Then check if it's a database name
-          const databaseNames = databaseNamesRef.current;
+          const databaseNames = resolveMetadataLinks ? databaseNamesRef.current : undefined;
           if (databaseNames && codeText) {
             const databaseInfo = databaseNames.get(codeText);
             if (databaseInfo) {
@@ -155,7 +157,7 @@ export const MessageMarkdown = memo(function MessageMarkdown({
             }
           }
 
-          const nodeNames = nodeNamesRef.current;
+          const nodeNames = resolveMetadataLinks ? nodeNamesRef.current : undefined;
           if (nodeNames && codeText) {
             if (nodeNames.has(codeText)) {
               return (

--- a/src/components/chat/view/sample-questions.test.tsx
+++ b/src/components/chat/view/sample-questions.test.tsx
@@ -12,9 +12,17 @@ const testGlobal = globalThis as typeof globalThis & {
 };
 
 const useAgentCommandsMock = vi.fn();
+const messageMarkdownSpy = vi.fn();
 
 vi.mock("../agent-command-context", () => ({
   useAgentCommands: () => useAgentCommandsMock(),
+}));
+
+vi.mock("../message/message-markdown", () => ({
+  MessageMarkdown: (props: { text: string }) => {
+    messageMarkdownSpy(props);
+    return <pre data-testid="sample-question-markdown">{props.text}</pre>;
+  },
 }));
 
 describe("SampleQuestions", () => {
@@ -48,6 +56,7 @@ describe("SampleQuestions", () => {
     container.setAttribute("data-sample-questions-scroll-root", "true");
     document.body.appendChild(container);
     root = createRoot(container);
+    messageMarkdownSpy.mockReset();
   });
 
   afterEach(() => {
@@ -251,5 +260,77 @@ describe("SampleQuestions", () => {
     );
 
     expect(sqlGenerationButton?.className).toContain("bg-muted/40");
+  });
+
+  it("renders sample questions through MessageMarkdown without flattening fenced SQL", () => {
+    useAgentCommandsMock.mockReturnValue({
+      commands: [{ skillId: "source-code-inspection" }],
+      loading: false,
+    });
+
+    act(() => {
+      root.render(<SampleQuestions onQuestionClick={vi.fn()} />);
+    });
+
+    const markdownCall = messageMarkdownSpy.mock.calls.find(
+      ([props]) => typeof props?.text === "string" && props.text.includes("```sql")
+    )?.[0];
+
+    expect(markdownCall).toEqual(
+      expect.objectContaining({
+        showExecuteButton: false,
+        resolveMetadataLinks: false,
+        customStyle: expect.objectContaining({
+          backgroundColor: "transparent",
+        }),
+        text: expect.stringContaining("flowchart.\n```sql\nSELECT"),
+      })
+    );
+  });
+
+  it("activates a sample question card and preserves the original markdown", () => {
+    useAgentCommandsMock.mockReturnValue({
+      commands: [{ skillId: "source-code-inspection" }],
+      loading: false,
+    });
+    const onQuestionClick = vi.fn();
+
+    act(() => {
+      root.render(<SampleQuestions onQuestionClick={onQuestionClick} />);
+    });
+
+    const markdownCard = Array.from(container.querySelectorAll("[role='button']")).find((element) =>
+      element.textContent?.includes("Explain what the following query does.")
+    );
+
+    expect(markdownCard).toBeTruthy();
+
+    act(() => {
+      markdownCard?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onQuestionClick).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("flowchart.\n```sql\nSELECT"),
+      })
+    );
+  });
+
+  it("shows long desktop group titles without truncating them", () => {
+    useAgentCommandsMock.mockReturnValue({
+      commands: [{ skillId: "source-code-inspection" }],
+      loading: false,
+    });
+
+    act(() => {
+      root.render(<SampleQuestions onQuestionClick={vi.fn()} />);
+    });
+
+    const sourceCodeNavButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Source Code Inspection")
+    );
+
+    expect(sourceCodeNavButton).toBeTruthy();
+    expect(sourceCodeNavButton?.textContent).toContain("Source Code Inspection");
   });
 });

--- a/src/components/chat/view/sample-questions.test.tsx
+++ b/src/components/chat/view/sample-questions.test.tsx
@@ -18,7 +18,7 @@ vi.mock("../agent-command-context", () => ({
   useAgentCommands: () => useAgentCommandsMock(),
 }));
 
-vi.mock("../message/message-markdown", () => ({
+vi.mock("@/components/chat/message/message-markdown", () => ({
   MessageMarkdown: (props: { text: string }) => {
     messageMarkdownSpy(props);
     return <pre data-testid="sample-question-markdown">{props.text}</pre>;
@@ -279,6 +279,7 @@ describe("SampleQuestions", () => {
     expect(markdownCall).toEqual(
       expect.objectContaining({
         showExecuteButton: false,
+        showSqlActions: false,
         resolveMetadataLinks: false,
         customStyle: expect.objectContaining({
           backgroundColor: "transparent",
@@ -299,8 +300,8 @@ describe("SampleQuestions", () => {
       root.render(<SampleQuestions onQuestionClick={onQuestionClick} />);
     });
 
-    const markdownCard = Array.from(container.querySelectorAll("[role='button']")).find((element) =>
-      element.textContent?.includes("Explain what the following query does.")
+    const markdownCard = Array.from(container.querySelectorAll("button")).find((element) =>
+      element.getAttribute("aria-label")?.includes("Explain what the following query does")
     );
 
     expect(markdownCard).toBeTruthy();

--- a/src/components/chat/view/sample-questions.tsx
+++ b/src/components/chat/view/sample-questions.tsx
@@ -281,10 +281,7 @@ export function SampleQuestions({
       </div>
       <div className="space-y-2">
         {questions.map((question) => (
-          <div
-            key={question.text}
-            className={questionCardClassName}
-          >
+          <div key={question.text} className={questionCardClassName}>
             <button
               type="button"
               aria-label={question.text}
@@ -318,7 +315,12 @@ export function SampleQuestions({
 
   return (
     <SampleQuestionsShell greeting={greeting}>
-      <div className={cn("mx-auto mt-6 grid min-h-0 flex-1 w-full max-w-5xl gap-0", DESKTOP_GRID_CLASS_NAME)}>
+      <div
+        className={cn(
+          "mx-auto mt-6 grid min-h-0 flex-1 w-full max-w-5xl gap-0",
+          DESKTOP_GRID_CLASS_NAME
+        )}
+      >
         <nav className="hidden self-start md:block">
           <div className="space-y-1">
             {filteredGroups.map(([group, { icon }]) => {

--- a/src/components/chat/view/sample-questions.tsx
+++ b/src/components/chat/view/sample-questions.tsx
@@ -2,10 +2,11 @@
 
 import { AppLogo } from "@/components/app-logo";
 import { useAgentCommands } from "@/components/chat/agent-command-context";
+import { MessageMarkdown } from "@/components/chat/message/message-markdown";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
-import { Activity, BarChart, Code2, Globe, Lightbulb, Zap } from "lucide-react";
+import { Activity, BarChart, Brain, Code, Code2, Globe, Lightbulb, Zap } from "lucide-react";
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 export type Question = { text: string; autoRun?: boolean; requiredSkillId?: string };
@@ -69,16 +70,35 @@ export const DEFAULT_CHAT_QUESTION_GROUPS: Record<string, QuestionGroupData> = {
       },
     ],
   },
-  General: {
-    icon: <Lightbulb className="h-4 w-4 text-yellow-500" />,
+  "SQL Explanation": {
+    icon: <Brain className="h-4 w-4 text-yellow-500" />,
     questions: [
-      { text: "What are the best practices for partitioning?", autoRun: true },
+      {
+        text: `Explain what the following query does. And show the exeuction plan in flowchart.
+\`\`\`sql
+SELECT toStartOfDay(event_time), count()
+FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - INTERVAL 1 hour
+AND query_kind = 'Select'
+GROUP BY 1
+\`\`\``,
+        autoRun: true,
+      },
+    ],
+  },
+  "Source Code Inspection": {
+    icon: <Code className="h-4 w-4 text-green-500" />,
+    questions: [
       {
         text: "How does async_insert work from the source code? Will data be lost if the server is restarted when this setting is enabled?",
         autoRun: true,
         requiredSkillId: "source-code-inspection",
       },
     ],
+  },
+  Others: {
+    icon: <Lightbulb className="h-4 w-4 text-yellow-500" />,
+    questions: [{ text: "What are the best practices for partitioning?", autoRun: true }],
   },
 };
 
@@ -234,7 +254,11 @@ export function SampleQuestions({
   }
 
   const questionCardClassName =
-    "group relative w-full rounded-xl border border-border/50 bg-card px-3 py-3 text-left shadow-sm transition-colors duration-150 hover:border-primary/40 hover:bg-accent/60 hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40 focus-visible:ring-offset-0 active:bg-accent/70";
+    "group relative w-full cursor-pointer rounded-xl border border-border/50 bg-card px-3 py-3 text-left shadow-sm transition-colors duration-150 hover:border-primary/40 hover:bg-accent/60 hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40 focus-visible:ring-offset-0 active:bg-accent/70";
+
+  const handleQuestionActivate = (question: Question) => {
+    onQuestionClick(question);
+  };
 
   const renderGroupSection = (
     [group, { icon, questions }]: readonly [string, QuestionGroupData],
@@ -259,16 +283,28 @@ export function SampleQuestions({
       </div>
       <div className="space-y-2">
         {questions.map((question) => (
-          <button
+          <div
             key={question.text}
-            type="button"
+            role="button"
+            tabIndex={0}
             className={questionCardClassName}
-            onClick={() => onQuestionClick(question)}
+            onClick={() => handleQuestionActivate(question)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                handleQuestionActivate(question);
+              }
+            }}
           >
-            <span className="block break-words [overflow-wrap:anywhere] text-sm font-medium leading-6 text-foreground transition-colors group-hover:text-primary group-focus-visible:text-primary">
-              {question.text}
-            </span>
-          </button>
+            <div className="pointer-events-none break-words text-sm leading-6 text-foreground transition-colors group-hover:text-primary group-focus-visible:text-primary [&_.prose]:text-inherit [&_.prose]:leading-6 [&_.prose]:max-w-none [&_.prose]:text-sm [&_.prose_code]:text-inherit [&_.prose_p]:mb-0 [&_.prose_pre]:my-2 [&_.prose_ul]:mb-0 [&_.prose_ol]:mb-0">
+              <MessageMarkdown
+                text={question.text}
+                showExecuteButton={false}
+                resolveMetadataLinks={false}
+                customStyle={{ backgroundColor: "transparent" }}
+              />
+            </div>
+          </div>
         ))}
       </div>
     </section>
@@ -286,7 +322,7 @@ export function SampleQuestions({
 
   return (
     <SampleQuestionsShell greeting={greeting}>
-      <div className="mx-auto mt-6 grid min-h-0 flex-1 w-full max-w-5xl gap-0 md:grid-cols-[200px_minmax(0,1fr)]">
+      <div className="mx-auto mt-6 grid min-h-0 flex-1 w-full max-w-5xl gap-0 md:grid-cols-[240px_minmax(0,1fr)]">
         <nav className="hidden self-start md:block">
           <div className="space-y-1">
             {filteredGroups.map(([group, { icon }]) => {
@@ -323,7 +359,9 @@ export function SampleQuestions({
                   >
                     {icon}
                   </span>
-                  <span className="truncate font-medium">{group}</span>
+                  <span className="min-w-0 whitespace-normal break-words font-medium leading-5">
+                    {group}
+                  </span>
                 </button>
               );
             })}

--- a/src/components/chat/view/sample-questions.tsx
+++ b/src/components/chat/view/sample-questions.tsx
@@ -74,7 +74,7 @@ export const DEFAULT_CHAT_QUESTION_GROUPS: Record<string, QuestionGroupData> = {
     icon: <Brain className="h-4 w-4 text-yellow-500" />,
     questions: [
       {
-        text: `Explain what the following query does. And show the exeuction plan in flowchart.
+        text: `Explain what the following query does, and show the execution plan in a flowchart.
 \`\`\`sql
 SELECT toStartOfDay(event_time), count()
 FROM system.query_log
@@ -110,6 +110,8 @@ const GREETINGS = [
   "Hello and welcome! Let's explore your ClickHouse cluster and data!",
 ];
 
+const DESKTOP_GRID_CLASS_NAME = "md:grid-cols-[240px_minmax(0,1fr)]";
+
 function SampleQuestionsShell({ greeting, children }: { greeting: string; children: ReactNode }) {
   return (
     <div
@@ -129,7 +131,7 @@ function SampleQuestionsShell({ greeting, children }: { greeting: string; childr
 
 function LoadingSkeleton() {
   return (
-    <div className="mx-auto mt-6 grid w-full max-w-5xl gap-6 md:grid-cols-[200px_minmax(0,1fr)]">
+    <div className={cn("mx-auto mt-6 grid w-full max-w-5xl gap-6", DESKTOP_GRID_CLASS_NAME)}>
       <div className="hidden flex-col gap-2 md:flex">
         {[1, 2, 3, 4].map((i) => (
           <Skeleton key={i} className="h-8 w-36 rounded-lg" />
@@ -254,11 +256,7 @@ export function SampleQuestions({
   }
 
   const questionCardClassName =
-    "group relative w-full cursor-pointer rounded-xl border border-border/50 bg-card px-3 py-3 text-left shadow-sm transition-colors duration-150 hover:border-primary/40 hover:bg-accent/60 hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40 focus-visible:ring-offset-0 active:bg-accent/70";
-
-  const handleQuestionActivate = (question: Question) => {
-    onQuestionClick(question);
-  };
+    "group relative w-full rounded-xl border border-border/50 bg-card px-3 py-3 text-left shadow-sm transition-colors duration-150 hover:border-primary/40 hover:bg-accent/60 hover:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)] focus-within:ring-1 focus-within:ring-primary/40 focus-within:ring-offset-0 active:bg-accent/70";
 
   const renderGroupSection = (
     [group, { icon, questions }]: readonly [string, QuestionGroupData],
@@ -285,21 +283,19 @@ export function SampleQuestions({
         {questions.map((question) => (
           <div
             key={question.text}
-            role="button"
-            tabIndex={0}
             className={questionCardClassName}
-            onClick={() => handleQuestionActivate(question)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" || event.key === " ") {
-                event.preventDefault();
-                handleQuestionActivate(question);
-              }
-            }}
           >
+            <button
+              type="button"
+              aria-label={question.text}
+              className="absolute inset-0 z-10 rounded-xl focus-visible:outline-none"
+              onClick={() => onQuestionClick(question)}
+            />
             <div className="pointer-events-none break-words text-sm leading-6 text-foreground transition-colors group-hover:text-primary group-focus-visible:text-primary [&_.prose]:text-inherit [&_.prose]:leading-6 [&_.prose]:max-w-none [&_.prose]:text-sm [&_.prose_code]:text-inherit [&_.prose_p]:mb-0 [&_.prose_pre]:my-2 [&_.prose_ul]:mb-0 [&_.prose_ol]:mb-0">
               <MessageMarkdown
                 text={question.text}
                 showExecuteButton={false}
+                showSqlActions={false}
                 resolveMetadataLinks={false}
                 customStyle={{ backgroundColor: "transparent" }}
               />
@@ -322,7 +318,7 @@ export function SampleQuestions({
 
   return (
     <SampleQuestionsShell greeting={greeting}>
-      <div className="mx-auto mt-6 grid min-h-0 flex-1 w-full max-w-5xl gap-0 md:grid-cols-[240px_minmax(0,1fr)]">
+      <div className={cn("mx-auto mt-6 grid min-h-0 flex-1 w-full max-w-5xl gap-0", DESKTOP_GRID_CLASS_NAME)}>
         <nav className="hidden self-start md:block">
           <div className="space-y-1">
             {filteredGroups.map(([group, { icon }]) => {


### PR DESCRIPTION
## Summary
- render sample question cards through MessageMarkdown
- preserve fenced SQL blocks and keep the SQL preview background transparent
- allow long sidebar group titles to wrap instead of truncating

## Validation
- npm test -- src/components/chat/view/sample-questions.test.tsx
- npm run typecheck
- npm run build (fails in external/number-flow due missing @vitest/browser/providers/playwright type definitions in the workspace build)