### PR TITLE
[codex] Collapse multiple consecutive tool call rendering

### DIFF
--- a/src/app/api/ai/agent/route.ts
+++ b/src/app/api/ai/agent/route.ts
@@ -546,6 +546,7 @@ export async function POST(req: Request) {
     const responseStream = result.toUIMessageStream({
       originalMessages: originalMessages as UIMessage[],
       generateMessageId: () => messageId,
+      sendReasoning: outputReasoning,
       onFinish:
         repositoryType === "remote" &&
         sessionRepository &&

--- a/src/components/chat/chat-factory.ts
+++ b/src/components/chat/chat-factory.ts
@@ -158,7 +158,7 @@ export function buildSendMessagesRequestPayload({
   generateTitle,
   ephemeral,
   pruneValidateSql,
-  outputReasoning = false,
+  outputReasoning = true,
   agentContext,
   chatPersistenceMode,
 }: SendMessagesRequestPayloadArgs): Record<string, unknown> {
@@ -523,8 +523,7 @@ export class ChatFactory {
               ephemeral: options.ephemeral,
               pruneValidateSql:
                 AgentConfigurationManager.getConfiguration().pruneValidateSql ?? true,
-              outputReasoning:
-                AgentConfigurationManager.getConfiguration().outputReasoning ?? false,
+              outputReasoning: AgentConfigurationManager.getConfiguration().outputReasoning ?? true,
               agentContext: options.agentContext,
               chatPersistenceMode,
             }),

--- a/src/components/chat/message/chat-message-parts.test.ts
+++ b/src/components/chat/message/chat-message-parts.test.ts
@@ -1,0 +1,78 @@
+import type { AppUIMessage } from "@/lib/ai/ai-types";
+import { describe, expect, it } from "vitest";
+import { getToolGroupState, groupRenderableParts } from "./chat-message-parts";
+
+function createToolPart(
+  toolName: string,
+  toolCallId: string,
+  state = "output-available",
+  output: unknown = { success: true }
+): AppUIMessage["parts"][0] {
+  return {
+    type: "dynamic-tool",
+    toolName,
+    toolCallId,
+    state,
+    input: {},
+    output,
+  } as unknown as AppUIMessage["parts"][0];
+}
+
+describe("chat message part grouping", () => {
+  it("collapses consecutive tool calls when later content follows", () => {
+    const groups = groupRenderableParts([
+      createToolPart("skill", "skill-1"),
+      createToolPart("validate_sql", "validate-1"),
+      createToolPart("execute_sql", "execute-1"),
+      { type: "text", text: "What the query does" },
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({ type: "tool-group", startIndex: 0 });
+    expect(groups[0].type === "tool-group" ? groups[0].parts : []).toHaveLength(3);
+    expect(groups[1]).toMatchObject({ type: "part", index: 3 });
+  });
+
+  it("ignores invisible stream separators between visually consecutive tool calls", () => {
+    const groups = groupRenderableParts([
+      createToolPart("skill", "skill-1"),
+      { type: "step-start" } as unknown as AppUIMessage["parts"][0],
+      { type: "reasoning", text: "" } as unknown as AppUIMessage["parts"][0],
+      createToolPart("skill", "skill-2"),
+      createToolPart("skill_resource", "skill-resource-1"),
+      { type: "step-start" } as unknown as AppUIMessage["parts"][0],
+      { type: "reasoning", text: "   " } as unknown as AppUIMessage["parts"][0],
+      createToolPart("get_tables", "get-tables-1"),
+      createToolPart("validate_sql", "validate-1"),
+      { type: "text", text: "Here's what the query does:" },
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({ type: "tool-group", startIndex: 0 });
+    expect(groups[0].type === "tool-group" ? groups[0].parts : []).toHaveLength(5);
+    expect(groups[1]).toMatchObject({ type: "part", index: 9 });
+  });
+
+  it("keeps trailing consecutive tool calls visible when no later content exists", () => {
+    const groups = groupRenderableParts([
+      { type: "text", text: "Checking the query" },
+      { type: "step-start" } as unknown as AppUIMessage["parts"][0],
+      createToolPart("validate_sql", "validate-1"),
+      { type: "reasoning", text: "" } as unknown as AppUIMessage["parts"][0],
+      { type: "step-start" } as unknown as AppUIMessage["parts"][0],
+      createToolPart("execute_sql", "execute-1"),
+    ]);
+
+    expect(groups).toHaveLength(3);
+    expect(groups.map((group) => group.type)).toEqual(["part", "part", "part"]);
+  });
+
+  it("marks a grouped tool run as failed when any tool failed", () => {
+    const state = getToolGroupState([
+      createToolPart("validate_sql", "validate-1"),
+      createToolPart("execute_sql", "execute-1", "output-error", { error: "bad sql" }),
+    ]);
+
+    expect(state).toEqual({ state: "output-error", success: false });
+  });
+});

--- a/src/components/chat/message/chat-message-parts.test.ts
+++ b/src/components/chat/message/chat-message-parts.test.ts
@@ -65,6 +65,9 @@ describe("chat message part grouping", () => {
 
     expect(groups).toHaveLength(3);
     expect(groups.map((group) => group.type)).toEqual(["part", "part", "part"]);
+    expect(groups.map((group) => (group.type === "part" ? group.index : group.startIndex))).toEqual(
+      [0, 2, 5]
+    );
   });
 
   it("marks a grouped tool run as failed when any tool failed", () => {

--- a/src/components/chat/message/chat-message-parts.ts
+++ b/src/components/chat/message/chat-message-parts.ts
@@ -50,11 +50,11 @@ export function groupRenderableParts(parts: MessagePart[]): RenderPartGroup[] {
     }
 
     const startIndex = index;
-    const toolParts: MessagePart[] = [];
+    const toolEntries: { part: MessagePart; index: number }[] = [];
     while (index < parts.length) {
       const currentPart = parts[index];
       if (isToolPart(currentPart)) {
-        toolParts.push(currentPart);
+        toolEntries.push({ part: currentPart, index });
         index += 1;
         continue;
       }
@@ -67,19 +67,23 @@ export function groupRenderableParts(parts: MessagePart[]): RenderPartGroup[] {
       break;
     }
 
-    if (toolParts.length === 0) {
+    if (toolEntries.length === 0) {
       index += 1;
       continue;
     }
 
     const hasPartAfterToolRun = index < parts.length;
-    if (toolParts.length > 1 && hasPartAfterToolRun) {
-      groups.push({ type: "tool-group", parts: toolParts, startIndex });
+    if (toolEntries.length > 1 && hasPartAfterToolRun) {
+      groups.push({
+        type: "tool-group",
+        parts: toolEntries.map((entry) => entry.part),
+        startIndex,
+      });
       continue;
     }
 
-    toolParts.forEach((toolPart, offset) => {
-      groups.push({ type: "part", part: toolPart, index: startIndex + offset });
+    toolEntries.forEach(({ part, index }) => {
+      groups.push({ type: "part", part, index });
     });
   }
 

--- a/src/components/chat/message/chat-message-parts.ts
+++ b/src/components/chat/message/chat-message-parts.ts
@@ -1,0 +1,119 @@
+import type { AppUIMessage, ToolPart } from "@/lib/ai/ai-types";
+
+export type MessagePart = AppUIMessage["parts"][0];
+export type RenderPartGroup =
+  | { type: "part"; part: MessagePart; index: number }
+  | { type: "tool-group"; parts: MessagePart[]; startIndex: number };
+
+export function getToolName(part: MessagePart): string | undefined {
+  if (part.type === "dynamic-tool") {
+    return (part as ToolPart).toolName;
+  }
+
+  if (typeof part.type === "string" && part.type.startsWith("tool-")) {
+    return part.type.replace("tool-", "");
+  }
+
+  return undefined;
+}
+
+export function isToolPart(part: MessagePart): boolean {
+  return getToolName(part) != null;
+}
+
+function isVisibleNonToolPart(part: MessagePart): boolean {
+  const partType = String(part.type);
+  if (partType === "reasoning") {
+    const text = (part as { text?: unknown }).text;
+    return typeof text === "string" && text.trim().length > 0;
+  }
+
+  return partType === "text" || partType === "file" || partType === "reasoning";
+}
+
+export function groupRenderableParts(parts: MessagePart[]): RenderPartGroup[] {
+  const groups: RenderPartGroup[] = [];
+  let index = 0;
+
+  while (index < parts.length) {
+    const part = parts[index];
+
+    if (!isToolPart(part) && !isVisibleNonToolPart(part)) {
+      index += 1;
+      continue;
+    }
+
+    if (!isToolPart(part)) {
+      groups.push({ type: "part", part, index });
+      index += 1;
+      continue;
+    }
+
+    const startIndex = index;
+    const toolParts: MessagePart[] = [];
+    while (index < parts.length) {
+      const currentPart = parts[index];
+      if (isToolPart(currentPart)) {
+        toolParts.push(currentPart);
+        index += 1;
+        continue;
+      }
+
+      if (!isVisibleNonToolPart(currentPart)) {
+        index += 1;
+        continue;
+      }
+
+      break;
+    }
+
+    if (toolParts.length === 0) {
+      index += 1;
+      continue;
+    }
+
+    const hasPartAfterToolRun = index < parts.length;
+    if (toolParts.length > 1 && hasPartAfterToolRun) {
+      groups.push({ type: "tool-group", parts: toolParts, startIndex });
+      continue;
+    }
+
+    toolParts.forEach((toolPart, offset) => {
+      groups.push({ type: "part", part: toolPart, index: startIndex + offset });
+    });
+  }
+
+  return groups;
+}
+
+function isCompleteToolPart(part: MessagePart): boolean {
+  const state = (part as ToolPart).state;
+  return state === "output-available" || state === "done" || state === "output-error";
+}
+
+function isErroredToolPart(part: MessagePart): boolean {
+  const toolPart = part as ToolPart;
+  const state = toolPart.state;
+  const output = toolPart.output as { error?: unknown; success?: unknown } | undefined;
+
+  return (
+    state === "output-error" ||
+    state?.includes("error") === true ||
+    output?.success === false ||
+    typeof output?.error === "string"
+  );
+}
+
+export function getToolGroupState(parts: MessagePart[]): { state?: string; success?: boolean } {
+  if (parts.some(isErroredToolPart)) {
+    return { state: "output-error", success: false };
+  }
+
+  if (parts.every(isCompleteToolPart)) {
+    return { state: "output-available", success: true };
+  }
+
+  return {
+    state: (parts.find((part) => !isCompleteToolPart(part)) as ToolPart | undefined)?.state,
+  };
+}

--- a/src/components/chat/message/chat-message.tsx
+++ b/src/components/chat/message/chat-message.tsx
@@ -10,6 +10,13 @@ import NumberFlow from "@number-flow/react";
 import type { LanguageModelUsage } from "ai";
 import { Info, Loader2 } from "lucide-react";
 import { memo } from "react";
+import {
+  getToolGroupState,
+  getToolName,
+  groupRenderableParts,
+  type MessagePart,
+} from "./chat-message-parts";
+import { CollapsiblePart } from "./collapsible-part";
 import { ErrorMessageDisplay } from "./message-error";
 import { MessageMarkdown } from "./message-markdown";
 import { MessageReasoning } from "./message-reasoning";
@@ -194,12 +201,7 @@ const ChatMessagePart = memo(
     }
 
     // Handle tool calls and responses
-    let toolName: string | undefined;
-    if (part.type === "dynamic-tool") {
-      toolName = (part as ToolPart).toolName;
-    } else if (typeof part.type === "string" && part.type.startsWith("tool-")) {
-      toolName = part.type.replace("tool-", "");
-    }
+    const toolName = getToolName(part);
 
     // SERVER TOOLS
     if (toolName === SERVER_TOOL_NAMES.GENERATE_SQL) {
@@ -288,6 +290,43 @@ const ChatMessagePart = memo(
   }
 );
 
+const CollapsedToolCallGroup = memo(function CollapsedToolCallGroup({
+  parts,
+  isUser,
+  isRunning,
+  messageId,
+}: {
+  parts: MessagePart[];
+  isUser: boolean;
+  isRunning: boolean;
+  messageId?: string;
+}) {
+  const { state, success } = getToolGroupState(parts);
+
+  return (
+    <CollapsiblePart
+      toolName={`${parts.length} tool calls`}
+      state={state}
+      success={success}
+      isRunning={isRunning}
+      showStatusIcon={false}
+      expandIncomplete={false}
+    >
+      <div className="mt-1 space-y-0.5">
+        {parts.map((part, index) => (
+          <ChatMessagePart
+            key={`${(part as ToolPart).toolCallId ?? index}-${index}`}
+            part={part}
+            isUser={isUser}
+            isRunning={isRunning}
+            messageId={messageId}
+          />
+        ))}
+      </div>
+    </CollapsiblePart>
+  );
+});
+
 interface ChatMessageProps {
   message: AppUIMessage;
   isLoading?: boolean;
@@ -327,6 +366,7 @@ export const ChatMessage = memo(function ChatMessage({
   const isUser = message.role === "user";
   const timestamp = resolveMessageTimestamp(message);
   const parts = message.parts || [];
+  const partGroups = groupRenderableParts(parts);
   const error = (message as { error?: Error }).error;
 
   const showLoading = !isUser && isLoading;
@@ -369,15 +409,25 @@ export const ChatMessage = memo(function ChatMessage({
                 </div>
               )}
               {parts.length === 0 && !isLoading && !error && "Nothing returned"}
-              {parts.map((part: AppUIMessage["parts"][0], i: number) => (
-                <ChatMessagePart
-                  key={i}
-                  part={part}
-                  isUser={isUser}
-                  isRunning={isRunning}
-                  messageId={message.id}
-                />
-              ))}
+              {partGroups.map((group) =>
+                group.type === "tool-group" ? (
+                  <CollapsedToolCallGroup
+                    key={`tool-group-${group.startIndex}`}
+                    parts={group.parts}
+                    isUser={isUser}
+                    isRunning={isRunning}
+                    messageId={message.id}
+                  />
+                ) : (
+                  <ChatMessagePart
+                    key={group.index}
+                    part={group.part}
+                    isUser={isUser}
+                    isRunning={isRunning}
+                    messageId={message.id}
+                  />
+                )
+              )}
               {error && <ErrorMessageDisplay errorText={error.message || String(error)} />}
               {showLoading && (
                 <div className="mt-2 flex items-center gap-2 text-muted-foreground">

--- a/src/components/chat/message/collapsible-part.test.tsx
+++ b/src/components/chat/message/collapsible-part.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CollapsiblePart } from "./collapsible-part";
+
+describe("CollapsiblePart", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("does not reset manual expansion on state changes when incomplete auto-expansion is disabled", () => {
+    act(() => {
+      root.render(
+        <CollapsiblePart
+          toolName="2 tool calls"
+          state="input-available"
+          isRunning={false}
+          expandIncomplete={false}
+        >
+          <div>Grouped tool call details</div>
+        </CollapsiblePart>
+      );
+    });
+
+    expect(container.textContent).not.toContain("Grouped tool call details");
+
+    const header = container.querySelector(".cursor-pointer");
+    expect(header).not.toBeNull();
+
+    act(() => {
+      header!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("Grouped tool call details");
+
+    act(() => {
+      root.render(
+        <CollapsiblePart
+          toolName="2 tool calls"
+          state="output-available"
+          isRunning={false}
+          expandIncomplete={false}
+        >
+          <div>Grouped tool call details</div>
+        </CollapsiblePart>
+      );
+    });
+
+    expect(container.textContent).toContain("Grouped tool call details");
+  });
+});

--- a/src/components/chat/message/collapsible-part.tsx
+++ b/src/components/chat/message/collapsible-part.tsx
@@ -69,7 +69,15 @@ export function CollapsiblePart({
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
 
   useEffect(() => {
-    setIsExpanded(defaultExpanded || (expandIncomplete && state !== "output-available"));
+    setIsExpanded(defaultExpanded);
+  }, [defaultExpanded]);
+
+  useEffect(() => {
+    if (!expandIncomplete) {
+      return;
+    }
+
+    setIsExpanded(defaultExpanded || state !== "output-available");
   }, [defaultExpanded, expandIncomplete, state]);
 
   // Determine if tool is complete

--- a/src/components/chat/message/collapsible-part.tsx
+++ b/src/components/chat/message/collapsible-part.tsx
@@ -52,6 +52,8 @@ export function CollapsiblePart({
   keepChildrenMounted = false,
   success,
   isRunning = true,
+  showStatusIcon = true,
+  expandIncomplete = true,
 }: {
   toolName: string;
   headerExtra?: React.ReactNode;
@@ -61,12 +63,14 @@ export function CollapsiblePart({
   keepChildrenMounted?: boolean;
   success?: boolean;
   isRunning?: boolean;
+  showStatusIcon?: boolean;
+  expandIncomplete?: boolean;
 }) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
 
   useEffect(() => {
-    setIsExpanded(defaultExpanded || state !== "output-available");
-  }, [defaultExpanded, state]);
+    setIsExpanded(defaultExpanded || (expandIncomplete && state !== "output-available"));
+  }, [defaultExpanded, expandIncomplete, state]);
 
   // Determine if tool is complete
   // Use external success value if provided, otherwise use state-based logic
@@ -98,16 +102,20 @@ export function CollapsiblePart({
         onClick={() => setIsExpanded(!isExpanded)}
       >
         <div className="flex items-center gap-2 py-0.5 text-[10px] leading-4">
-          {isComplete ? (
-            isError ? (
-              <CircleX className="h-3 w-3 text-destructive" />
-            ) : (
-              <Check className="h-3 w-3" />
-            )
-          ) : isActuallyRunning ? (
-            <Loader2 className="h-3 w-3 animate-spin" />
-          ) : (
-            <CircleX className="h-3 w-3 text-destructive" />
+          {showStatusIcon && (
+            <>
+              {isComplete ? (
+                isError ? (
+                  <CircleX className="h-3 w-3 text-destructive" />
+                ) : (
+                  <Check className="h-3 w-3" />
+                )
+              ) : isActuallyRunning ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <CircleX className="h-3 w-3 text-destructive" />
+              )}
+            </>
           )}
           <Badge className="flex items-center gap-0.5 rounded-sm border-none pl-1 pr-2 h-4 py-0 font-normal text-[10px]">
             {children &&

--- a/src/components/chat/message/message-tool-skill.tsx
+++ b/src/components/chat/message/message-tool-skill.tsx
@@ -78,9 +78,9 @@ export const MessageToolSkill = memo(function MessageToolSkill({
       isRunning={isRunning}
     >
       {requestedItems.length > 0 ? (
-        <div className="mt-1 text-[10px] text-muted-foreground">
+        <div className="text-[10px] text-muted-foreground">
           <div className="font-medium">input:</div>
-          <div className="mt-1 space-y-1 font-mono">
+          <div className="pl-3 font-mono">
             {requestedItems.map((item, index) => (
               <div key={`${item}-${index}`}>{item}</div>
             ))}
@@ -88,7 +88,10 @@ export const MessageToolSkill = memo(function MessageToolSkill({
         </div>
       ) : null}
       {characterCount != null ? (
-        <div className="mt-1 text-[10px] text-muted-foreground">{characterCount} characters</div>
+        <div className="text-[10px] text-muted-foreground">
+          <div className="font-medium">output:</div>
+          <div className="pl-3 font-mono">{characterCount} characters</div>
+        </div>
       ) : null}
     </CollapsiblePart>
   );

--- a/src/components/chat/view/chat-panel.tsx
+++ b/src/components/chat/view/chat-panel.tsx
@@ -268,6 +268,7 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
   const { connection, isInitialized: isConnectionInitialized } = useConnection();
   const chatConnectionId = getSessionRepositoryConnectionId(connection);
   const [loadedChatConnectionId, setLoadedChatConnectionId] = useState(chatConnectionId);
+  const [loadedChatIsDraft, setLoadedChatIsDraft] = useState(false);
   const { data: authSession } = useSession();
   const createDraftSession = useCallback(
     () => ({
@@ -290,6 +291,7 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
       const targetConnectionId =
         options?.connectionId ?? getSessionRepositoryConnectionId(targetConnection);
       setLoadedChatConnectionId(targetConnectionId);
+      setLoadedChatIsDraft(options?.isNewSession === true);
 
       const newChat = await ChatFactory.create({
         sessionId: chatIdToLoad,
@@ -443,6 +445,28 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
     });
     clearSelectedChat();
   }, [chat, clearSelectedChat, connection, loadChat, selectedChat]);
+
+  useEffect(() => {
+    if (
+      !chat ||
+      !loadedChatIsDraft ||
+      isRunning ||
+      chat.messages.length > 0 ||
+      !isNoConnectionSessionConnectionId(loadedChatConnectionId) ||
+      isNoConnectionSessionConnectionId(chatConnectionId)
+    ) {
+      return;
+    }
+
+    void loadChat(chat.id, { isNewSession: true });
+  }, [
+    chat,
+    chatConnectionId,
+    isRunning,
+    loadedChatConnectionId,
+    loadedChatIsDraft,
+    loadChat,
+  ]);
 
   // Update context builder when props change
   useEffect(() => {

--- a/src/components/chat/view/chat-panel.tsx
+++ b/src/components/chat/view/chat-panel.tsx
@@ -265,10 +265,9 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
   const processedNewChatRequestRef = useRef(newChatRequestNonce);
   const trackedRunningChatRef = useRef<{ chatId: string; connectionId: string } | null>(null);
   const isInitializedRef = useRef(false);
-  const { connection } = useConnection();
+  const { connection, isInitialized: isConnectionInitialized } = useConnection();
   const chatConnectionId = getSessionRepositoryConnectionId(connection);
   const [loadedChatConnectionId, setLoadedChatConnectionId] = useState(chatConnectionId);
-  const [loadedChatIsDraft, setLoadedChatIsDraft] = useState(false);
   const { data: authSession } = useSession();
   const createDraftSession = useCallback(
     () => ({
@@ -291,7 +290,6 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
       const targetConnectionId =
         options?.connectionId ?? getSessionRepositoryConnectionId(targetConnection);
       setLoadedChatConnectionId(targetConnectionId);
-      setLoadedChatIsDraft(options?.isNewSession === true);
 
       const newChat = await ChatFactory.create({
         sessionId: chatIdToLoad,
@@ -321,7 +319,7 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
   // Initial chat loading - only run once when chat is null
   useEffect(() => {
     // Skip if already initialized or chat already exists
-    if (isInitializedRef.current || chat) return;
+    if (!isConnectionInitialized || isInitializedRef.current || chat) return;
 
     const initializeChat = async () => {
       // Capture pendingCommand at initialization time to avoid re-running when it changes
@@ -390,6 +388,7 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     connection?.connectionId,
+    isConnectionInitialized,
     chatConnectionId,
     createDraftSession,
     initialInput?.chatId,
@@ -444,19 +443,6 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
     });
     clearSelectedChat();
   }, [chat, clearSelectedChat, connection, loadChat, selectedChat]);
-
-  useEffect(() => {
-    if (
-      !chat ||
-      !loadedChatIsDraft ||
-      !isNoConnectionSessionConnectionId(loadedChatConnectionId) ||
-      isNoConnectionSessionConnectionId(chatConnectionId)
-    ) {
-      return;
-    }
-
-    void loadChat(chat.id, { isNewSession: true });
-  }, [chat, chatConnectionId, loadedChatConnectionId, loadedChatIsDraft, loadChat]);
 
   // Update context builder when props change
   useEffect(() => {

--- a/src/components/chat/view/chat-panel.tsx
+++ b/src/components/chat/view/chat-panel.tsx
@@ -459,14 +459,7 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
     }
 
     void loadChat(chat.id, { isNewSession: true });
-  }, [
-    chat,
-    chatConnectionId,
-    isRunning,
-    loadedChatConnectionId,
-    loadedChatIsDraft,
-    loadChat,
-  ]);
+  }, [chat, chatConnectionId, isRunning, loadedChatConnectionId, loadedChatIsDraft, loadChat]);
 
   // Update context builder when props change
   useEffect(() => {

--- a/src/components/settings/agent/agent-edit.tsx
+++ b/src/components/settings/agent/agent-edit.tsx
@@ -346,7 +346,7 @@ export function AgentEdit() {
             <TableCell className="px-0 py-1 align-middle">
               <div className="flex h-10 items-center">
                 <Switch
-                  checked={configuration.outputReasoning ?? false}
+                  checked={configuration.outputReasoning ?? true}
                   onCheckedChange={handleOutputReasoningChange}
                 />
               </div>

--- a/src/components/settings/agent/agent-manager.ts
+++ b/src/components/settings/agent/agent-manager.ts
@@ -43,7 +43,7 @@ export type AgentConfiguration = {
   mode: AgentMode;
   /** Whether to prune successful validate_sql tool calls from history. Default true. */
   pruneValidateSql?: boolean;
-  /** Whether to request reasoning summaries from models that support them. Default false. */
+  /** Whether to request reasoning summaries from models that support them. Default true. */
   outputReasoning?: boolean;
   /** Whether eligible ClickHouse errors should auto-trigger an inline AI explanation. */
   autoExplainClickHouseErrors?: boolean;
@@ -70,7 +70,7 @@ export class AgentConfigurationManager {
       const stored = storage.getAsJSON<AgentConfiguration>(() => ({
         mode: "v2",
         pruneValidateSql: true,
-        outputReasoning: false,
+        outputReasoning: true,
         autoExplainClickHouseErrors: true,
         autoExplainBlacklist: DEFAULT_AUTO_EXPLAIN_BLACKLIST,
         aiResponseLanguage: DEFAULT_AI_RESPONSE_LANGUAGE,

--- a/src/lib/ai/session/serialization.test.ts
+++ b/src/lib/ai/session/serialization.test.ts
@@ -56,6 +56,46 @@ describe("sanitizeMessageForPersistence", () => {
     expect(serializeMessageParts(message)).toBe(JSON.stringify([{ type: "text", text: "hello" }]));
   });
 
+  it("drops non-visible stream marker parts from persisted messages", () => {
+    const message = createMessage([
+      { type: "step-start" },
+      { type: "reasoning", text: "" },
+      { type: "reasoning", text: "   " },
+      { type: "reasoning", text: "visible reasoning" },
+      { type: "text", text: "hello" },
+    ] as unknown as AppUIMessage["parts"]);
+
+    expect(sanitizeMessageForPersistence(message).parts).toEqual([
+      { type: "reasoning", text: "visible reasoning" },
+      { type: "text", text: "hello" },
+    ]);
+  });
+
+  it("preserves empty reasoning parts with provider continuation metadata", () => {
+    const reasoningPart = {
+      type: "reasoning",
+      text: "",
+      providerMetadata: {
+        openai: {
+          itemId: "rs_123",
+          reasoningEncryptedContent: "encrypted-reasoning",
+        },
+      },
+    } as unknown as AppUIMessage["parts"][number];
+    const message = createMessage([{ type: "step-start" }, reasoningPart] as AppUIMessage["parts"]);
+
+    expect(sanitizeMessageForPersistence(message).parts).toEqual([reasoningPart]);
+  });
+
+  it("does not replace stream-marker-only messages with an image placeholder", () => {
+    const message = createMessage([
+      { type: "step-start" },
+      { type: "reasoning", text: "" },
+    ] as unknown as AppUIMessage["parts"]);
+
+    expect(sanitizeMessageForPersistence(message).parts).toEqual([]);
+  });
+
   it("ignores malformed file parts without throwing", () => {
     const message = createMessage([
       { type: "text", text: "hello" },

--- a/src/lib/ai/session/serialization.ts
+++ b/src/lib/ai/session/serialization.ts
@@ -19,17 +19,41 @@ function isPersistedImagePart(part: MessagePart): part is FilePart {
   );
 }
 
+function hasProviderMetadata(part: MessagePart): boolean {
+  const metadata = (part as { providerMetadata?: unknown }).providerMetadata;
+  return typeof metadata === "object" && metadata !== null;
+}
+
+function isNonPersistedStreamPart(part: MessagePart): boolean {
+  const partType = String(part.type);
+  if (partType === "step-start") {
+    return true;
+  }
+
+  if (partType === "reasoning") {
+    const text = (part as { text?: unknown }).text;
+    return (typeof text !== "string" || text.trim().length === 0) && !hasProviderMetadata(part);
+  }
+
+  return false;
+}
+
 export function sanitizeMessageForPersistence(message: AppUIMessage): AppUIMessage {
   const parts = (message.parts ?? []) as MessagePart[];
-  if (!parts.some(isPersistedImagePart)) {
+  if (!parts.some((part) => isPersistedImagePart(part) || isNonPersistedStreamPart(part))) {
     return message;
   }
 
-  const sanitizedParts = parts.filter((part) => !isPersistedImagePart(part));
+  const removedImagePart = parts.some(isPersistedImagePart);
+  const sanitizedParts = parts.filter(
+    (part) => !isPersistedImagePart(part) && !isNonPersistedStreamPart(part)
+  );
   const nextParts =
     sanitizedParts.length > 0
       ? sanitizedParts
-      : ([{ type: "text", text: IMAGE_HISTORY_PLACEHOLDER }] satisfies MessagePart[]);
+      : removedImagePart
+        ? ([{ type: "text", text: IMAGE_HISTORY_PLACEHOLDER }] satisfies MessagePart[])
+        : [];
 
   return {
     ...message,


### PR DESCRIPTION
## Summary

- Collapse consecutive chat tool calls by default when visible assistant content follows them, while leaving trailing tool calls expanded.
- Hide stream-only separators from saved messages without dropping encrypted reasoning provider metadata.
- Polish Load Skill rendering with indented input/output sections and default output reasoning on.
- Fix first-request streaming by avoiding draft chat reloads during the initial stream.

## Validation

- npm run test -- src/lib/ai/session/serialization.test.ts src/components/chat/message/chat-message-parts.test.ts
- npm run test -- src/lib/connection/connection.test.ts src/lib/ai/session/remote-chat-request.test.ts src/lib/ai/session/serialization.test.ts src/components/chat/message/chat-message-parts.test.ts
- npx eslint src/components/chat/view/chat-panel.tsx
- npm run typecheck
- git diff --check
- npm run build
