### PR TITLE
[codex] Significantly improve chat response rendering performance

### DIFF
--- a/src/components/chat/input/chat-input.tsx
+++ b/src/components/chat/input/chat-input.tsx
@@ -104,6 +104,20 @@ function useChatInputRuntime() {
   return React.useContext(ChatInputRuntimeContext);
 }
 
+interface ChatInputEditorElementProps {
+  editorRef: React.Ref<HTMLDivElement>;
+  isResizable: boolean;
+  style?: React.CSSProperties;
+  onCompositionStart: React.CompositionEventHandler<HTMLDivElement>;
+  onCompositionEnd: React.CompositionEventHandler<HTMLDivElement>;
+  onInput: React.FormEventHandler<HTMLDivElement>;
+  onKeyDown: React.KeyboardEventHandler<HTMLDivElement>;
+  onKeyUp: React.KeyboardEventHandler<HTMLDivElement>;
+  onMouseUp: React.MouseEventHandler<HTMLDivElement>;
+  onFocus: React.FocusEventHandler<HTMLDivElement>;
+  onPaste: React.ClipboardEventHandler<HTMLDivElement>;
+}
+
 type TokenSegment =
   | {
       kind: "command";
@@ -584,7 +598,6 @@ const ChatInputContent = React.memo(
     const editorRef = React.useRef<HTMLDivElement>(null);
     const editorScrollRef = React.useRef<HTMLDivElement>(null);
     const fileInputRef = React.useRef<HTMLInputElement>(null);
-    const attachmentTriggerRef = React.useRef<HTMLButtonElement>(null);
     const suggestionRef = React.useRef<ChatInputSuggestionsType>(null);
     const commandRef = React.useRef<ChatInputCommandsType>(null);
     const dragStateRef = React.useRef<{
@@ -1593,17 +1606,9 @@ const ChatInputContent = React.memo(
                     </div>
                   )}
 
-                  <div
-                    ref={editorRef}
-                    role="textbox"
-                    aria-multiline="true"
-                    aria-label="Chat input. Press Enter for new line, use Cmd/Ctrl + Enter to send. Use @ to open table or setting suggestions, / for commands."
-                    contentEditable
-                    suppressContentEditableWarning
-                    className={cn(
-                      "w-full bg-transparent py-3 pl-3 pr-10 text-sm outline-none whitespace-pre-wrap break-words",
-                      isResizable ? "h-full min-h-0 flex-1 max-h-none" : "min-h-[80px]"
-                    )}
+                  <ChatInputEditorElement
+                    editorRef={editorRef}
+                    isResizable={isResizable}
                     style={isResizable ? { minHeight: `${EDITOR_MIN_HEIGHT}px` } : undefined}
                     onCompositionStart={handleCompositionStart}
                     onCompositionEnd={handleCompositionEnd}
@@ -1613,7 +1618,7 @@ const ChatInputContent = React.memo(
                     onMouseUp={syncSelectionState}
                     onFocus={syncSelectionState}
                     onPaste={handlePaste}
-                  ></div>
+                  />
                 </div>
               </div>
               {attachments.length > 0 && (
@@ -1654,27 +1659,11 @@ const ChatInputContent = React.memo(
                   className="hidden"
                   onChange={handleFileInputChange}
                 />
-                <ChatInputRuntimeDomState
-                  editorRef={editorRef}
-                  attachmentTriggerRef={attachmentTriggerRef}
-                />
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <Button
-                      ref={attachmentTriggerRef}
-                      type="button"
-                      size="icon"
-                      variant="ghost"
-                      className="h-6 w-6 rounded-md"
-                      title={
-                        selectedModelSupportsImages
-                          ? "Add attachment"
-                          : "Select a vision-capable model to add images"
-                      }
-                      aria-label="Add attachment"
-                    >
-                      <Plus className="h-3.5 w-3.5" />
-                    </Button>
+                    <ChatInputAttachmentTrigger
+                      selectedModelSupportsImages={selectedModelSupportsImages}
+                    />
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="start" side="top" className="w-32 p-1">
                     <DropdownMenuItem
@@ -1706,26 +1695,76 @@ const ChatInputContent = React.memo(
 
 ChatInputContent.displayName = "ChatInputContent";
 
-const ChatInputRuntimeDomState = React.memo(function ChatInputRuntimeDomState({
+const ChatInputEditorElement = React.memo(function ChatInputEditorElement({
   editorRef,
-  attachmentTriggerRef,
-}: {
-  editorRef: React.RefObject<HTMLDivElement | null>;
-  attachmentTriggerRef: React.RefObject<HTMLButtonElement | null>;
-}) {
+  isResizable,
+  style,
+  onCompositionStart,
+  onCompositionEnd,
+  onInput,
+  onKeyDown,
+  onKeyUp,
+  onMouseUp,
+  onFocus,
+  onPaste,
+}: ChatInputEditorElementProps) {
   const { isRunning } = useChatInputRuntime();
 
-  React.useLayoutEffect(() => {
-    if (editorRef.current) {
-      editorRef.current.contentEditable = String(!isRunning);
-    }
-    if (attachmentTriggerRef.current) {
-      attachmentTriggerRef.current.disabled = isRunning;
-    }
-  }, [attachmentTriggerRef, editorRef, isRunning]);
-
-  return null;
+  return (
+    <div
+      ref={editorRef}
+      role="textbox"
+      aria-multiline="true"
+      aria-label="Chat input. Press Enter for new line, use Cmd/Ctrl + Enter to send. Use @ to open table or setting suggestions, / for commands."
+      contentEditable={!isRunning}
+      suppressContentEditableWarning
+      className={cn(
+        "w-full bg-transparent py-3 pl-3 pr-10 text-sm outline-none whitespace-pre-wrap break-words",
+        isResizable ? "h-full min-h-0 flex-1 max-h-none" : "min-h-[80px]"
+      )}
+      style={style}
+      onCompositionStart={onCompositionStart}
+      onCompositionEnd={onCompositionEnd}
+      onInput={onInput}
+      onKeyDown={onKeyDown}
+      onKeyUp={onKeyUp}
+      onMouseUp={onMouseUp}
+      onFocus={onFocus}
+      onPaste={onPaste}
+    />
+  );
 });
+
+const ChatInputAttachmentTrigger = React.memo(
+  React.forwardRef<
+    HTMLButtonElement,
+    React.ComponentPropsWithoutRef<typeof Button> & { selectedModelSupportsImages: boolean }
+  >(function ChatInputAttachmentTrigger({ selectedModelSupportsImages, className, ...props }, ref) {
+    const { isRunning } = useChatInputRuntime();
+
+    return (
+      <Button
+        {...props}
+        ref={ref}
+        type="button"
+        size="icon"
+        variant="ghost"
+        className={cn("h-6 w-6 rounded-md", className)}
+        title={
+          selectedModelSupportsImages
+            ? "Add attachment"
+            : "Select a vision-capable model to add images"
+        }
+        aria-label="Add attachment"
+        disabled={isRunning}
+      >
+        <Plus className="h-3.5 w-3.5" />
+      </Button>
+    );
+  })
+);
+
+ChatInputAttachmentTrigger.displayName = "ChatInputAttachmentTrigger";
 
 const ChatInputFooterStatus = React.memo(function ChatInputFooterStatus({
   onNewChat,

--- a/src/components/chat/input/chat-input.tsx
+++ b/src/components/chat/input/chat-input.tsx
@@ -81,8 +81,27 @@ export interface ChatInputHandle {
   focus: () => void;
 }
 
-interface ChatInputContentProps extends ChatInputProps {
+interface ChatInputContentProps {
+  onSubmit: ChatInputProps["onSubmit"];
+  onNewChat?: ChatInputProps["onNewChat"];
+  externalInput?: ChatInputProps["externalInput"];
   forwardedRef: React.ForwardedRef<ChatInputHandle>;
+}
+
+interface ChatInputRuntimeValue {
+  isRunning: boolean;
+  hasMessages: boolean;
+  tokenUsage?: LanguageModelUsage;
+  onStop?: () => void;
+}
+
+const ChatInputRuntimeContext = React.createContext<ChatInputRuntimeValue>({
+  isRunning: false,
+  hasMessages: false,
+});
+
+function useChatInputRuntime() {
+  return React.useContext(ChatInputRuntimeContext);
 }
 
 type TokenSegment =
@@ -557,10 +576,6 @@ function buildRenderSegments(
 const ChatInputContent = React.memo(
   function ChatInputContent({
     onSubmit,
-    onStop,
-    isRunning,
-    hasMessages = false,
-    tokenUsage,
     onNewChat,
     externalInput,
     forwardedRef,
@@ -569,6 +584,7 @@ const ChatInputContent = React.memo(
     const editorRef = React.useRef<HTMLDivElement>(null);
     const editorScrollRef = React.useRef<HTMLDivElement>(null);
     const fileInputRef = React.useRef<HTMLInputElement>(null);
+    const attachmentTriggerRef = React.useRef<HTMLButtonElement>(null);
     const suggestionRef = React.useRef<ChatInputSuggestionsType>(null);
     const commandRef = React.useRef<ChatInputCommandsType>(null);
     const dragStateRef = React.useRef<{
@@ -905,10 +921,6 @@ const ChatInputContent = React.memo(
       onNewChat?.();
       editorRef.current?.focus();
     }, [onNewChat]);
-
-    const handleStopChat = React.useCallback(() => {
-      onStop?.();
-    }, [onStop]);
 
     React.useEffect(() => {
       editorRef.current?.focus();
@@ -1586,7 +1598,7 @@ const ChatInputContent = React.memo(
                     role="textbox"
                     aria-multiline="true"
                     aria-label="Chat input. Press Enter for new line, use Cmd/Ctrl + Enter to send. Use @ to open table or setting suggestions, / for commands."
-                    contentEditable={!isRunning}
+                    contentEditable
                     suppressContentEditableWarning
                     className={cn(
                       "w-full bg-transparent py-3 pl-3 pr-10 text-sm outline-none whitespace-pre-wrap break-words",
@@ -1642,9 +1654,14 @@ const ChatInputContent = React.memo(
                   className="hidden"
                   onChange={handleFileInputChange}
                 />
+                <ChatInputRuntimeDomState
+                  editorRef={editorRef}
+                  attachmentTriggerRef={attachmentTriggerRef}
+                />
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button
+                      ref={attachmentTriggerRef}
                       type="button"
                       size="icon"
                       variant="ghost"
@@ -1655,7 +1672,6 @@ const ChatInputContent = React.memo(
                           : "Select a vision-capable model to add images"
                       }
                       aria-label="Add attachment"
-                      disabled={isRunning}
                     >
                       <Plus className="h-3.5 w-3.5" />
                     </Button>
@@ -1672,47 +1688,9 @@ const ChatInputContent = React.memo(
                   </DropdownMenuContent>
                 </DropdownMenu>
                 <ModelSelector className="bg-muted" />
-                {hasMessages && (
-                  <>
-                    {onNewChat && (
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        className="h-6 gap-1 px-2 text-xs"
-                        title="Start New Chat"
-                        onClick={handleNewChat}
-                      >
-                        <MessageSquarePlus className="h-3 w-3" />
-                        New
-                      </Button>
-                    )}
-                    {tokenUsage && <ChatTokenStatus usage={tokenUsage} />}
-                  </>
-                )}
+                <ChatInputFooterStatus onNewChat={onNewChat ? handleNewChat : undefined} />
               </div>
-              {isRunning ? (
-                <Button
-                  onClick={handleStopChat}
-                  size="icon"
-                  variant="destructive"
-                  className="h-6 w-6 rounded-md shadow-sm"
-                  aria-label="Stop generating"
-                  title="Stop generating"
-                >
-                  <Square className="h-3.5 w-3.5" />
-                </Button>
-              ) : (
-                <Button
-                  onClick={handleSubmit}
-                  disabled={!canSubmit}
-                  size="icon"
-                  className="h-6 w-6 rounded-md shadow-sm"
-                  aria-label="Send message"
-                  title={`Send (${typeof navigator !== "undefined" && navigator.platform.includes("Mac") ? "Cmd" : "Ctrl"}+Enter)`}
-                >
-                  <Send className="h-3.5 w-3.5" />
-                </Button>
-              )}
+              <ChatInputSubmitButton canSubmit={canSubmit} onSubmit={handleSubmit} />
             </div>
           </div>
         </div>
@@ -1721,10 +1699,6 @@ const ChatInputContent = React.memo(
   },
   (prevProps, nextProps) =>
     prevProps.onSubmit === nextProps.onSubmit &&
-    prevProps.onStop === nextProps.onStop &&
-    prevProps.isRunning === nextProps.isRunning &&
-    prevProps.hasMessages === nextProps.hasMessages &&
-    prevProps.tokenUsage === nextProps.tokenUsage &&
     prevProps.onNewChat === nextProps.onNewChat &&
     prevProps.externalInput === nextProps.externalInput &&
     prevProps.forwardedRef === nextProps.forwardedRef
@@ -1732,10 +1706,114 @@ const ChatInputContent = React.memo(
 
 ChatInputContent.displayName = "ChatInputContent";
 
-export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
-  function ChatInput(props, ref) {
-    return <ChatInputContent {...props} forwardedRef={ref} />;
+const ChatInputRuntimeDomState = React.memo(function ChatInputRuntimeDomState({
+  editorRef,
+  attachmentTriggerRef,
+}: {
+  editorRef: React.RefObject<HTMLDivElement | null>;
+  attachmentTriggerRef: React.RefObject<HTMLButtonElement | null>;
+}) {
+  const { isRunning } = useChatInputRuntime();
+
+  React.useLayoutEffect(() => {
+    if (editorRef.current) {
+      editorRef.current.contentEditable = String(!isRunning);
+    }
+    if (attachmentTriggerRef.current) {
+      attachmentTriggerRef.current.disabled = isRunning;
+    }
+  }, [attachmentTriggerRef, editorRef, isRunning]);
+
+  return null;
+});
+
+const ChatInputFooterStatus = React.memo(function ChatInputFooterStatus({
+  onNewChat,
+}: {
+  onNewChat?: () => void;
+}) {
+  const { hasMessages, tokenUsage } = useChatInputRuntime();
+
+  if (!hasMessages) {
+    return null;
   }
-);
+
+  return (
+    <>
+      {onNewChat && (
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-6 gap-1 px-2 text-xs"
+          title="Start New Chat"
+          onClick={onNewChat}
+        >
+          <MessageSquarePlus className="h-3 w-3" />
+          New
+        </Button>
+      )}
+      {tokenUsage && <ChatTokenStatus usage={tokenUsage} />}
+    </>
+  );
+});
+
+const ChatInputSubmitButton = React.memo(function ChatInputSubmitButton({
+  canSubmit,
+  onSubmit,
+}: {
+  canSubmit: boolean;
+  onSubmit: () => void;
+}) {
+  const { isRunning, onStop } = useChatInputRuntime();
+
+  if (isRunning) {
+    return (
+      <Button
+        onClick={onStop}
+        size="icon"
+        variant="destructive"
+        className="h-6 w-6 rounded-md shadow-sm"
+        aria-label="Stop generating"
+        title="Stop generating"
+      >
+        <Square className="h-3.5 w-3.5" />
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      onClick={onSubmit}
+      disabled={!canSubmit}
+      size="icon"
+      className="h-6 w-6 rounded-md shadow-sm"
+      aria-label="Send message"
+      title={`Send (${typeof navigator !== "undefined" && navigator.platform.includes("Mac") ? "Cmd" : "Ctrl"}+Enter)`}
+    >
+      <Send className="h-3.5 w-3.5" />
+    </Button>
+  );
+});
+
+export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput(
+  { onSubmit, onStop, isRunning, hasMessages = false, tokenUsage, onNewChat, externalInput },
+  ref
+) {
+  const runtimeValue = React.useMemo(
+    () => ({ isRunning, hasMessages, tokenUsage, onStop }),
+    [hasMessages, isRunning, onStop, tokenUsage]
+  );
+
+  return (
+    <ChatInputRuntimeContext.Provider value={runtimeValue}>
+      <ChatInputContent
+        onSubmit={onSubmit}
+        onNewChat={onNewChat}
+        externalInput={externalInput}
+        forwardedRef={ref}
+      />
+    </ChatInputRuntimeContext.Provider>
+  );
+});
 
 ChatInput.displayName = "ChatInput";

--- a/src/components/chat/input/chat-input.tsx
+++ b/src/components/chat/input/chat-input.tsx
@@ -81,6 +81,10 @@ export interface ChatInputHandle {
   focus: () => void;
 }
 
+interface ChatInputContentProps extends ChatInputProps {
+  forwardedRef: React.ForwardedRef<ChatInputHandle>;
+}
+
 type TokenSegment =
   | {
       kind: "command";
@@ -550,11 +554,17 @@ function buildRenderSegments(
   return segments.filter((segment) => segment.kind !== "text" || segment.text.length > 0);
 }
 
-export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
-  (
-    { onSubmit, onStop, isRunning, hasMessages = false, tokenUsage, onNewChat, externalInput },
-    ref
-  ) => {
+const ChatInputContent = React.memo(
+  function ChatInputContent({
+    onSubmit,
+    onStop,
+    isRunning,
+    hasMessages = false,
+    tokenUsage,
+    onNewChat,
+    externalInput,
+    forwardedRef,
+  }: ChatInputContentProps) {
     const containerRef = React.useRef<HTMLDivElement>(null);
     const editorRef = React.useRef<HTMLDivElement>(null);
     const editorScrollRef = React.useRef<HTMLDivElement>(null);
@@ -1492,7 +1502,7 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
     );
 
     React.useImperativeHandle(
-      ref,
+      forwardedRef,
       () => ({
         getInput: () => input,
         focus: () => {
@@ -1708,6 +1718,23 @@ export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
         </div>
       </div>
     );
+  },
+  (prevProps, nextProps) =>
+    prevProps.onSubmit === nextProps.onSubmit &&
+    prevProps.onStop === nextProps.onStop &&
+    prevProps.isRunning === nextProps.isRunning &&
+    prevProps.hasMessages === nextProps.hasMessages &&
+    prevProps.tokenUsage === nextProps.tokenUsage &&
+    prevProps.onNewChat === nextProps.onNewChat &&
+    prevProps.externalInput === nextProps.externalInput &&
+    prevProps.forwardedRef === nextProps.forwardedRef
+);
+
+ChatInputContent.displayName = "ChatInputContent";
+
+export const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(
+  function ChatInput(props, ref) {
+    return <ChatInputContent {...props} forwardedRef={ref} />;
   }
 );
 

--- a/src/components/chat/input/model-selector-impl.tsx
+++ b/src/components/chat/input/model-selector-impl.tsx
@@ -15,7 +15,7 @@ import { resolveModelSupportsImageInput, type ModelProps } from "@/lib/ai/llm/ll
 import { PROVIDER_GITHUB_COPILOT } from "@/lib/ai/llm/provider-ids";
 import { cn } from "@/lib/utils";
 import { Check, ChevronsUpDown, Layers, Settings2 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { showSettingsDialog } from "../../settings/settings-dialog";
@@ -159,7 +159,6 @@ export function ModelSelectorImpl({
   showConfigureAction = true,
 }: ModelSelectorImplProps = {}) {
   const [open, setOpen] = useState(false);
-  const leftPanelRef = useRef<HTMLDivElement | null>(null);
   const {
     availableModels,
     selectedModel,
@@ -176,7 +175,6 @@ export function ModelSelectorImpl({
     activeModel ? `${activeModel.provider} ${activeModel.modelId}` : undefined
   );
   const [groupByProvider, setGroupByProvider] = useState(false);
-  const [detailPaneHeight, setDetailPaneHeight] = useState<number | null>(null);
 
   // Filter out "System (Auto)" if auto-select is not available
   const filteredModels = useMemo(() => {
@@ -298,26 +296,6 @@ export function ModelSelectorImpl({
     [highlightedModel]
   );
 
-  useEffect(() => {
-    if (!open) {
-      setDetailPaneHeight(null);
-      return;
-    }
-
-    const node = leftPanelRef.current;
-    if (!node) {
-      return;
-    }
-
-    const frame = window.requestAnimationFrame(() => {
-      setDetailPaneHeight(node.offsetHeight || null);
-    });
-
-    return () => {
-      window.cancelAnimationFrame(frame);
-    };
-  }, [open]);
-
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -361,11 +339,10 @@ export function ModelSelectorImpl({
           }}
         >
           <div
-            ref={leftPanelRef}
             data-panel="left"
             className={cn(
-              "flex max-h-[300px] w-[300px] flex-col overflow-hidden rounded-sm border bg-popover shadow-md",
-              highlightedModel?.description ? "rounded-r-none" : ""
+              "flex h-[250px] min-h-[250px] max-h-[250px] w-[300px] flex-col overflow-hidden rounded-sm border bg-popover shadow-md",
+              highlightedModelFields.length > 0 ? "rounded-r-none" : ""
             )}
           >
             <CommandInput
@@ -389,7 +366,7 @@ export function ModelSelectorImpl({
             )}
             <CommandList
               id="model-list"
-              className="flex-1 overflow-y-auto [&_[cmdk-list-sizer]]:max-h-none"
+              className="min-h-0 flex-1 overflow-y-auto [&_[cmdk-list-sizer]]:max-h-none"
             >
               <CommandEmpty className="h-[32px] py-2 text-center text-[10px]">
                 No model found.
@@ -454,8 +431,7 @@ export function ModelSelectorImpl({
           {highlightedModelFields.length > 0 && (
             <div
               data-panel="right"
-              className="w-[250px] overflow-y-auto rounded-sm rounded-l-none border border-l-0 bg-popover p-2 text-[10px] text-popover-foreground shadow-md"
-              style={detailPaneHeight ? { height: `${detailPaneHeight}px` } : undefined}
+              className="h-[250px] min-h-[250px] max-h-[250px] w-[250px] overflow-y-auto rounded-sm rounded-l-none border border-l-0 bg-popover p-2 text-[10px] text-popover-foreground shadow-md"
             >
               <div className="flex flex-col gap-3">
                 {highlightedModelFields.map((field) => (

--- a/src/components/chat/message/chat-message.tsx
+++ b/src/components/chat/message/chat-message.tsx
@@ -267,7 +267,10 @@ const ChatMessagePart = memo(
       );
     }
     if (prevProps.part.type === "reasoning" && nextProps.part.type === "reasoning") {
-      return prevProps.part.text === nextProps.part.text;
+      return (
+        prevProps.part.text === nextProps.part.text &&
+        (prevProps.part as { state?: string }).state === (nextProps.part as { state?: string }).state
+      );
     }
 
     // Tool parts can change rendering while running, so include isRunning in comparison.

--- a/src/components/chat/message/chat-message.tsx
+++ b/src/components/chat/message/chat-message.tsx
@@ -269,7 +269,8 @@ const ChatMessagePart = memo(
     if (prevProps.part.type === "reasoning" && nextProps.part.type === "reasoning") {
       return (
         prevProps.part.text === nextProps.part.text &&
-        (prevProps.part as { state?: string }).state === (nextProps.part as { state?: string }).state
+        (prevProps.part as { state?: string }).state ===
+          (nextProps.part as { state?: string }).state
       );
     }
 

--- a/src/components/chat/message/message-markdown.tsx
+++ b/src/components/chat/message/message-markdown.tsx
@@ -49,6 +49,7 @@ interface MessageMarkdownProps {
   showExecuteButton?: boolean;
   showSqlActions?: boolean;
   resolveMetadataLinks?: boolean;
+  renderLinks?: boolean;
   /**
    * Allow expandable SQL blocks inside markdown. Default: false.
    */
@@ -101,6 +102,7 @@ export const MessageMarkdown = memo(function MessageMarkdown({
   showExecuteButton = true,
   showSqlActions = true,
   resolveMetadataLinks = true,
+  renderLinks = true,
   expandable = false,
 }: MessageMarkdownProps) {
   const { connection } = useConnection();
@@ -291,6 +293,10 @@ export const MessageMarkdown = memo(function MessageMarkdown({
         return <pre {...props}>{children}</pre>;
       },
       a: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
+        if (!renderLinks) {
+          return <span>{children}</span>;
+        }
+
         if (href?.startsWith("skill://")) {
           const skillId = href.replace("skill://", "");
           const trigger = (
@@ -449,6 +455,7 @@ export const MessageMarkdown = memo(function MessageMarkdown({
       codeBlockStyle,
       customStyle,
       expandable,
+      renderLinks,
       resolveMetadataLinks,
       showExecuteButton,
       showSqlActions,

--- a/src/components/chat/message/message-reasoning.tsx
+++ b/src/components/chat/message/message-reasoning.tsx
@@ -16,14 +16,22 @@ export const MessageReasoning = memo(function MessageReasoning({
     return null;
   }
 
+  const isStreaming = part.state !== undefined && part.state !== "done";
+  if (isStreaming) {
+    return (
+      <div className="whitespace-pre-wrap break-words text-[10px] leading-[1.45]">{part.text}</div>
+    );
+  }
+
   return (
-    <div className="text-[12px] [&_.prose]:text-[12px] [&_.prose_*]:text-[12px]">
+    <div className="text-[10px] [&_.prose]:text-[10px] [&_.prose_*]:text-[10px]">
       <MessageMarkdown
         text={part.text}
         customStyle={REASONING_MARKDOWN_STYLE}
         showExecuteButton={false}
         showSqlActions={false}
         resolveMetadataLinks={false}
+        renderLinks={false}
       />
     </div>
   );

--- a/src/components/chat/message/message-reasoning.tsx
+++ b/src/components/chat/message/message-reasoning.tsx
@@ -1,22 +1,30 @@
 import type { AppUIMessage } from "@/lib/ai/ai-types";
 import { memo } from "react";
-import { CollapsiblePart } from "./collapsible-part";
+import { MessageMarkdown } from "./message-markdown";
+
+const REASONING_MARKDOWN_STYLE = { fontSize: "10px", lineHeight: "1.45" } as const;
 
 /**
- * Render reasoning part with collapsible display
+ * Render reasoning as assistant text instead of a tool part.
  */
 export const MessageReasoning = memo(function MessageReasoning({
   part,
 }: {
   part: AppUIMessage["parts"][0] & { state?: string; text: string };
 }) {
+  if (!part.text.trim()) {
+    return null;
+  }
+
   return (
-    <CollapsiblePart toolName="Reasoning" state={part.state}>
-      <div className="mt-1 max-h-[300px] overflow-auto text-[10px] text-muted-foreground">
-        <pre className="bg-muted/30 overflow-x-auto shadow-sm leading-tight whitespace-pre-wrap break-words">
-          {part.text}
-        </pre>
-      </div>
-    </CollapsiblePart>
+    <div className="text-[12px] [&_.prose]:text-[12px] [&_.prose_*]:text-[12px]">
+      <MessageMarkdown
+        text={part.text}
+        customStyle={REASONING_MARKDOWN_STYLE}
+        showExecuteButton={false}
+        showSqlActions={false}
+        resolveMetadataLinks={false}
+      />
+    </div>
   );
 });

--- a/src/components/chat/view/chat-view.tsx
+++ b/src/components/chat/view/chat-view.tsx
@@ -38,7 +38,7 @@ function useStableCallback<Args extends unknown[], Return>(
 
   useLayoutEffect(() => {
     callbackRef.current = callback;
-  });
+  }, [callback]);
 
   return useCallback((...args: Args) => callbackRef.current(...args), []);
 }

--- a/src/components/chat/view/chat-view.tsx
+++ b/src/components/chat/view/chat-view.tsx
@@ -6,7 +6,15 @@ import { MentionContext } from "@/lib/ai/mention-context";
 import "@/lib/number-utils"; // Ensure formatTimeDiff is available
 
 import { useChat, type Chat } from "@ai-sdk/react";
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { v7 as uuidv7 } from "uuid";
 import { ChatActionProvider, type UserActionInput } from "../chat-action-context";
 import { ChatContext, getDatabaseContextFromConnection } from "../chat-context";
@@ -20,6 +28,20 @@ import { ChatMessageList } from "../message/chat-message-list";
 import { SampleQuestions } from "./sample-questions";
 import { type ChatComposerInput } from "./use-chat-panel";
 import { useTokenUsage } from "./use-token-usage";
+
+const CHAT_STREAM_UPDATE_THROTTLE_MS = 50;
+
+function useStableCallback<Args extends unknown[], Return>(
+  callback: (...args: Args) => Return
+): (...args: Args) => Return {
+  const callbackRef = useRef(callback);
+
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  return useCallback((...args: Args) => callbackRef.current(...args), []);
+}
 
 interface ChatViewProps {
   chat: Chat<AppUIMessage>;
@@ -53,7 +75,10 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
     }
     setPromptInput(undefined);
   }, [chat.id, externalInput]);
-  const { messages, error, sendMessage, status, stop } = useChat({ chat });
+  const { messages, error, sendMessage, status, stop } = useChat({
+    chat,
+    experimental_throttle: CHAT_STREAM_UPDATE_THROTTLE_MS,
+  });
 
   // Focus input when ChatView is mounted
   useEffect(() => {
@@ -69,7 +94,7 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
     onStreamingChange?.(status === "streaming" || status === "submitted");
   }, [status, onStreamingChange]);
 
-  const handleSubmit = useCallback(
+  const handleSubmit = useStableCallback(
     async ({ text, files = [] }: { text: string; files?: ChatInputImageAttachment[] }) => {
       if (!chat || (!text.trim() && files.length === 0)) return;
 
@@ -99,8 +124,7 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
           ...(mentionMetadata ? { mentionMetadata } : {}),
         },
       });
-    },
-    [chat, sendMessage, connection, currentDatabase]
+    }
   );
 
   // Expose send and getInput to parent component via imperative handle
@@ -122,7 +146,7 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
 
   const isRunning = status === "streaming" || status === "submitted";
 
-  const tokenUsage = useTokenUsage(messages as AppUIMessage[]);
+  const tokenUsage = useTokenUsage(isRunning ? undefined : (messages as AppUIMessage[]));
 
   const isEmpty = !messages || messages.length === 0;
 
@@ -130,7 +154,7 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
     return { text, mode: "replace", nonce: ++promptInputNonceRef.current };
   }, []);
 
-  const handleQuestionClick = useCallback(
+  const handleQuestionClick = useStableCallback(
     (question: { text: string; autoRun?: boolean }) => {
       if (question.autoRun) {
         // Auto-run: send the message immediately
@@ -139,36 +163,37 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
         // Default: set the input for user to review/edit
         setPromptInput(createPromptInput(question.text));
       }
-    },
-    [createPromptInput, handleSubmit]
+    }
   );
 
-  const handleUserAction = useCallback(
+  const handleUserAction = useStableCallback(
     (input: UserActionInput) => {
       if (input.autoRun) {
         handleSubmit({ text: input.text });
         return;
       }
       setPromptInput(createPromptInput(input.text));
-    },
-    [createPromptInput, handleSubmit]
+    }
   );
 
-  const handleStop = useCallback(() => {
+  const handleStop = useStableCallback(() => {
     ChatFactory.stopClientTools(chat.id);
     stop();
-  }, [chat.id, stop]);
+  });
+
+  const handleToolOutput = useStableCallback(
+    ({ tool, toolCallId, output }: { tool: string; toolCallId: string; output: unknown }) =>
+      chat.addToolOutput({
+        tool: tool as never,
+        toolCallId,
+        output: output as never,
+      })
+  );
 
   return (
     <ChatActionProvider
       onAction={handleUserAction}
-      onToolOutput={({ tool, toolCallId, output }) =>
-        chat.addToolOutput({
-          tool: tool as never,
-          toolCallId,
-          output: output as never,
-        })
-      }
+      onToolOutput={handleToolOutput}
       chatId={chat.id}
     >
       <div className="flex flex-col h-full bg-background overflow-hidden relative">

--- a/src/components/chat/view/chat-view.tsx
+++ b/src/components/chat/view/chat-view.tsx
@@ -154,27 +154,23 @@ export const ChatView = forwardRef<ChatViewHandle, ChatViewProps>(function ChatV
     return { text, mode: "replace", nonce: ++promptInputNonceRef.current };
   }, []);
 
-  const handleQuestionClick = useStableCallback(
-    (question: { text: string; autoRun?: boolean }) => {
-      if (question.autoRun) {
-        // Auto-run: send the message immediately
-        handleSubmit({ text: question.text });
-      } else {
-        // Default: set the input for user to review/edit
-        setPromptInput(createPromptInput(question.text));
-      }
+  const handleQuestionClick = useStableCallback((question: { text: string; autoRun?: boolean }) => {
+    if (question.autoRun) {
+      // Auto-run: send the message immediately
+      handleSubmit({ text: question.text });
+    } else {
+      // Default: set the input for user to review/edit
+      setPromptInput(createPromptInput(question.text));
     }
-  );
+  });
 
-  const handleUserAction = useStableCallback(
-    (input: UserActionInput) => {
-      if (input.autoRun) {
-        handleSubmit({ text: input.text });
-        return;
-      }
-      setPromptInput(createPromptInput(input.text));
+  const handleUserAction = useStableCallback((input: UserActionInput) => {
+    if (input.autoRun) {
+      handleSubmit({ text: input.text });
+      return;
     }
-  );
+    setPromptInput(createPromptInput(input.text));
+  });
 
   const handleStop = useStableCallback(() => {
     ChatFactory.stopClientTools(chat.id);


### PR DESCRIPTION
## Summary
- throttle chat stream updates to reduce response-time render churn
- memoize the heavy chat input implementation while preserving the forwardRef export shape
- render reasoning as small assistant markdown text instead of a tool-style row

## Validation
- npm run typecheck
- npm run lint
- npm run build