### PR TITLE
Fix currency dollar rendering in markdown

### DIFF
--- a/src/components/chat/message/message-markdown-math.ts
+++ b/src/components/chat/message/message-markdown-math.ts
@@ -210,10 +210,10 @@ export function escapeCurrencyDollarSigns(text: string) {
       !inCode &&
       character === "$" &&
       /\d/.test(text[index + 1] ?? "") &&
+      isUnescapedDollar(text, index) &&
       !isNumericInlineMathOpen(index, currentLineStart)
     ) {
-      const previousCharacter = text[index - 1] ?? "";
-      normalized += previousCharacter === "\\" ? "$" : "\\$";
+      normalized += "\\$";
       index += 1;
       atLineStart = false;
       continue;

--- a/src/components/chat/message/message-markdown-math.ts
+++ b/src/components/chat/message/message-markdown-math.ts
@@ -29,11 +29,30 @@ function getCurrentLinePrefix(text: string, index: number) {
   return text.slice(lineStart, index);
 }
 
-function getIndentedFenceMarker(text: string, index: number) {
+function skipOptionalIndent(text: string, index: number) {
   let markerStart = index;
   while (text[markerStart] === " " && markerStart - index < 3) {
     markerStart += 1;
   }
+  return markerStart;
+}
+
+function getMarkdownLineContentStart(text: string, index: number) {
+  let markerStart = skipOptionalIndent(text, index);
+
+  while (text[markerStart] === ">") {
+    markerStart += 1;
+    if (text[markerStart] === " " || text[markerStart] === "\t") {
+      markerStart += 1;
+    }
+    markerStart = skipOptionalIndent(text, markerStart);
+  }
+
+  return markerStart;
+}
+
+function getIndentedFenceMarker(text: string, index: number) {
+  const markerStart = getMarkdownLineContentStart(text, index);
 
   const fenceCharacter = text[markerStart];
   if (fenceCharacter !== "`" && fenceCharacter !== "~") {
@@ -51,26 +70,66 @@ function getIndentedFenceMarker(text: string, index: number) {
   };
 }
 
-function hasNumericInlineMathClose(text: string, openIndex: number) {
-  let index = openIndex + 1;
-  while (index < text.length) {
+function isUnescapedDollar(text: string, index: number) {
+  if (text[index] !== "$") {
+    return false;
+  }
+
+  let backslashCount = 0;
+  let cursor = index - 1;
+  while (text[cursor] === "\\") {
+    backslashCount += 1;
+    cursor -= 1;
+  }
+
+  return backslashCount % 2 === 0;
+}
+
+function getLineEnd(text: string, lineStart: number) {
+  const lineEnd = text.indexOf("\n", lineStart);
+  return lineEnd === -1 ? text.length : lineEnd;
+}
+
+function findNumericInlineMathOpenIndexes(text: string, lineStart: number) {
+  const lineEnd = getLineEnd(text, lineStart);
+  const openIndexes = new Set<number>();
+  let pendingNumericOpenIndex: number | null = null;
+  let index = lineStart;
+
+  while (index < lineEnd) {
     const character = text[index];
 
-    if (character === "`" || character === "\n") {
-      return false;
+    if (character === "`") {
+      pendingNumericOpenIndex = null;
+      const delimiterLength = countRepeatedCharacter(text, index, "`");
+      const delimiter = "`".repeat(delimiterLength);
+      const closeIndex = text.indexOf(delimiter, index + delimiterLength);
+      if (closeIndex === -1 || closeIndex >= lineEnd) {
+        break;
+      }
+      index = closeIndex + delimiterLength;
+      continue;
     }
 
-    if (character === "$" && text[index - 1] !== "\\") {
-      if (/\s/.test(text[index - 1] ?? "")) {
-        return false;
+    if (isUnescapedDollar(text, index)) {
+      if (pendingNumericOpenIndex !== null) {
+        const previousCharacter = text[index - 1] ?? "";
+        const nextCharacter = text[index + 1] ?? "";
+        if (!/\s/.test(previousCharacter) && !/\d/.test(nextCharacter)) {
+          openIndexes.add(pendingNumericOpenIndex);
+          pendingNumericOpenIndex = null;
+          index += 1;
+          continue;
+        }
       }
-      return !/\d/.test(text[index + 1] ?? "");
+
+      pendingNumericOpenIndex = /\d/.test(text[index + 1] ?? "") ? index : null;
     }
 
     index += 1;
   }
 
-  return false;
+  return openIndexes;
 }
 
 export function escapeCurrencyDollarSigns(text: string) {
@@ -79,6 +138,17 @@ export function escapeCurrencyDollarSigns(text: string) {
   let atLineStart = true;
   let fenceMarker: string | null = null;
   let inlineCodeDelimiterLength = 0;
+  const numericInlineMathOpenIndexesByLine = new Map<number, Set<number>>();
+
+  function isNumericInlineMathOpen(openIndex: number) {
+    const lineStart = text.lastIndexOf("\n", openIndex - 1) + 1;
+    let openIndexes = numericInlineMathOpenIndexesByLine.get(lineStart);
+    if (openIndexes === undefined) {
+      openIndexes = findNumericInlineMathOpenIndexes(text, lineStart);
+      numericInlineMathOpenIndexesByLine.set(lineStart, openIndexes);
+    }
+    return openIndexes.has(openIndex);
+  }
 
   while (index < text.length) {
     if (atLineStart) {
@@ -123,7 +193,7 @@ export function escapeCurrencyDollarSigns(text: string) {
       !inCode &&
       character === "$" &&
       /\d/.test(text[index + 1] ?? "") &&
-      !hasNumericInlineMathClose(text, index)
+      !isNumericInlineMathOpen(index)
     ) {
       const previousCharacter = text[index - 1] ?? "";
       normalized += previousCharacter === "\\" ? "$" : "\\$";

--- a/src/components/chat/message/message-markdown-math.ts
+++ b/src/components/chat/message/message-markdown-math.ts
@@ -39,8 +39,10 @@ function skipOptionalIndent(text: string, index: number) {
 
 function getMarkdownLineContentStart(text: string, index: number) {
   let markerStart = skipOptionalIndent(text, index);
+  let hasBlockquoteMarker = false;
 
   while (text[markerStart] === ">") {
+    hasBlockquoteMarker = true;
     markerStart += 1;
     if (text[markerStart] === " " || text[markerStart] === "\t") {
       markerStart += 1;
@@ -48,11 +50,18 @@ function getMarkdownLineContentStart(text: string, index: number) {
     markerStart = skipOptionalIndent(text, markerStart);
   }
 
-  return markerStart;
+  return { markerStart, hasBlockquoteMarker };
 }
 
-function getIndentedFenceMarker(text: string, index: number) {
-  const markerStart = getMarkdownLineContentStart(text, index);
+function getIndentedFenceMarker(
+  text: string,
+  index: number,
+  { allowBlockquoteMarkers }: { allowBlockquoteMarkers: boolean }
+) {
+  const { markerStart, hasBlockquoteMarker } = getMarkdownLineContentStart(text, index);
+  if (hasBlockquoteMarker && !allowBlockquoteMarkers) {
+    return null;
+  }
 
   const fenceCharacter = text[markerStart];
   if (fenceCharacter !== "`" && fenceCharacter !== "~") {
@@ -67,6 +76,7 @@ function getIndentedFenceMarker(text: string, index: number) {
   return {
     markerStart,
     marker: fenceCharacter.repeat(fenceCount),
+    hasBlockquoteMarker,
   };
 }
 
@@ -137,6 +147,7 @@ export function escapeCurrencyDollarSigns(text: string) {
   let index = 0;
   let atLineStart = true;
   let fenceMarker: string | null = null;
+  let fenceHasBlockquoteMarker = false;
   let inlineCodeDelimiterLength = 0;
   const numericInlineMathOpenIndexesByLine = new Map<number, Set<number>>();
 
@@ -152,7 +163,9 @@ export function escapeCurrencyDollarSigns(text: string) {
 
   while (index < text.length) {
     if (atLineStart) {
-      const fence = getIndentedFenceMarker(text, index);
+      const fence = getIndentedFenceMarker(text, index, {
+        allowBlockquoteMarkers: fenceMarker === null || fenceHasBlockquoteMarker,
+      });
       const canCloseExistingFence =
         fenceMarker !== null &&
         fence !== null &&
@@ -163,8 +176,10 @@ export function escapeCurrencyDollarSigns(text: string) {
         const prefix = text.slice(index, fence.markerStart);
         if (fenceMarker === null) {
           fenceMarker = fence.marker;
+          fenceHasBlockquoteMarker = fence.hasBlockquoteMarker;
         } else if (canCloseExistingFence) {
           fenceMarker = null;
+          fenceHasBlockquoteMarker = false;
         }
         normalized += `${prefix}${fence.marker}`;
         index = fence.markerStart + fence.marker.length;
@@ -215,11 +230,14 @@ export function normalizeMathMarkdown(text: string) {
   let index = 0;
   let atLineStart = true;
   let fenceMarker: string | null = null;
+  let fenceHasBlockquoteMarker = false;
   let inlineCodeDelimiterLength = 0;
 
   while (index < text.length) {
     if (atLineStart) {
-      const fence = getIndentedFenceMarker(text, index);
+      const fence = getIndentedFenceMarker(text, index, {
+        allowBlockquoteMarkers: fenceMarker === null || fenceHasBlockquoteMarker,
+      });
       const canCloseExistingFence =
         fenceMarker !== null &&
         fence !== null &&
@@ -230,8 +248,10 @@ export function normalizeMathMarkdown(text: string) {
         const prefix = text.slice(index, fence.markerStart);
         if (fenceMarker === null) {
           fenceMarker = fence.marker;
+          fenceHasBlockquoteMarker = fence.hasBlockquoteMarker;
         } else if (canCloseExistingFence) {
           fenceMarker = null;
+          fenceHasBlockquoteMarker = false;
         }
         normalized += `${prefix}${fence.marker}`;
         index = fence.markerStart + fence.marker.length;

--- a/src/components/chat/message/message-markdown-math.ts
+++ b/src/components/chat/message/message-markdown-math.ts
@@ -115,7 +115,8 @@ function findNumericInlineMathOpenIndexes(text: string, lineStart: number) {
       const delimiter = "`".repeat(delimiterLength);
       const closeIndex = text.indexOf(delimiter, index + delimiterLength);
       if (closeIndex === -1 || closeIndex >= lineEnd) {
-        break;
+        index += delimiterLength;
+        continue;
       }
       index = closeIndex + delimiterLength;
       continue;
@@ -151,8 +152,7 @@ export function escapeCurrencyDollarSigns(text: string) {
   let inlineCodeDelimiterLength = 0;
   const numericInlineMathOpenIndexesByLine = new Map<number, Set<number>>();
 
-  function isNumericInlineMathOpen(openIndex: number) {
-    const lineStart = text.lastIndexOf("\n", openIndex - 1) + 1;
+  function isNumericInlineMathOpen(openIndex: number, lineStart: number) {
     let openIndexes = numericInlineMathOpenIndexesByLine.get(lineStart);
     if (openIndexes === undefined) {
       openIndexes = findNumericInlineMathOpenIndexes(text, lineStart);
@@ -161,8 +161,10 @@ export function escapeCurrencyDollarSigns(text: string) {
     return openIndexes.has(openIndex);
   }
 
+  let currentLineStart = 0;
   while (index < text.length) {
     if (atLineStart) {
+      currentLineStart = index;
       const fence = getIndentedFenceMarker(text, index, {
         allowBlockquoteMarkers: fenceMarker === null || fenceHasBlockquoteMarker,
       });
@@ -208,7 +210,7 @@ export function escapeCurrencyDollarSigns(text: string) {
       !inCode &&
       character === "$" &&
       /\d/.test(text[index + 1] ?? "") &&
-      !isNumericInlineMathOpen(index)
+      !isNumericInlineMathOpen(index, currentLineStart)
     ) {
       const previousCharacter = text[index - 1] ?? "";
       normalized += previousCharacter === "\\" ? "$" : "\\$";

--- a/src/components/chat/message/message-markdown-math.ts
+++ b/src/components/chat/message/message-markdown-math.ts
@@ -29,6 +29,117 @@ function getCurrentLinePrefix(text: string, index: number) {
   return text.slice(lineStart, index);
 }
 
+function getIndentedFenceMarker(text: string, index: number) {
+  let markerStart = index;
+  while (text[markerStart] === " " && markerStart - index < 3) {
+    markerStart += 1;
+  }
+
+  const fenceCharacter = text[markerStart];
+  if (fenceCharacter !== "`" && fenceCharacter !== "~") {
+    return null;
+  }
+
+  const fenceCount = countRepeatedCharacter(text, markerStart, fenceCharacter);
+  if (fenceCount < 3) {
+    return null;
+  }
+
+  return {
+    markerStart,
+    marker: fenceCharacter.repeat(fenceCount),
+  };
+}
+
+function hasNumericInlineMathClose(text: string, openIndex: number) {
+  let index = openIndex + 1;
+  while (index < text.length) {
+    const character = text[index];
+
+    if (character === "`" || character === "\n") {
+      return false;
+    }
+
+    if (character === "$" && text[index - 1] !== "\\") {
+      if (/\s/.test(text[index - 1] ?? "")) {
+        return false;
+      }
+      return !/\d/.test(text[index + 1] ?? "");
+    }
+
+    index += 1;
+  }
+
+  return false;
+}
+
+export function escapeCurrencyDollarSigns(text: string) {
+  let normalized = "";
+  let index = 0;
+  let atLineStart = true;
+  let fenceMarker: string | null = null;
+  let inlineCodeDelimiterLength = 0;
+
+  while (index < text.length) {
+    if (atLineStart) {
+      const fence = getIndentedFenceMarker(text, index);
+      const canCloseExistingFence =
+        fenceMarker !== null &&
+        fence !== null &&
+        fence.marker[0] === fenceMarker[0] &&
+        fence.marker.length >= fenceMarker.length;
+
+      if (fence !== null) {
+        const prefix = text.slice(index, fence.markerStart);
+        if (fenceMarker === null) {
+          fenceMarker = fence.marker;
+        } else if (canCloseExistingFence) {
+          fenceMarker = null;
+        }
+        normalized += `${prefix}${fence.marker}`;
+        index = fence.markerStart + fence.marker.length;
+        atLineStart = false;
+        continue;
+      }
+    }
+
+    if (fenceMarker === null && text[index] === "`") {
+      const backtickCount = countRepeatedCharacter(text, index, "`");
+      if (inlineCodeDelimiterLength === 0) {
+        inlineCodeDelimiterLength = backtickCount;
+      } else if (inlineCodeDelimiterLength === backtickCount) {
+        inlineCodeDelimiterLength = 0;
+      }
+      normalized += "`".repeat(backtickCount);
+      index += backtickCount;
+      atLineStart = false;
+      continue;
+    }
+
+    const inCode = fenceMarker !== null || inlineCodeDelimiterLength > 0;
+    const character = text[index] ?? "";
+
+    if (
+      !inCode &&
+      character === "$" &&
+      /\d/.test(text[index + 1] ?? "") &&
+      !hasNumericInlineMathClose(text, index)
+    ) {
+      const previousCharacter = text[index - 1] ?? "";
+      normalized += previousCharacter === "\\" ? "$" : "\\$";
+      index += 1;
+      atLineStart = false;
+      continue;
+    }
+
+    normalized += character;
+    atLineStart = character === "\n";
+    index += 1;
+  }
+
+  return normalized;
+}
+
 export function normalizeMathMarkdown(text: string) {
   let normalized = "";
   let index = 0;
@@ -37,23 +148,23 @@ export function normalizeMathMarkdown(text: string) {
   let inlineCodeDelimiterLength = 0;
 
   while (index < text.length) {
-    if (atLineStart && (text[index] === "`" || text[index] === "~")) {
-      const fenceCharacter = text[index]!;
-      const fenceCount = countRepeatedCharacter(text, index, fenceCharacter);
+    if (atLineStart) {
+      const fence = getIndentedFenceMarker(text, index);
       const canCloseExistingFence =
         fenceMarker !== null &&
-        fenceMarker[0] === fenceCharacter &&
-        fenceCount >= fenceMarker.length;
+        fence !== null &&
+        fence.marker[0] === fenceMarker[0] &&
+        fence.marker.length >= fenceMarker.length;
 
-      if (fenceCount >= 3) {
-        const marker = fenceCharacter.repeat(fenceCount);
+      if (fence !== null) {
+        const prefix = text.slice(index, fence.markerStart);
         if (fenceMarker === null) {
-          fenceMarker = marker;
+          fenceMarker = fence.marker;
         } else if (canCloseExistingFence) {
           fenceMarker = null;
         }
-        normalized += marker;
-        index += fenceCount;
+        normalized += `${prefix}${fence.marker}`;
+        index = fence.markerStart + fence.marker.length;
         atLineStart = false;
         continue;
       }

--- a/src/components/chat/message/message-markdown.test.tsx
+++ b/src/components/chat/message/message-markdown.test.tsx
@@ -159,6 +159,14 @@ describe("MessageMarkdown", () => {
     expect(container.querySelector(".katex")).not.toBeNull();
   });
 
+  it("preserves numeric inline math after unmatched backticks", () => {
+    act(() => {
+      root.render(<MessageMarkdown text={"Unmatched ` marker before inline math: $300$"} />);
+    });
+
+    expect(container.querySelector(".katex")).not.toBeNull();
+  });
+
   it("does not pair currency with a later inline math opener", () => {
     act(() => {
       root.render(<MessageMarkdown text={"Close below $300 and compare $x$"} />);

--- a/src/components/chat/message/message-markdown.test.tsx
+++ b/src/components/chat/message/message-markdown.test.tsx
@@ -282,6 +282,20 @@ describe("MessageMarkdown", () => {
     );
   });
 
+  it("does not treat blockquote-looking content as a closing fence inside normal code blocks", () => {
+    act(() => {
+      root.render(<MessageMarkdown text={"```text\n> ```\n$300\n```"} />);
+    });
+
+    expect(container.querySelector(".katex")).toBeNull();
+    expect(syntaxHighlighterSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        language: "text",
+        children: "> ```\n$300",
+      })
+    );
+  });
+
   it("does not parse LaTeX delimiters inside tilde-fenced code blocks", () => {
     act(() => {
       root.render(<MessageMarkdown text={"~~~text\n\\[\n\\text{avg_row_size}\n\\]\n~~~"} />);

--- a/src/components/chat/message/message-markdown.test.tsx
+++ b/src/components/chat/message/message-markdown.test.tsx
@@ -151,6 +151,21 @@ describe("MessageMarkdown", () => {
     expect(container.textContent).toContain("below $285 plus weak guidance");
   });
 
+  it("escapes currency after an even-length backslash run", async () => {
+    const { escapeCurrencyDollarSigns } = await import("./message-markdown-math");
+    const source = String.raw`Path prefix \\$300 remains currency`;
+
+    expect(escapeCurrencyDollarSigns(source)).toBe(
+      String.raw`Path prefix \\\$300 remains currency`
+    );
+
+    act(() => {
+      root.render(<MessageMarkdown text={source} />);
+    });
+
+    expect(container.querySelector(".katex")).toBeNull();
+  });
+
   it("preserves valid numeric inline math with dollar delimiters", () => {
     act(() => {
       root.render(<MessageMarkdown text={"Inline math: $300$"} />);

--- a/src/components/chat/message/message-markdown.test.tsx
+++ b/src/components/chat/message/message-markdown.test.tsx
@@ -170,6 +170,24 @@ describe("MessageMarkdown", () => {
     expect(container.textContent).toContain("Close below $300 and compare");
   });
 
+  it("escapes repeated currency values without breaking later inline math", () => {
+    act(() => {
+      root.render(
+        <MessageMarkdown
+          text={`${Array.from({ length: 50 }, (_, index) => `$${index + 100}`).join(
+            ", "
+          )}, formula $x$`}
+        />
+      );
+    });
+
+    const math = container.querySelector(".katex");
+    expect(math).not.toBeNull();
+    expect(math?.textContent).toContain("x");
+    expect(math?.textContent).not.toContain("100");
+    expect(container.textContent).toContain("$100, $101");
+  });
+
   it("renders LaTeX display math from backslash delimiters", () => {
     act(() => {
       root.render(
@@ -239,6 +257,20 @@ describe("MessageMarkdown", () => {
   it("does not escape currency inside indented fenced code blocks", () => {
     act(() => {
       root.render(<MessageMarkdown text={"   ```text\n$300\n```"} />);
+    });
+
+    expect(container.querySelector(".katex")).toBeNull();
+    expect(syntaxHighlighterSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        language: "text",
+        children: "$300",
+      })
+    );
+  });
+
+  it("does not escape currency inside blockquoted fenced code blocks", () => {
+    act(() => {
+      root.render(<MessageMarkdown text={"> ```text\n> $300\n> ```"} />);
     });
 
     expect(container.querySelector(".katex")).toBeNull();

--- a/src/components/chat/message/message-markdown.test.tsx
+++ b/src/components/chat/message/message-markdown.test.tsx
@@ -135,6 +135,41 @@ describe("MessageMarkdown", () => {
     expect(container.querySelector(".katex-display")).toBeNull();
   });
 
+  it("renders currency dollar signs inside markdown tables as text, not math delimiters", () => {
+    act(() => {
+      root.render(
+        <MessageMarkdown
+          text={
+            "| Field | Detail |\n| --- | --- |\n| **Stop / invalidation** | Close below **$300** damages breakout; below **$285** plus weak guidance invalidates current setup |"
+          }
+        />
+      );
+    });
+
+    expect(container.querySelector(".katex")).toBeNull();
+    expect(container.textContent).toContain("Close below $300 damages breakout");
+    expect(container.textContent).toContain("below $285 plus weak guidance");
+  });
+
+  it("preserves valid numeric inline math with dollar delimiters", () => {
+    act(() => {
+      root.render(<MessageMarkdown text={"Inline math: $300$"} />);
+    });
+
+    expect(container.querySelector(".katex")).not.toBeNull();
+  });
+
+  it("does not pair currency with a later inline math opener", () => {
+    act(() => {
+      root.render(<MessageMarkdown text={"Close below $300 and compare $x$"} />);
+    });
+
+    const math = container.querySelector(".katex");
+    expect(math).not.toBeNull();
+    expect(math?.textContent).not.toContain("300");
+    expect(container.textContent).toContain("Close below $300 and compare");
+  });
+
   it("renders LaTeX display math from backslash delimiters", () => {
     act(() => {
       root.render(
@@ -197,6 +232,20 @@ describe("MessageMarkdown", () => {
       expect.objectContaining({
         language: "text",
         children: "\\[\n\\text{avg_row_size}\n\\]",
+      })
+    );
+  });
+
+  it("does not escape currency inside indented fenced code blocks", () => {
+    act(() => {
+      root.render(<MessageMarkdown text={"   ```text\n$300\n```"} />);
+    });
+
+    expect(container.querySelector(".katex")).toBeNull();
+    expect(syntaxHighlighterSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        language: "text",
+        children: "$300",
       })
     );
   });

--- a/src/components/chat/message/message-markdown.tsx
+++ b/src/components/chat/message/message-markdown.tsx
@@ -16,7 +16,7 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { FileLink } from "./file-link";
 import { MessageMarkdownChartSpec } from "./message-markdown-chat";
-import { normalizeMathMarkdown } from "./message-markdown-math";
+import { escapeCurrencyDollarSigns, normalizeMathMarkdown } from "./message-markdown-math";
 import { MessageMarkdownSql } from "./message-markdown-sql";
 import { MessageMarkdownVizlayer } from "./message-markdown-vizlayer";
 import { remarkExtensions } from "./remark-extensions";
@@ -106,7 +106,10 @@ export const MessageMarkdown = memo(function MessageMarkdown({
   expandable = false,
 }: MessageMarkdownProps) {
   const { connection } = useConnection();
-  const normalizedText = useMemo(() => normalizeMathMarkdown(text), [text]);
+  const normalizedText = useMemo(
+    () => normalizeMathMarkdown(escapeCurrencyDollarSigns(text)),
+    [text]
+  );
 
   const codeBlockStyle = useMemo<React.CSSProperties>(
     () => ({


### PR DESCRIPTION
## Summary
- escape currency-style dollar signs before remark-math parses chat markdown
- preserve numeric inline math and indented fenced code blocks
- add regression coverage for currency in tables and currency before inline math

## Validation
- npm run test -- src/components/chat/message/message-markdown.test.tsx --run
- npm run build