### PR TITLE
[codex] Add chat session share links

### DIFF
--- a/src/app/api/ai/agent/route.ts
+++ b/src/app/api/ai/agent/route.ts
@@ -28,6 +28,8 @@ import {
   getServerSessionRepository,
   getSessionRepositoryType,
 } from "@/lib/ai/session/server-session-repository-factory";
+import { resolveSessionAccess, SessionAccessError } from "@/lib/ai/session/session-access";
+import { SESSION_SHARE_CODE_HEADER } from "@/lib/ai/session/session-share-constants";
 import { createSkillAvailabilityFilter } from "@/lib/ai/skills/skill-availability";
 import { SkillProviderFactory } from "@/lib/ai/skills/skill-provider-factory";
 import { normalizeUsage, sumTokenUsage } from "@/lib/ai/token-usage-utils";
@@ -304,6 +306,7 @@ export async function POST(req: Request) {
     let sessionRepositoryUserId: string | null = null;
     let sessionRepositoryChatId: string | null = null;
     let sessionRepositoryAllowMissingSession = false;
+    let isSharedSessionAccess = false;
     const sessionRepository: ReturnType<typeof getServerSessionRepository> | null =
       repositoryType === "remote" ? getServerSessionRepository() : null;
     let titlePromise: Promise<SessionTitleGenerationResponse | undefined> | undefined;
@@ -328,6 +331,7 @@ export async function POST(req: Request) {
       if (!sessionRepositoryUserId) {
         return new Response("Authentication required", { status: 401 });
       }
+      const shareCode = req.headers.get(SESSION_SHARE_CODE_HEADER);
 
       context = apiRequest.context
         ? ({ ...apiRequest.context, userEmail } as ServerDatabaseContext)
@@ -379,10 +383,31 @@ export async function POST(req: Request) {
         sessionRepositoryChatId = apiRequest.sessionId;
         sessionRepositoryAllowMissingSession = true;
       } else {
-        const existingSession = await sessionRepository!.getSession(
-          sessionRepositoryUserId,
-          apiRequest.sessionId
-        );
+        let existingSession;
+        if (shareCode) {
+          try {
+            const access = await resolveSessionAccess({
+              repository: sessionRepository!,
+              authenticatedUserId: sessionRepositoryUserId,
+              sessionId: apiRequest.sessionId,
+              shareCode,
+            });
+            sessionRepositoryUserId = access.ownerId;
+            existingSession = access.session;
+            isSharedSessionAccess = access.kind === "share";
+          } catch (error) {
+            if (error instanceof SessionAccessError) {
+              return new Response(error.message, { status: error.status });
+            }
+            throw error;
+          }
+        } else {
+          existingSession = await sessionRepository!.getSession(
+            sessionRepositoryUserId,
+            apiRequest.sessionId
+          );
+        }
+
         if (!existingSession) {
           await sessionRepository!.createSession({
             id: apiRequest.sessionId,
@@ -395,6 +420,11 @@ export async function POST(req: Request) {
           });
         } else if (existingSession.connection_id !== apiRequest.connectionId) {
           return new Response("Session connectionId mismatch", { status: 409 });
+        }
+
+        if (isSharedSessionAccess) {
+          clickHouseConnection = undefined;
+          context = { userEmail, clusterAvailable: false };
         }
 
         const persistedMessages = (

--- a/src/app/api/ai/chat/sessions/[sessionId]/messages/route.ts
+++ b/src/app/api/ai/chat/sessions/[sessionId]/messages/route.ts
@@ -2,6 +2,8 @@ import { getAuthenticatedUserEmail } from "@/auth";
 import { validateSessionId } from "@/lib/ai/session/remote-chat-request";
 import { persistedMessageToDTO } from "@/lib/ai/session/serialization";
 import { getServerSessionRepository } from "@/lib/ai/session/server-session-repository-factory";
+import { resolveSessionAccess, SessionAccessError } from "@/lib/ai/session/session-access";
+import { SESSION_SHARE_CODE_HEADER } from "@/lib/ai/session/session-share-constants";
 
 export const dynamic = "force-dynamic";
 
@@ -11,9 +13,6 @@ type RouteContext = {
 
 export async function GET(req: Request, context: RouteContext) {
   const userId = getAuthenticatedUserEmail(req);
-  if (!userId) {
-    return new Response("Authentication required", { status: 401 });
-  }
 
   const { sessionId } = await context.params;
   if (!validateSessionId(sessionId)) {
@@ -21,11 +20,21 @@ export async function GET(req: Request, context: RouteContext) {
   }
 
   const sessionRepository = getServerSessionRepository();
-  const session = await sessionRepository.getSession(userId, sessionId);
-  if (!session) {
-    return new Response("Not found", { status: 404 });
+  let access;
+  try {
+    access = await resolveSessionAccess({
+      repository: sessionRepository,
+      authenticatedUserId: userId,
+      sessionId,
+      shareCode: req.headers.get(SESSION_SHARE_CODE_HEADER),
+    });
+  } catch (error) {
+    if (error instanceof SessionAccessError) {
+      return new Response(error.message, { status: error.status });
+    }
+    throw error;
   }
 
-  const messages = await sessionRepository.getMessages(userId, sessionId);
+  const messages = await sessionRepository.getMessages(access.ownerId, sessionId);
   return Response.json(messages.map(persistedMessageToDTO));
 }

--- a/src/app/api/ai/chat/sessions/[sessionId]/route.ts
+++ b/src/app/api/ai/chat/sessions/[sessionId]/route.ts
@@ -2,6 +2,8 @@ import { getAuthenticatedUserEmail } from "@/auth";
 import { validateSessionId } from "@/lib/ai/session/remote-chat-request";
 import { persistedSessionToDTO } from "@/lib/ai/session/serialization";
 import { getServerSessionRepository } from "@/lib/ai/session/server-session-repository-factory";
+import { resolveSessionAccess, SessionAccessError } from "@/lib/ai/session/session-access";
+import { SESSION_SHARE_CODE_HEADER } from "@/lib/ai/session/session-share-constants";
 
 export const dynamic = "force-dynamic";
 
@@ -11,9 +13,6 @@ type RouteContext = {
 
 export async function GET(req: Request, context: RouteContext) {
   const userId = getAuthenticatedUserEmail(req);
-  if (!userId) {
-    return new Response("Authentication required", { status: 401 });
-  }
 
   const { sessionId } = await context.params;
   if (!validateSessionId(sessionId)) {
@@ -21,19 +20,26 @@ export async function GET(req: Request, context: RouteContext) {
   }
 
   const sessionRepository = getServerSessionRepository();
-  const session = await sessionRepository.getSession(userId, sessionId);
-  if (!session) {
-    return new Response("Not found", { status: 404 });
+  let access;
+  try {
+    access = await resolveSessionAccess({
+      repository: sessionRepository,
+      authenticatedUserId: userId,
+      sessionId,
+      shareCode: req.headers.get(SESSION_SHARE_CODE_HEADER),
+    });
+  } catch (error) {
+    if (error instanceof SessionAccessError) {
+      return new Response(error.message, { status: error.status });
+    }
+    throw error;
   }
 
-  return Response.json(persistedSessionToDTO(session));
+  return Response.json(persistedSessionToDTO(access.session));
 }
 
 export async function PATCH(req: Request, context: RouteContext) {
   const userId = getAuthenticatedUserEmail(req);
-  if (!userId) {
-    return new Response("Authentication required", { status: 401 });
-  }
 
   const { sessionId } = await context.params;
   if (!validateSessionId(sessionId)) {
@@ -52,13 +58,23 @@ export async function PATCH(req: Request, context: RouteContext) {
   }
 
   const sessionRepository = getServerSessionRepository();
-  const session = await sessionRepository.getSession(userId, sessionId);
-  if (!session) {
-    return new Response("Not found", { status: 404 });
+  let access;
+  try {
+    access = await resolveSessionAccess({
+      repository: sessionRepository,
+      authenticatedUserId: userId,
+      sessionId,
+      shareCode: req.headers.get(SESSION_SHARE_CODE_HEADER),
+    });
+  } catch (error) {
+    if (error instanceof SessionAccessError) {
+      return new Response(error.message, { status: error.status });
+    }
+    throw error;
   }
 
-  await sessionRepository.renameSession(userId, sessionId, payload.title.trim());
-  const updated = await sessionRepository.getSession(userId, sessionId);
+  await sessionRepository.renameSession(access.ownerId, sessionId, payload.title.trim());
+  const updated = await sessionRepository.getSession(access.ownerId, sessionId);
   if (!updated) {
     return new Response("Not found", { status: 404 });
   }
@@ -68,9 +84,6 @@ export async function PATCH(req: Request, context: RouteContext) {
 
 export async function DELETE(req: Request, context: RouteContext) {
   const userId = getAuthenticatedUserEmail(req);
-  if (!userId) {
-    return new Response("Authentication required", { status: 401 });
-  }
 
   const { sessionId } = await context.params;
   if (!validateSessionId(sessionId)) {
@@ -78,11 +91,21 @@ export async function DELETE(req: Request, context: RouteContext) {
   }
 
   const sessionRepository = getServerSessionRepository();
-  const session = await sessionRepository.getSession(userId, sessionId);
-  if (!session) {
-    return new Response("Not found", { status: 404 });
+  let access;
+  try {
+    access = await resolveSessionAccess({
+      repository: sessionRepository,
+      authenticatedUserId: userId,
+      sessionId,
+      shareCode: req.headers.get(SESSION_SHARE_CODE_HEADER),
+    });
+  } catch (error) {
+    if (error instanceof SessionAccessError) {
+      return new Response(error.message, { status: error.status });
+    }
+    throw error;
   }
 
-  await sessionRepository.deleteSession(userId, sessionId);
+  await sessionRepository.deleteSession(access.ownerId, sessionId);
   return new Response(null, { status: 204 });
 }

--- a/src/app/api/ai/sessions/[sessionId]/share/route.ts
+++ b/src/app/api/ai/sessions/[sessionId]/share/route.ts
@@ -1,0 +1,47 @@
+import { getAuthenticatedUserEmail } from "@/auth";
+import { validateSessionId } from "@/lib/ai/session/remote-chat-request";
+import { getServerSessionRepository } from "@/lib/ai/session/server-session-repository-factory";
+import { signSessionShareCode } from "@/lib/ai/session/session-share-code";
+import {
+  SESSION_SHARE_EXPIRES_AT,
+  SESSION_SHARE_EXPIRES_AT_SECONDS,
+} from "@/lib/ai/session/session-share-constants";
+import { BasePath } from "@/lib/base-path";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type RouteContext = {
+  params: Promise<{ sessionId: string }>;
+};
+
+export async function POST(req: Request, context: RouteContext) {
+  const userId = getAuthenticatedUserEmail(req);
+  if (!userId) {
+    return new Response("Authentication required", { status: 401 });
+  }
+
+  const { sessionId } = await context.params;
+  if (!validateSessionId(sessionId)) {
+    return new Response("Invalid sessionId", { status: 400 });
+  }
+
+  const sessionRepository = getServerSessionRepository();
+  const session = await sessionRepository.getSession(userId, sessionId);
+  if (!session) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const code = await signSessionShareCode({
+    ownerId: userId,
+    sessionId,
+    expiresAt: SESSION_SHARE_EXPIRES_AT_SECONDS,
+  });
+  const url = `${BasePath.getURL(`/session/${encodeURIComponent(sessionId)}`)}?code=${encodeURIComponent(code)}`;
+
+  return Response.json({
+    url,
+    code,
+    expiresAt: SESSION_SHARE_EXPIRES_AT.toISOString(),
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,43 +1,7 @@
 "use client";
 
-import { AppSidebar } from "@/components/app-sidebar";
-import { AppStorageProvider } from "@/components/app-storage-provider";
-import { ChatPanelProvider } from "@/components/chat/view/use-chat-panel";
-import { ConnectionProvider } from "@/components/connection/connection-context";
-import { MainPage } from "@/components/main-page";
-import { ReleaseDetectorProvider } from "@/components/release-note/release-detector";
-import { ModelConfigBootstrap } from "@/components/settings/models/model-config-bootstrap";
-import { ErrorBoundary } from "@/components/shared/error-boundary";
-import { ThemeProvider } from "@/components/shared/theme-provider";
-import { ToastProvider } from "@/components/shared/toast-provider";
-import { DialogProvider } from "@/components/shared/use-dialog";
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { AppShell } from "@/components/app-shell";
 
 export default function Home() {
-  return (
-    <AppStorageProvider>
-      <ModelConfigBootstrap>
-        <ThemeProvider defaultTheme="dark">
-          <ConnectionProvider>
-            <ChatPanelProvider>
-              <ReleaseDetectorProvider>
-                <ToastProvider />
-                <DialogProvider />
-                <SidebarProvider open={false}>
-                  <AppSidebar />
-                  <SidebarInset className="min-w-0 flex flex-col overflow-x-hidden h-screen">
-                    <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
-                      <ErrorBoundary>
-                        <MainPage />
-                      </ErrorBoundary>
-                    </div>
-                  </SidebarInset>
-                </SidebarProvider>
-              </ReleaseDetectorProvider>
-            </ChatPanelProvider>
-          </ConnectionProvider>
-        </ThemeProvider>
-      </ModelConfigBootstrap>
-    </AppStorageProvider>
-  );
+  return <AppShell />;
 }

--- a/src/app/session/[sessionId]/page.tsx
+++ b/src/app/session/[sessionId]/page.tsx
@@ -1,0 +1,13 @@
+import { AppShell } from "@/components/app-shell";
+
+type SessionPageProps = {
+  params: Promise<{ sessionId: string }>;
+  searchParams: Promise<{ code?: string | string[] }>;
+};
+
+export default async function SessionPage({ params, searchParams }: SessionPageProps) {
+  const [{ sessionId }, { code }] = await Promise.all([params, searchParams]);
+  const shareCode = Array.isArray(code) ? code[0] : code;
+
+  return <AppShell initialSessionId={sessionId} initialSessionShareCode={shareCode} />;
+}

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { AppSidebar } from "@/components/app-sidebar";
+import { AppStorageProvider } from "@/components/app-storage-provider";
+import { ChatPanelProvider } from "@/components/chat/view/use-chat-panel";
+import { ConnectionProvider } from "@/components/connection/connection-context";
+import { MainPage } from "@/components/main-page";
+import { ReleaseDetectorProvider } from "@/components/release-note/release-detector";
+import { ModelConfigBootstrap } from "@/components/settings/models/model-config-bootstrap";
+import { ErrorBoundary } from "@/components/shared/error-boundary";
+import { ThemeProvider } from "@/components/shared/theme-provider";
+import { ToastProvider } from "@/components/shared/toast-provider";
+import { DialogProvider } from "@/components/shared/use-dialog";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+
+interface AppShellProps {
+  initialSessionId?: string;
+  initialSessionShareCode?: string;
+}
+
+export function AppShell({ initialSessionId, initialSessionShareCode }: AppShellProps) {
+  return (
+    <AppStorageProvider>
+      <ModelConfigBootstrap>
+        <ThemeProvider defaultTheme="dark">
+          <ConnectionProvider>
+            <ChatPanelProvider
+              initialSessionId={initialSessionId}
+              initialSessionShareCode={initialSessionShareCode}
+            >
+              <ReleaseDetectorProvider>
+                <ToastProvider />
+                <DialogProvider />
+                <SidebarProvider open={false}>
+                  <AppSidebar />
+                  <SidebarInset className="min-w-0 flex flex-col overflow-x-hidden h-screen">
+                    <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
+                      <ErrorBoundary>
+                        <MainPage />
+                      </ErrorBoundary>
+                    </div>
+                  </SidebarInset>
+                </SidebarProvider>
+              </ReleaseDetectorProvider>
+            </ChatPanelProvider>
+          </ConnectionProvider>
+        </ThemeProvider>
+      </ModelConfigBootstrap>
+    </AppStorageProvider>
+  );
+}

--- a/src/components/chat/chat-factory.ts
+++ b/src/components/chat/chat-factory.ts
@@ -4,6 +4,7 @@ import { ModelManager } from "@/components/settings/models/model-manager";
 import type { PlanToolOutput } from "@/lib/ai/agent/plan/planning-types";
 import type { AgentContext, AppUIMessage, Message, MessageMetadata } from "@/lib/ai/ai-types";
 import { sanitizeMessageForPersistence } from "@/lib/ai/session/serialization";
+import { SESSION_SHARE_CODE_HEADER } from "@/lib/ai/session/session-share-constants";
 import {
   getClickHouseConnectionValidationError,
   type ClickHouseConnection,
@@ -50,6 +51,7 @@ type ChatFactoryCreateOptions = {
     modelId: string;
     apiKey?: string;
   };
+  shareCode?: string;
 };
 type PrepareSendMessagesRequestArgs = {
   sessionId: string;
@@ -218,6 +220,27 @@ function buildClickHouseConnectionPayload(
   return getClickHouseConnectionValidationError(payload) ? undefined : payload;
 }
 
+function buildChatRequestHeaders(
+  headers: HeadersInit | undefined,
+  shareCode: string | undefined
+): HeadersInit | undefined {
+  if (!shareCode) {
+    return headers;
+  }
+
+  const normalizedHeaders =
+    headers instanceof Headers
+      ? Object.fromEntries(headers.entries())
+      : Array.isArray(headers)
+        ? Object.fromEntries(headers)
+        : (headers ?? {});
+
+  return {
+    ...normalizedHeaders,
+    [SESSION_SHARE_CODE_HEADER]: shareCode,
+  };
+}
+
 export class ChatFactory {
   private static readonly clientToolAbortControllers = new Map<string, Set<AbortController>>();
 
@@ -359,7 +382,9 @@ export class ChatFactory {
             }
           }
 
-          await SessionManager.touchSessionById(sessionId, connectionId, provisionalTitle);
+          await SessionManager.touchSessionById(sessionId, connectionId, provisionalTitle, {
+            shareCode: options.shareCode,
+          });
           return;
         }
 
@@ -404,7 +429,9 @@ export class ChatFactory {
         }
 
         await SessionManager.saveMessages(sessionId, userMessagesToSave);
-        await SessionManager.touchSessionById(sessionId, connectionId, provisionalTitle);
+        await SessionManager.touchSessionById(sessionId, connectionId, provisionalTitle, {
+          shareCode: options.shareCode,
+        });
       },
       onFinish: async ({ message, connectionId, sessionId }) => {
         const chatPersistenceMode = getRuntimeConfig().sessionRepositoryType;
@@ -441,7 +468,9 @@ export class ChatFactory {
           await SessionManager.saveMessage(sessionId, messageToSave);
         }
 
-        await SessionManager.touchSessionById(sessionId, connectionId, title);
+        await SessionManager.touchSessionById(sessionId, connectionId, title, {
+          shareCode: options.shareCode,
+        });
       },
     });
   }
@@ -528,7 +557,7 @@ export class ChatFactory {
               agentContext: options.agentContext,
               chatPersistenceMode,
             }),
-            headers,
+            headers: buildChatRequestHeaders(headers, options.shareCode),
             credentials,
           };
         },

--- a/src/components/chat/session/chat-session-list.tsx
+++ b/src/components/chat/session/chat-session-list.tsx
@@ -53,7 +53,7 @@ interface ChatHistoryListProps {
   currentChatId: string;
   onNewChat: () => void;
   onClose?: () => void;
-  onSelectChat?: (id: string, connectionId?: string) => void;
+  onSelectChat?: (id: string, connectionId?: string, shareCode?: string) => void;
   className?: string;
 }
 
@@ -613,8 +613,8 @@ export const ChatSessionList = React.memo<ChatHistoryListProps>(
           return;
         }
 
-        if (isNoConnectionSessionConnectionId(chat.databaseId)) {
-          onSelectChat?.(chat.chatId, chat.databaseId);
+        if (isNoConnectionSessionConnectionId(chat.databaseId) || chat.shareCode) {
+          onSelectChat?.(chat.chatId, chat.databaseId, chat.shareCode);
           onClose?.();
           return;
         }
@@ -630,7 +630,7 @@ export const ChatSessionList = React.memo<ChatHistoryListProps>(
           }
         }
 
-        onSelectChat?.(chat.chatId, chat.databaseId);
+        onSelectChat?.(chat.chatId, chat.databaseId, chat.shareCode);
         onClose?.();
       },
       [connection, currentChatId, onClose, onSelectChat, switchConnection]

--- a/src/components/chat/session/local-session-repository.ts
+++ b/src/components/chat/session/local-session-repository.ts
@@ -260,9 +260,9 @@ export class LocalSessionRepository implements SessionRepository {
     );
   }
 
-  async getSession(id: string): Promise<Chat | null> {
+  async getSession(sessionId: string): Promise<Chat | null> {
     const chats = this.chatsStorage.getAsJSON<Record<string, Chat>>(() => ({}));
-    const chat = chats[id];
+    const chat = chats[sessionId];
 
     if (!chat) return null;
 
@@ -283,28 +283,28 @@ export class LocalSessionRepository implements SessionRepository {
     await this.safeSave(null, () => this.chatsStorage.setJSON(chats), session.chatId);
   }
 
-  async updateSessionTitle(id: string, title: string): Promise<void> {
+  async updateSessionTitle(sessionId: string, title: string): Promise<void> {
     const chats = this.chatsStorage.getAsJSON<Record<string, Chat>>(() => ({}));
-    if (chats[id]) {
-      chats[id] = {
-        ...chats[id],
+    if (chats[sessionId]) {
+      chats[sessionId] = {
+        ...chats[sessionId],
         title,
         updatedAt: new Date(),
       };
-      await this.safeSave(null, () => this.chatsStorage.setJSON(chats), id);
+      await this.safeSave(null, () => this.chatsStorage.setJSON(chats), sessionId);
     }
   }
 
-  async renameSession(chatId: string, title: string): Promise<void> {
-    await this.updateSessionTitle(chatId, title);
+  async renameSession(sessionId: string, title: string): Promise<void> {
+    await this.updateSessionTitle(sessionId, title);
   }
 
-  async deleteSession(id: string): Promise<void> {
+  async deleteSession(sessionId: string): Promise<void> {
     const chats = this.chatsStorage.getAsJSON<Record<string, Chat>>(() => ({}));
-    delete chats[id];
+    delete chats[sessionId];
 
     await this.safeSave(null, () => this.chatsStorage.setJSON(chats));
-    await this.clearMessages(id);
+    await this.clearMessages(sessionId);
   }
 
   private async getStoredSessions(): Promise<Chat[]> {
@@ -337,8 +337,8 @@ export class LocalSessionRepository implements SessionRepository {
     };
   }
 
-  async getMessages(chatId: string): Promise<Message[]> {
-    const messagesMap = this.getMessagesForChat(chatId);
+  async getMessages(sessionId: string): Promise<Message[]> {
+    const messagesMap = this.getMessagesForChat(sessionId);
     const messages = Object.values(messagesMap).map((message) => this.normalizeMessage(message));
 
     const needsBackfill = messages.some((message) => message.sequence == null);
@@ -349,7 +349,7 @@ export class LocalSessionRepository implements SessionRepository {
         sorted[index].sequence = sequence;
         messagesMap[sorted[index].id] = sorted[index];
       }
-      await this.saveMessagesForChat(chatId, messagesMap);
+      await this.saveMessagesForChat(sessionId, messagesMap);
     }
 
     return messages.sort((a, b) => this.compareMessages(a, b));
@@ -374,8 +374,8 @@ export class LocalSessionRepository implements SessionRepository {
     return session;
   }
 
-  async saveMessage(chatId: string, message: Message): Promise<void> {
-    const messagesMap = this.getMessagesForChat(chatId);
+  async saveMessage(sessionId: string, message: Message): Promise<void> {
+    const messagesMap = this.getMessagesForChat(sessionId);
     let sequence = messagesMap[message.id]?.sequence;
 
     if (sequence === undefined) {
@@ -394,18 +394,18 @@ export class LocalSessionRepository implements SessionRepository {
     };
 
     messagesMap[message.id] = messageToSave;
-    await this.saveMessagesForChat(chatId, messagesMap);
+    await this.saveMessagesForChat(sessionId, messagesMap);
 
-    const session = await this.getSession(chatId);
+    const session = await this.getSession(sessionId);
     if (session) {
       await this.saveSession({ ...session, updatedAt: new Date() });
     }
   }
 
-  async saveMessages(chatId: string, messagesToSave: Message[]): Promise<void> {
+  async saveMessages(sessionId: string, messagesToSave: Message[]): Promise<void> {
     if (messagesToSave.length === 0) return;
 
-    const messagesMap = this.getMessagesForChat(chatId);
+    const messagesMap = this.getMessagesForChat(sessionId);
     const messages = Object.values(messagesMap);
     let maxSequence =
       messages.length > 0 ? Math.max(...messages.map((message) => message.sequence ?? 0)) : 0;
@@ -425,9 +425,9 @@ export class LocalSessionRepository implements SessionRepository {
       messagesMap[message.id] = messageToSave;
     }
 
-    await this.saveMessagesForChat(chatId, messagesMap);
+    await this.saveMessagesForChat(sessionId, messagesMap);
 
-    const session = await this.getSession(chatId);
+    const session = await this.getSession(sessionId);
     if (session) {
       await this.saveSession({ ...session, updatedAt: new Date() });
     }

--- a/src/components/chat/session/open-session-list-button.tsx
+++ b/src/components/chat/session/open-session-list-button.tsx
@@ -11,7 +11,7 @@ interface OpenHistoryButtonProps {
   disabled?: boolean;
   currentChatId: string;
   onNewChat: () => void;
-  onSelectChat?: (id: string, connectionId?: string) => void;
+  onSelectChat?: (id: string, connectionId?: string, shareCode?: string) => void;
   variant?: "ghost" | "outline" | "secondary";
   className?: string;
   iconClassName?: string;

--- a/src/components/chat/session/remote-session-repository.test.ts
+++ b/src/components/chat/session/remote-session-repository.test.ts
@@ -1,0 +1,34 @@
+import { SESSION_SHARE_CODE_HEADER } from "@/lib/ai/session/session-share-constants";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RemoteSessionRepository } from "./remote-session-repository";
+
+describe("RemoteSessionRepository", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("adds the session share code header when loading a shared session", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          chatId: "session-1",
+          databaseId: "conn-1",
+          title: "Session",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const repository = new RemoteSessionRepository();
+    await repository.getSession("session-1", { shareCode: "share-token" });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/ai/chat/sessions/session-1", {
+      headers: { [SESSION_SHARE_CODE_HEADER]: "share-token" },
+      credentials: "same-origin",
+      cache: "no-store",
+    });
+  });
+});

--- a/src/components/chat/session/remote-session-repository.ts
+++ b/src/components/chat/session/remote-session-repository.ts
@@ -1,7 +1,9 @@
 import type { Chat, Message } from "@/lib/ai/ai-types";
+import { SESSION_SHARE_CODE_HEADER } from "@/lib/ai/session/session-share-constants";
 import { BasePath } from "@/lib/base-path";
 import type {
   CreateSessionFromMessagesInput,
+  SessionAccessOptions,
   SessionPage,
   SessionPageInput,
   SessionRepository,
@@ -54,11 +56,16 @@ async function parseJson<T>(response: Response): Promise<T> {
   return (await response.json()) as T;
 }
 
+function buildShareCodeHeaders(options?: SessionAccessOptions): HeadersInit | undefined {
+  return options?.shareCode ? { [SESSION_SHARE_CODE_HEADER]: options.shareCode } : undefined;
+}
+
 export class RemoteSessionRepository implements SessionRepository {
-  async getSession(chatId: string): Promise<Chat | null> {
+  async getSession(sessionId: string, options?: SessionAccessOptions): Promise<Chat | null> {
     const response = await fetch(
-      BasePath.getURL(`/api/ai/chat/sessions/${encodeURIComponent(chatId)}`),
+      BasePath.getURL(`/api/ai/chat/sessions/${encodeURIComponent(sessionId)}`),
       {
+        headers: buildShareCodeHeaders(options),
         credentials: "same-origin",
         cache: "no-store",
       }
@@ -97,10 +104,11 @@ export class RemoteSessionRepository implements SessionRepository {
     };
   }
 
-  async getMessages(chatId: string): Promise<Message[]> {
+  async getMessages(sessionId: string, options?: SessionAccessOptions): Promise<Message[]> {
     const response = await fetch(
-      BasePath.getURL(`/api/ai/chat/sessions/${encodeURIComponent(chatId)}/messages`),
+      BasePath.getURL(`/api/ai/chat/sessions/${encodeURIComponent(sessionId)}/messages`),
       {
+        headers: buildShareCodeHeaders(options),
         credentials: "same-origin",
         cache: "no-store",
       }
@@ -135,14 +143,21 @@ export class RemoteSessionRepository implements SessionRepository {
 
   async saveMessages(_chatId: string, _messages: Message[]): Promise<void> {}
 
-  async saveMessage(_chatId: string, _message: Message): Promise<void> {}
+  async saveMessage(_sessionId: string, _message: Message): Promise<void> {}
 
-  async renameSession(chatId: string, title: string): Promise<void> {
+  async renameSession(
+    sessionId: string,
+    title: string,
+    options?: SessionAccessOptions
+  ): Promise<void> {
     const response = await fetch(
-      BasePath.getURL(`/api/ai/chat/sessions/${encodeURIComponent(chatId)}`),
+      BasePath.getURL(`/api/ai/chat/sessions/${encodeURIComponent(sessionId)}`),
       {
         method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          ...buildShareCodeHeaders(options),
+        },
         credentials: "same-origin",
         body: JSON.stringify({ title }),
       }
@@ -153,11 +168,12 @@ export class RemoteSessionRepository implements SessionRepository {
     }
   }
 
-  async deleteSession(chatId: string): Promise<void> {
+  async deleteSession(sessionId: string, options?: SessionAccessOptions): Promise<void> {
     const response = await fetch(
-      BasePath.getURL(`/api/ai/chat/sessions/${encodeURIComponent(chatId)}`),
+      BasePath.getURL(`/api/ai/chat/sessions/${encodeURIComponent(sessionId)}`),
       {
         method: "DELETE",
+        headers: buildShareCodeHeaders(options),
         credentials: "same-origin",
       }
     );

--- a/src/components/chat/session/session-manager.ts
+++ b/src/components/chat/session/session-manager.ts
@@ -7,13 +7,14 @@ import {
   isNoConnectionSessionConnectionId,
   toSessionRepositoryConnectionId,
 } from "./session-connection-id";
-import type { SessionPageInput } from "./session-repository";
+import type { SessionAccessOptions, SessionPageInput } from "./session-repository";
 import { getSessionRepository } from "./session-repository-factory";
 
 const MAX_SESSION_PAGE_LIMIT = 500;
 
 export interface ManagedSession extends Chat {
   running: boolean;
+  shareCode?: string;
 }
 
 type SessionState = {
@@ -52,11 +53,27 @@ function getConnectionBucket(connectionId: string) {
   return state.sessionsByConnection[connectionId]!;
 }
 
-function toManagedSession(session: Chat, current?: ManagedSession): ManagedSession {
+function toManagedSession(
+  session: Chat,
+  current?: ManagedSession,
+  options?: SessionAccessOptions
+): ManagedSession {
   return {
     ...session,
     running: current?.running ?? state.runningByChatId[session.chatId] ?? false,
+    ...((options?.shareCode ?? current?.shareCode)
+      ? { shareCode: options?.shareCode ?? current?.shareCode }
+      : {}),
   };
+}
+
+function findManagedSession(sessionId: string): ManagedSession | undefined {
+  for (const bucket of Object.values(state.sessionsByConnection)) {
+    if (bucket[sessionId]) {
+      return bucket[sessionId]!;
+    }
+  }
+  return undefined;
 }
 
 export const SessionManager = {
@@ -190,15 +207,17 @@ export const SessionManager = {
     }
   },
 
-  async getSession(chatId: string): Promise<ManagedSession | null> {
-    for (const bucket of Object.values(state.sessionsByConnection)) {
-      if (bucket[chatId]) {
-        return bucket[chatId]!;
-      }
+  async getSession(
+    sessionId: string,
+    options?: SessionAccessOptions
+  ): Promise<ManagedSession | null> {
+    const cached = findManagedSession(sessionId);
+    if (cached && (!options?.shareCode || cached.shareCode === options.shareCode)) {
+      return cached;
     }
 
     const storage = getSessionRepository();
-    const session = await storage.getSession(chatId);
+    const session = await storage.getSession(sessionId, options);
     if (!session) {
       return null;
     }
@@ -206,18 +225,25 @@ export const SessionManager = {
     const connectionId = session.databaseId;
     if (connectionId) {
       const bucket = getConnectionBucket(connectionId);
-      bucket[chatId] = toManagedSession(session, bucket[chatId]);
+      bucket[sessionId] = toManagedSession(session, bucket[sessionId], options);
       emitChange();
-      return bucket[chatId]!;
+      return bucket[sessionId]!;
     }
 
-    return { ...session, running: false };
+    return {
+      ...session,
+      running: false,
+      ...(options?.shareCode ? { shareCode: options.shareCode } : {}),
+    };
   },
 
   upsertSession(session: Chat): ManagedSession {
     const connectionId = session.databaseId;
     if (!connectionId) {
-      return { ...session, running: state.runningByChatId[session.chatId] ?? false };
+      return {
+        ...session,
+        running: state.runningByChatId[session.chatId] ?? false,
+      };
     }
 
     const bucket = getConnectionBucket(connectionId);
@@ -242,9 +268,9 @@ export const SessionManager = {
     return this.upsertSession(session);
   },
 
-  async getMessages(chatId: string): Promise<Message[]> {
+  async getMessages(sessionId: string, options?: SessionAccessOptions): Promise<Message[]> {
     const storage = getSessionRepository();
-    return storage.getMessages(chatId);
+    return storage.getMessages(sessionId, options);
   },
 
   async createSessionFromMessages(
@@ -263,34 +289,44 @@ export const SessionManager = {
     return this.upsertSession(session);
   },
 
-  async saveMessages(chatId: string, messages: Message[]): Promise<void> {
+  async saveMessages(sessionId: string, messages: Message[]): Promise<void> {
     const storage = getSessionRepository();
-    await storage.saveMessages(chatId, messages);
+    await storage.saveMessages(sessionId, messages);
   },
 
-  async saveMessage(chatId: string, message: Message): Promise<void> {
+  async saveMessage(sessionId: string, message: Message): Promise<void> {
     const storage = getSessionRepository();
-    await storage.saveMessage(chatId, message);
+    await storage.saveMessage(sessionId, message);
   },
 
-  async getOrCreateSession(chatId: string, connectionId: string): Promise<ManagedSession> {
+  async getOrCreateSession(
+    sessionId: string,
+    connectionId: string,
+    options?: SessionAccessOptions
+  ): Promise<ManagedSession> {
     const repositoryConnectionId = toSessionRepositoryConnectionId(connectionId);
     const storage = getSessionRepository();
-    const existing = await storage.getSession(chatId);
+    const existing = await storage.getSession(sessionId, options);
     if (existing) {
-      return this.upsertSession(existing);
+      const bucket = getConnectionBucket(existing.databaseId ?? repositoryConnectionId);
+      bucket[sessionId] = toManagedSession(existing, bucket[sessionId], options);
+      emitChange();
+      return bucket[sessionId]!;
     }
 
     const now = new Date();
     const session: Chat = {
-      chatId,
+      chatId: sessionId,
       databaseId: repositoryConnectionId,
       createdAt: now,
       updatedAt: now,
     };
 
     await storage.saveSession(session);
-    return this.upsertSession(session);
+    const bucket = getConnectionBucket(repositoryConnectionId);
+    bucket[sessionId] = toManagedSession(session, bucket[sessionId], options);
+    emitChange();
+    return bucket[sessionId]!;
   },
 
   markRunning(connectionId: string | undefined, chatId: string, running: boolean) {
@@ -320,9 +356,9 @@ export const SessionManager = {
     emitChange();
   },
 
-  async renameSession(chatId: string, title: string) {
+  async renameSession(sessionId: string, title: string) {
     const storage = getSessionRepository();
-    const current = await this.getSession(chatId);
+    const current = await this.getSession(sessionId);
 
     if (!current) {
       return;
@@ -333,13 +369,17 @@ export const SessionManager = {
       title,
     };
 
-    await storage.renameSession(chatId, title);
+    await storage.renameSession(sessionId, title, { shareCode: current.shareCode });
     this.upsertSession(nextSession);
   },
 
   async deleteSessions(chatIds: string[]) {
     const storage = getSessionRepository();
-    await Promise.all(chatIds.map((chatId) => storage.deleteSession(chatId)));
+    await Promise.all(
+      chatIds.map((chatId) =>
+        storage.deleteSession(chatId, { shareCode: findManagedSession(chatId)?.shareCode })
+      )
+    );
 
     for (const chatId of chatIds) {
       for (const bucket of Object.values(state.sessionsByConnection)) {
@@ -356,8 +396,13 @@ export const SessionManager = {
     this.upsertSession(session);
   },
 
-  async touchSessionById(chatId: string, connectionId: string, title?: string) {
-    const current = await this.getOrCreateSession(chatId, connectionId);
+  async touchSessionById(
+    sessionId: string,
+    connectionId: string,
+    title?: string,
+    options?: SessionAccessOptions
+  ) {
+    const current = await this.getOrCreateSession(sessionId, connectionId, options);
     const repositoryConnectionId = toSessionRepositoryConnectionId(connectionId);
     const shouldBackfillConnectionId =
       !current.databaseId ||
@@ -374,7 +419,10 @@ export const SessionManager = {
 
     const storage = getSessionRepository();
     await storage.saveSession(nextSession);
-    return this.upsertSession(nextSession);
+    const bucket = getConnectionBucket(nextSession.databaseId ?? repositoryConnectionId);
+    bucket[sessionId] = toManagedSession(nextSession, bucket[sessionId], options);
+    emitChange();
+    return bucket[sessionId]!;
   },
 };
 

--- a/src/components/chat/session/session-repository.ts
+++ b/src/components/chat/session/session-repository.ts
@@ -18,14 +18,18 @@ export interface SessionPage<TSession = Chat> {
   nextCursor: string | null;
 }
 
+export interface SessionAccessOptions {
+  shareCode?: string;
+}
+
 export interface SessionRepository {
-  getSession(chatId: string): Promise<Chat | null>;
+  getSession(sessionId: string, options?: SessionAccessOptions): Promise<Chat | null>;
   getSessions(input: SessionPageInput): Promise<SessionPage>;
-  getMessages(chatId: string): Promise<Message[]>;
+  getMessages(sessionId: string, options?: SessionAccessOptions): Promise<Message[]>;
   createSessionFromMessages(input: CreateSessionFromMessagesInput): Promise<Chat>;
   saveSession(session: Chat): Promise<void>;
-  saveMessages(chatId: string, messages: Message[]): Promise<void>;
-  saveMessage(chatId: string, message: Message): Promise<void>;
-  renameSession(chatId: string, title: string): Promise<void>;
-  deleteSession(chatId: string): Promise<void>;
+  saveMessages(sessionId: string, messages: Message[]): Promise<void>;
+  saveMessage(sessionId: string, message: Message): Promise<void>;
+  renameSession(sessionId: string, title: string, options?: SessionAccessOptions): Promise<void>;
+  deleteSession(sessionId: string, options?: SessionAccessOptions): Promise<void>;
 }

--- a/src/components/chat/view/chat-panel.tsx
+++ b/src/components/chat/view/chat-panel.tsx
@@ -9,12 +9,15 @@ import {
 } from "@/components/chat/session/session-connection-id";
 import { SessionManager } from "@/components/chat/session/session-manager";
 import { useConnection } from "@/components/connection/connection-context";
+import { getRuntimeConfig } from "@/components/runtime-config-provider";
 import { Button } from "@/components/ui/button";
 import { useIsMobile } from "@/hooks/use-mobile";
 import type { AppUIMessage, Message } from "@/lib/ai/ai-types";
+import { BasePath } from "@/lib/base-path";
 import type { Connection } from "@/lib/connection/connection";
+import { toastManager } from "@/lib/toast";
 import type { Chat } from "@ai-sdk/react";
-import { Download, Loader2, Maximize2, Minimize2, Plus, Square, X } from "lucide-react";
+import { Download, Loader2, Maximize2, Minimize2, Plus, Share2, Square, X } from "lucide-react";
 import { useSession } from "next-auth/react";
 import * as React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -28,12 +31,15 @@ interface ChatHeaderProps {
   onClose?: () => void;
   onNewChat: () => void;
   onExport?: () => void;
+  onShare?: () => void;
   currentChatId: string;
   onSelectChat?: (id: string, connectionId?: string) => void;
   toggleDisplayMode?: () => void;
   displayMode?: ChatPanelDisplayMode;
   initialTitle?: string;
   isRunning?: boolean;
+  isSharing?: boolean;
+  canShare?: boolean;
 }
 
 type LoadChatOptions = {
@@ -41,6 +47,7 @@ type LoadChatOptions = {
   agentContext?: Partial<import("@/lib/ai/ai-types").AgentContext>;
   connectionOverride?: Connection | null;
   connectionId?: string;
+  shareCode?: string;
 };
 
 function sanitizeFileName(input: string): string {
@@ -136,16 +143,25 @@ const ChatHeader = React.memo(
     onClose,
     onNewChat,
     onExport,
+    onShare,
     currentChatId,
     onSelectChat,
     toggleDisplayMode,
     displayMode = "panel",
     initialTitle,
     isRunning,
+    isSharing,
+    canShare,
   }: ChatHeaderProps) => {
     const isMobile = useIsMobile();
     const { icon, tooltip } = getDisplayModeButtonInfo(displayMode);
     const [title, setTitle] = useState<string | undefined>(initialTitle);
+    const isShareUnavailable = !canShare;
+    const shareTitle = isShareUnavailable
+      ? getRuntimeConfig().sessionRepositoryType === "remote"
+        ? "Sharing is unavailable for this session"
+        : "Sharing is not supported because this deployment stores chat sessions in your browser."
+      : "Copy share link";
 
     // Reset title when chat ID changes
     useEffect(() => {
@@ -191,6 +207,21 @@ const ChatHeader = React.memo(
             title="Export session as Markdown"
           >
             <Download className="!h-3.5 !w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className={`h-6 w-6 ${isShareUnavailable ? "cursor-not-allowed opacity-50 hover:bg-transparent" : ""}`}
+            onClick={isShareUnavailable ? undefined : onShare}
+            disabled={canShare && (isRunning || isSharing)}
+            aria-disabled={isShareUnavailable || isRunning || isSharing}
+            title={shareTitle}
+          >
+            {isSharing ? (
+              <Loader2 className="!h-3.5 !w-3.5 animate-spin" />
+            ) : (
+              <Share2 className="!h-3.5 !w-3.5" />
+            )}
           </Button>
           {isMobile && (
             <OpenSessionListButton
@@ -251,6 +282,7 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
     setCurrentChatId,
     selectedChat,
     clearSelectedChat,
+    getSessionShareCode,
     newChatRequestNonce,
     toggleDisplayMode,
     selectChat,
@@ -258,6 +290,7 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
   const [chat, setChat] = useState<Chat<AppUIMessage> | null>(null);
   const [chatTitle, setChatTitle] = useState<string | undefined>(undefined);
   const [isRunning, setIsRunning] = useState(false);
+  const [isSharing, setIsSharing] = useState(false);
   const chatViewRef = useRef<ChatViewHandle | null>(null);
   const [isChatViewReady, setIsChatViewReady] = useState(false);
   const previousChatIdRef = useRef<string | null>(null);
@@ -280,16 +313,27 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
 
   const loadChat = useCallback(
     async (chatIdToLoad: string, options?: LoadChatOptions): Promise<void> => {
+      const shareCode = options?.shareCode ?? getSessionShareCode(chatIdToLoad);
       const chatData =
-        options?.isNewSession === true ? null : await SessionManager.getSession(chatIdToLoad);
+        options?.isNewSession === true
+          ? null
+          : await SessionManager.getSession(chatIdToLoad, { shareCode });
       const initialMessages = chatData
-        ? ((await SessionManager.getMessages(chatIdToLoad)).map(toAppUiMessage) as AppUIMessage[])
+        ? ((await SessionManager.getMessages(chatIdToLoad, { shareCode })).map(
+            toAppUiMessage
+          ) as AppUIMessage[])
         : [];
       setChatTitle(chatData?.title ?? "New Chat");
-      const targetConnection =
-        options && "connectionOverride" in options ? options.connectionOverride : connection;
+      const isSharedSession = Boolean(shareCode);
+      const targetConnection = isSharedSession
+        ? null
+        : options && "connectionOverride" in options
+          ? options.connectionOverride
+          : connection;
       const targetConnectionId =
-        options?.connectionId ?? getSessionRepositoryConnectionId(targetConnection);
+        options?.connectionId ??
+        chatData?.databaseId ??
+        getSessionRepositoryConnectionId(targetConnection);
       setLoadedChatConnectionId(targetConnectionId);
       setLoadedChatIsDraft(options?.isNewSession === true);
 
@@ -300,12 +344,13 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
         context: targetConnection ? undefined : {},
         initialMessages,
         agentContext: options?.agentContext,
+        shareCode,
       });
       setChat(newChat);
       chatViewRef.current = null;
       setIsChatViewReady(false);
     },
-    [connection]
+    [connection, getSessionShareCode]
   );
 
   const loadDraftChat = useCallback(async (): Promise<void> => {
@@ -337,6 +382,7 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
       // Explicit session selection should win when opening a hidden panel.
       if (
         selectedChat?.connectionId &&
+        !selectedChat.shareCode &&
         !isNoConnectionSessionConnectionId(selectedChat.connectionId) &&
         !connection?.matchesSessionConnectionId(selectedChat.connectionId)
       ) {
@@ -378,6 +424,7 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
               ? null
               : undefined,
           connectionId: selectedChat?.connectionId,
+          shareCode: selectedChat?.shareCode,
         });
         if (selectedChat?.chatId === loadTarget.id) {
           clearSelectedChat();
@@ -430,6 +477,7 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
     if (selectedChat.chatId === chat.id) return;
     if (
       selectedChat.connectionId &&
+      !selectedChat.shareCode &&
       !isNoConnectionSessionConnectionId(selectedChat.connectionId) &&
       !connection?.matchesSessionConnectionId(selectedChat.connectionId)
     ) {
@@ -441,6 +489,7 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
         ? null
         : undefined,
       connectionId: selectedChat.connectionId,
+      shareCode: selectedChat.shareCode,
     });
     clearSelectedChat();
   }, [chat, clearSelectedChat, connection, loadChat, selectedChat]);
@@ -487,8 +536,9 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
       return;
     }
 
-    const storedSession = await SessionManager.getSession(chat.id);
-    const storedMessages = await SessionManager.getMessages(chat.id);
+    const shareCode = getSessionShareCode(chat.id);
+    const storedSession = await SessionManager.getSession(chat.id, { shareCode });
+    const storedMessages = await SessionManager.getMessages(chat.id, { shareCode });
     const title =
       (storedSession?.title?.trim() || chatTitle?.trim() || "New Chat").trim() || "New Chat";
     const userLabel = authSession?.user?.email?.trim() || "You";
@@ -503,7 +553,42 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
     anchor.click();
     anchor.remove();
     URL.revokeObjectURL(url);
-  }, [authSession?.user?.email, chat?.id, chatTitle]);
+  }, [authSession?.user?.email, chat?.id, chatTitle, getSessionShareCode]);
+
+  const handleShareSession = useCallback(async () => {
+    if (!chat?.id || isSharing) {
+      return;
+    }
+
+    setIsSharing(true);
+    try {
+      const response = await fetch(
+        BasePath.getURL(`/api/ai/sessions/${encodeURIComponent(chat.id)}/share`),
+        {
+          method: "POST",
+          credentials: "same-origin",
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`Failed to create share link: ${response.status}`);
+      }
+
+      const data = (await response.json()) as { url?: unknown };
+      if (typeof data.url !== "string" || data.url.length === 0) {
+        throw new Error("Share API returned an invalid URL");
+      }
+
+      const shareUrl = new URL(data.url, window.location.origin).toString();
+      await navigator.clipboard.writeText(shareUrl);
+      toastManager.show("Share link copied to clipboard", "success");
+    } catch (error) {
+      console.error("Failed to share session", error);
+      toastManager.show("Failed to create share link", "error");
+    } finally {
+      setIsSharing(false);
+    }
+  }, [chat?.id, isSharing]);
 
   useEffect(() => {
     if (!chat?.id) {
@@ -552,8 +637,8 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
   }, [pendingCommand, isChatViewReady, chat, consumeCommand]);
 
   const handleSelectChat = useCallback(
-    (id: string, targetConnectionId?: string) => {
-      selectChat(id, targetConnectionId ?? chatConnectionId);
+    (id: string, targetConnectionId?: string, shareCode?: string) => {
+      selectChat(id, targetConnectionId ?? chatConnectionId, shareCode);
     },
     [chatConnectionId, selectChat]
   );
@@ -605,6 +690,11 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
     );
   }
 
+  const canShare =
+    getRuntimeConfig().sessionRepositoryType === "remote" &&
+    !loadedChatIsDraft &&
+    !getSessionShareCode(chat.id);
+
   return (
     <SqlExecutionProvider value={{ executionMode: "inline" }}>
       <div className="flex flex-col h-full bg-background overflow-hidden">
@@ -612,12 +702,15 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
           onClose={onClose}
           onNewChat={handleNewChat}
           onExport={handleExportSession}
+          onShare={handleShareSession}
           onSelectChat={handleSelectChat}
           currentChatId={chat.id}
           toggleDisplayMode={handleToggleDisplayMode}
           displayMode={displayMode}
           initialTitle={chatTitle}
           isRunning={isRunning}
+          isSharing={isSharing}
+          canShare={canShare}
         />
         <ChatView
           ref={(ref) => {

--- a/src/components/chat/view/use-chat-panel.tsx
+++ b/src/components/chat/view/use-chat-panel.tsx
@@ -8,6 +8,7 @@ export type SidebarTab = "database" | "snippets" | "history";
 export type SelectedChatTarget = {
   chatId: string;
   connectionId?: string;
+  shareCode?: string;
 };
 
 export type ChatComposerInputMode = "replace" | "append";
@@ -26,9 +27,11 @@ interface ChatPanelContextType {
   close: () => void;
   currentChatId: string | null;
   setCurrentChatId: (chatId: string | null) => void;
-  selectChat: (chatId: string, connectionId?: string) => void;
+  selectChat: (chatId: string, connectionId?: string, shareCode?: string) => void;
   selectedChat: SelectedChatTarget | null;
   clearSelectedChat: () => void;
+  getSessionShareCode: (sessionId: string) => string | undefined;
+  setSessionShareCode: (sessionId: string, shareCode: string) => void;
   requestNewChat: () => void;
   newChatRequestNonce: number;
   activeSidebarTab: SidebarTab;
@@ -74,6 +77,10 @@ const ChatPanelContext = createContext<ChatPanelContextType>({
   clearSelectedChat: () => {
     // Default implementation
   },
+  getSessionShareCode: () => undefined,
+  setSessionShareCode: () => {
+    // Default implementation
+  },
   requestNewChat: () => {
     // Default implementation
   },
@@ -98,11 +105,33 @@ const ChatPanelContext = createContext<ChatPanelContextType>({
   },
 });
 
-export function ChatPanelProvider({ children }: { children: React.ReactNode }) {
+export function ChatPanelProvider({
+  children,
+  initialSessionId,
+  initialSessionShareCode,
+}: {
+  children: React.ReactNode;
+  initialSessionId?: string;
+  initialSessionShareCode?: string;
+}) {
   // Default to hidden
-  const [displayMode, setDisplayMode] = useState<ChatPanelDisplayMode>("hidden");
+  const [displayMode, setDisplayMode] = useState<ChatPanelDisplayMode>(
+    initialSessionId ? "tabWidth" : "hidden"
+  );
   const [currentChatId, setCurrentChatId] = useState<string | null>(null);
-  const [selectedChat, setSelectedChat] = useState<SelectedChatTarget | null>(null);
+  const [selectedChat, setSelectedChat] = useState<SelectedChatTarget | null>(
+    initialSessionId
+      ? {
+          chatId: initialSessionId,
+          ...(initialSessionShareCode ? { shareCode: initialSessionShareCode } : {}),
+        }
+      : null
+  );
+  const [sessionShareCodes, setSessionShareCodes] = useState<Record<string, string>>(() =>
+    initialSessionId && initialSessionShareCode
+      ? { [initialSessionId]: initialSessionShareCode }
+      : {}
+  );
   const [newChatRequestNonce, setNewChatRequestNonce] = useState(0);
   const [activeSidebarTab, setActiveSidebarTab] = useState<SidebarTab>("database");
   const [pendingCommand, setPendingCommand] = useState<{
@@ -137,14 +166,31 @@ export function ChatPanelProvider({ children }: { children: React.ReactNode }) {
     setDisplayMode("hidden");
   };
 
-  const selectChat = (chatId: string, connectionId?: string) => {
-    setSelectedChat({ chatId, connectionId });
+  const selectChat = (chatId: string, connectionId?: string, shareCode?: string) => {
+    const nextShareCode = shareCode ?? sessionShareCodes[chatId];
+    setSelectedChat({
+      chatId,
+      connectionId,
+      ...(nextShareCode ? { shareCode: nextShareCode } : {}),
+    });
+    if (nextShareCode) {
+      setSessionShareCodes((current) => ({ ...current, [chatId]: nextShareCode }));
+    }
     setActiveSidebarTab("history");
     setDisplayMode("tabWidth");
   };
 
   const clearSelectedChat = () => {
     setSelectedChat(null);
+  };
+
+  const getSessionShareCode = (sessionId: string) => sessionShareCodes[sessionId];
+
+  const setSessionShareCode = (sessionId: string, shareCode: string) => {
+    setSessionShareCodes((current) => ({ ...current, [sessionId]: shareCode }));
+    setSelectedChat((current) =>
+      current?.chatId === sessionId ? { ...current, shareCode } : current
+    );
   };
 
   const requestNewChat = () => {
@@ -197,6 +243,8 @@ export function ChatPanelProvider({ children }: { children: React.ReactNode }) {
         selectChat,
         selectedChat,
         clearSelectedChat,
+        getSessionShareCode,
+        setSessionShareCode,
         requestNewChat,
         newChatRequestNonce,
         activeSidebarTab,

--- a/src/lib/ai/session/session-access.test.ts
+++ b/src/lib/ai/session/session-access.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PersistedChatSession, ServerSessionRepository } from "./server-session-repository";
+import { resolveSessionAccess, SessionAccessError } from "./session-access";
+import { signSessionShareCode } from "./session-share-code";
+
+function createSession(userId: string, sessionId: string): PersistedChatSession {
+  return {
+    user_id: userId,
+    session_id: sessionId,
+    connection_id: "conn-1",
+    title: "Session",
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    updated_at: new Date("2026-01-01T00:00:00.000Z"),
+  };
+}
+
+function createRepository(
+  sessions: PersistedChatSession[]
+): Pick<ServerSessionRepository, "getSession"> {
+  return {
+    async getSession(userId, sessionId) {
+      return (
+        sessions.find(
+          (session) => session.user_id === userId && session.session_id === sessionId
+        ) ?? null
+      );
+    },
+  };
+}
+
+describe("resolveSessionAccess", () => {
+  it("uses authenticated owner access before share access", async () => {
+    vi.stubEnv("SESSION_SHARE_SECRET", "test-secret");
+    const repository = createRepository([createSession("owner@example.com", "session-1")]);
+
+    await expect(
+      resolveSessionAccess({
+        repository: repository as ServerSessionRepository,
+        authenticatedUserId: "owner@example.com",
+        sessionId: "session-1",
+      })
+    ).resolves.toMatchObject({
+      kind: "owner",
+      ownerId: "owner@example.com",
+    });
+  });
+
+  it("uses a valid share code to resolve the session owner", async () => {
+    vi.stubEnv("SESSION_SHARE_SECRET", "test-secret");
+    const repository = createRepository([createSession("owner@example.com", "session-1")]);
+    const shareCode = await signSessionShareCode({
+      ownerId: "owner@example.com",
+      sessionId: "session-1",
+    });
+
+    await expect(
+      resolveSessionAccess({
+        repository: repository as ServerSessionRepository,
+        authenticatedUserId: "viewer@example.com",
+        sessionId: "session-1",
+        shareCode,
+      })
+    ).resolves.toMatchObject({
+      kind: "share",
+      ownerId: "owner@example.com",
+    });
+  });
+
+  it("prefers a supplied share code over a colliding viewer-owned session", async () => {
+    vi.stubEnv("SESSION_SHARE_SECRET", "test-secret");
+    const repository = createRepository([
+      createSession("viewer@example.com", "session-1"),
+      createSession("owner@example.com", "session-1"),
+    ]);
+    const shareCode = await signSessionShareCode({
+      ownerId: "owner@example.com",
+      sessionId: "session-1",
+    });
+
+    await expect(
+      resolveSessionAccess({
+        repository: repository as ServerSessionRepository,
+        authenticatedUserId: "viewer@example.com",
+        sessionId: "session-1",
+        shareCode,
+      })
+    ).resolves.toMatchObject({
+      kind: "share",
+      ownerId: "owner@example.com",
+    });
+  });
+
+  it("rejects a share code for a different session", async () => {
+    vi.stubEnv("SESSION_SHARE_SECRET", "test-secret");
+    const repository = createRepository([createSession("owner@example.com", "session-1")]);
+    const shareCode = await signSessionShareCode({
+      ownerId: "owner@example.com",
+      sessionId: "session-2",
+    });
+
+    await expect(
+      resolveSessionAccess({
+        repository: repository as ServerSessionRepository,
+        authenticatedUserId: "viewer@example.com",
+        sessionId: "session-1",
+        shareCode,
+      })
+    ).rejects.toMatchObject(new SessionAccessError("Invalid session share code", 403));
+  });
+});

--- a/src/lib/ai/session/session-access.ts
+++ b/src/lib/ai/session/session-access.ts
@@ -1,0 +1,76 @@
+import type {
+  PersistedChatSession,
+  ServerSessionRepository,
+} from "@/lib/ai/session/server-session-repository";
+import { verifySessionShareCode } from "./session-share-code";
+
+export type SessionAccess =
+  | {
+      kind: "owner";
+      ownerId: string;
+      session: PersistedChatSession;
+    }
+  | {
+      kind: "share";
+      ownerId: string;
+      session: PersistedChatSession;
+    };
+
+export class SessionAccessError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number
+  ) {
+    super(message);
+    this.name = "SessionAccessError";
+  }
+}
+
+export async function resolveSessionAccess(input: {
+  repository: ServerSessionRepository;
+  authenticatedUserId: string | undefined;
+  sessionId: string;
+  shareCode?: string | null;
+}): Promise<SessionAccess> {
+  if (!input.authenticatedUserId) {
+    throw new SessionAccessError("Authentication required", 401);
+  }
+
+  if (input.shareCode) {
+    let claims: Awaited<ReturnType<typeof verifySessionShareCode>>;
+    try {
+      claims = await verifySessionShareCode(input.shareCode);
+    } catch {
+      throw new SessionAccessError("Invalid session share code", 403);
+    }
+
+    if (claims.sessionId !== input.sessionId) {
+      throw new SessionAccessError("Invalid session share code", 403);
+    }
+
+    const sharedSession = await input.repository.getSession(claims.issuer, input.sessionId);
+    if (!sharedSession) {
+      throw new SessionAccessError("Not found", 404);
+    }
+
+    return {
+      kind: "share",
+      ownerId: claims.issuer,
+      session: sharedSession,
+    };
+  }
+
+  const ownerSession = await input.repository.getSession(
+    input.authenticatedUserId,
+    input.sessionId
+  );
+  if (ownerSession) {
+    return {
+      kind: "owner",
+      ownerId: input.authenticatedUserId,
+      session: ownerSession,
+    };
+  }
+
+  throw new SessionAccessError("Not found", 404);
+}

--- a/src/lib/ai/session/session-share-code.test.ts
+++ b/src/lib/ai/session/session-share-code.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { signSessionShareCode, verifySessionShareCode } from "./session-share-code";
+import { SESSION_SHARE_SCOPE_FULL } from "./session-share-constants";
+
+describe("session share codes", () => {
+  it("round-trips owner, session, scope, and expiration claims", async () => {
+    vi.stubEnv("SESSION_SHARE_SECRET", "test-secret");
+
+    const code = await signSessionShareCode({
+      ownerId: "owner@example.com",
+      sessionId: "session-1",
+      expiresAt: 4102444800,
+    });
+
+    await expect(verifySessionShareCode(code)).resolves.toEqual({
+      issuer: "owner@example.com",
+      sessionId: "session-1",
+      scope: SESSION_SHARE_SCOPE_FULL,
+      expiresAt: 4102444800,
+    });
+  });
+
+  it("rejects expired share codes", async () => {
+    vi.stubEnv("SESSION_SHARE_SECRET", "test-secret");
+
+    const code = await signSessionShareCode({
+      ownerId: "owner@example.com",
+      sessionId: "session-1",
+      expiresAt: 1,
+    });
+
+    await expect(verifySessionShareCode(code)).rejects.toThrow();
+  });
+});

--- a/src/lib/ai/session/session-share-code.ts
+++ b/src/lib/ai/session/session-share-code.ts
@@ -1,0 +1,66 @@
+import { jwtVerify, SignJWT } from "jose";
+import {
+  SESSION_SHARE_EXPIRES_AT_SECONDS,
+  SESSION_SHARE_SCOPE_FULL,
+} from "./session-share-constants";
+
+export type SessionShareClaims = {
+  issuer: string;
+  sessionId: string;
+  scope: typeof SESSION_SHARE_SCOPE_FULL;
+  expiresAt: number;
+};
+
+const SHARE_CODE_ISSUER = "https://datastoria.app/session/share";
+
+function getShareCodeSecret(): Uint8Array {
+  const secret = process.env.SESSION_SHARE_SECRET ?? process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    throw new Error("SESSION_SHARE_SECRET or NEXTAUTH_SECRET is required to sign session shares");
+  }
+  return new TextEncoder().encode(secret);
+}
+
+export async function signSessionShareCode(input: {
+  ownerId: string;
+  sessionId: string;
+  expiresAt?: number;
+}): Promise<string> {
+  const expiresAt = input.expiresAt ?? SESSION_SHARE_EXPIRES_AT_SECONDS;
+  const now = Math.floor(Date.now() / 1000);
+
+  return new SignJWT({ scope: SESSION_SHARE_SCOPE_FULL })
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .setIssuer(input.ownerId)
+    .setSubject(input.sessionId)
+    .setAudience(SHARE_CODE_ISSUER)
+    .setIssuedAt(now)
+    .setNotBefore(now)
+    .setExpirationTime(expiresAt)
+    .sign(getShareCodeSecret());
+}
+
+export async function verifySessionShareCode(code: string): Promise<SessionShareClaims> {
+  const { payload } = await jwtVerify(code, getShareCodeSecret(), {
+    algorithms: ["HS256"],
+    audience: SHARE_CODE_ISSUER,
+  });
+
+  if (
+    typeof payload.iss !== "string" ||
+    payload.iss.length === 0 ||
+    typeof payload.sub !== "string" ||
+    payload.sub.length === 0 ||
+    payload.scope !== SESSION_SHARE_SCOPE_FULL ||
+    typeof payload.exp !== "number"
+  ) {
+    throw new Error("Invalid session share code");
+  }
+
+  return {
+    issuer: payload.iss,
+    sessionId: payload.sub,
+    scope: SESSION_SHARE_SCOPE_FULL,
+    expiresAt: payload.exp,
+  };
+}

--- a/src/lib/ai/session/session-share-constants.ts
+++ b/src/lib/ai/session/session-share-constants.ts
@@ -1,0 +1,4 @@
+export const SESSION_SHARE_CODE_HEADER = "X-Session-Share-Code";
+export const SESSION_SHARE_SCOPE_FULL = "chat_session:full";
+export const SESSION_SHARE_EXPIRES_AT_SECONDS = 4102444800;
+export const SESSION_SHARE_EXPIRES_AT = new Date(SESSION_SHARE_EXPIRES_AT_SECONDS * 1000);


### PR DESCRIPTION
## Summary

Adds shareable chat session links served at `/session/[sessionId]?code=...` for deployments using the remote session repository.

## Changes

- Adds server-signed session share code generation and validation.
- Adds `POST /api/ai/sessions/[sessionId]/share` to create share URLs.
- Adds the shared session route and extracts the common app shell so shared sessions open inside the existing layout.
- Threads `X-Session-Share-Code` through remote session reads and chat continuation.
- Prevents shared sessions from executing against the viewer's local ClickHouse connection.
- Keeps the share icon visible when sharing is unavailable, with an explanatory disabled tooltip for browser-side session storage.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test -- src/lib/ai/session/session-share-code.test.ts src/lib/ai/session/session-access.test.ts src/components/chat/session/remote-session-repository.test.ts src/components/chat/view/use-chat-panel.test.tsx`
- `npm run build`