### PR TITLE
Refine chat tool rendering UI

### DIFF
--- a/src/components/chat/message/chat-message-list.tsx
+++ b/src/components/chat/message/chat-message-list.tsx
@@ -8,6 +8,7 @@ import { AlertCircle } from "lucide-react";
 import * as React from "react";
 import { useDebouncedCallback } from "use-debounce";
 import { ChatMessage } from "./chat-message";
+import { RUNNING_TEXT_CLASS } from "./collapsible-part";
 
 interface ChatMessageListProps {
   messages: AppUIMessage[];
@@ -156,7 +157,7 @@ export const ChatMessageList = React.memo(
 
                     <div className="flex-1 overflow-hidden min-w-0 text-sm pr-6">
                       <div className="flex items-center gap-2 text-muted-foreground">
-                        <span>Thinking</span>
+                        <span className={RUNNING_TEXT_CLASS}>Thinking</span>
                       </div>
                       <div className="mt-2 flex items-center gap-2 text-muted-foreground">
                         <TypingDots />

--- a/src/components/chat/message/chat-message.tsx
+++ b/src/components/chat/message/chat-message.tsx
@@ -16,7 +16,7 @@ import {
   groupRenderableParts,
   type MessagePart,
 } from "./chat-message-parts";
-import { CollapsiblePart } from "./collapsible-part";
+import { CollapsiblePart, RUNNING_TEXT_CLASS } from "./collapsible-part";
 import { ErrorMessageDisplay } from "./message-error";
 import { MessageMarkdown } from "./message-markdown";
 import { MessageReasoning } from "./message-reasoning";
@@ -405,7 +405,7 @@ export const ChatMessage = memo(function ChatMessage({
               {parts.length === 0 && isLoading && (
                 <div className="flex items-center gap-2 text-muted-foreground">
                   {/* Under the state that request is submitted, but server has not responded yet */}
-                  <span>{loadingText}</span>
+                  <span className={RUNNING_TEXT_CLASS}>{loadingText}</span>
                 </div>
               )}
               {parts.length === 0 && !isLoading && !error && "Nothing returned"}

--- a/src/components/chat/message/collapsible-part.test.tsx
+++ b/src/components/chat/message/collapsible-part.test.tsx
@@ -43,13 +43,14 @@ describe("CollapsiblePart", () => {
 
     expect(container.textContent).not.toContain("Grouped tool call details");
 
-    const header = container.querySelector(".cursor-pointer");
+    const header = container.querySelector('button[aria-expanded="false"]');
     expect(header).not.toBeNull();
 
     act(() => {
       header!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
+    expect(header?.getAttribute("aria-expanded")).toBe("true");
     expect(container.textContent).toContain("Grouped tool call details");
 
     act(() => {

--- a/src/components/chat/message/collapsible-part.test.tsx
+++ b/src/components/chat/message/collapsible-part.test.tsx
@@ -101,4 +101,26 @@ describe("CollapsiblePart", () => {
 
     expect(container.textContent).toContain("Grouped tool call details");
   });
+
+  it("does not present conditionally empty children as expandable", () => {
+    act(() => {
+      root.render(
+        <CollapsiblePart
+          toolName="Empty tool details"
+          state="output-available"
+          isRunning={false}
+          defaultExpanded
+        >
+          {false}
+          {null}
+          {undefined}
+          {""}
+        </CollapsiblePart>
+      );
+    });
+
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.querySelector(".border-l")).toBeNull();
+    expect(container.textContent).toContain("Empty tool details");
+  });
 });

--- a/src/components/chat/message/collapsible-part.test.tsx
+++ b/src/components/chat/message/collapsible-part.test.tsx
@@ -4,8 +4,8 @@
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { CollapsiblePart } from "./collapsible-part";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CollapsiblePart, Timer } from "./collapsible-part";
 
 describe("CollapsiblePart", () => {
   let container: HTMLDivElement;
@@ -24,7 +24,40 @@ describe("CollapsiblePart", () => {
     act(() => {
       root.unmount();
     });
+    vi.useRealTimers();
     container.remove();
+  });
+
+  it("shows whole-second timer updates after the first second", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+
+    act(() => {
+      root.render(<Timer isRunning />);
+    });
+
+    expect(container.querySelector("span")).toBeNull();
+    expect(container.textContent).toBe("");
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+
+    expect(container.querySelector("span")).toBeNull();
+    expect(container.textContent).toBe("");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(container.querySelector("span")?.className).toContain("min-w-[3ch]");
+    expect(container.textContent).toBe("1s");
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(container.textContent).toBe("2s");
   });
 
   it("does not reset manual expansion on state changes when incomplete auto-expansion is disabled", () => {

--- a/src/components/chat/message/collapsible-part.tsx
+++ b/src/components/chat/message/collapsible-part.tsx
@@ -101,7 +101,7 @@ export function CollapsiblePart({
   const statusText = getStatusText();
 
   return (
-    <div className="flex flex-col mt-1 overflow-hidden">
+    <div className="flex flex-col overflow-hidden">
       <div
         className={cn(
           "group flex w-fit items-center rounded-md px-1.5 py-1 text-muted-foreground transition-colors hover:bg-muted/30 hover:text-foreground",

--- a/src/components/chat/message/collapsible-part.tsx
+++ b/src/components/chat/message/collapsible-part.tsx
@@ -5,8 +5,6 @@ import { useEffect, useRef, useState } from "react";
 export const RUNNING_TEXT_CLASS =
   "animate-tool-call-text-shimmer bg-[linear-gradient(100deg,color-mix(in_oklch,var(--muted-foreground)_62%,transparent)_0%,var(--foreground)_24%,color-mix(in_oklch,var(--muted-foreground)_62%,transparent)_48%)] bg-[length:220%_100%] [background-position:140%_0] bg-clip-text text-transparent motion-reduce:animate-none motion-reduce:bg-none motion-reduce:text-muted-foreground";
 
-const RUNNING_TEXT_SHIMMER_DELAY_MS = 600;
-
 export function Timer({ isRunning }: { isRunning: boolean }) {
   const [formattedTime, setFormattedTime] = useState("");
 
@@ -91,20 +89,6 @@ export function CollapsiblePart({
 
   // If streaming stopped and tool is not complete, treat it as stopped (no timer, no spinner)
   const isActuallyRunning = !isComplete && isRunning;
-  const [showRunningTextShimmer, setShowRunningTextShimmer] = useState(false);
-
-  useEffect(() => {
-    if (!isActuallyRunning) {
-      setShowRunningTextShimmer(false);
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      setShowRunningTextShimmer(true);
-    }, RUNNING_TEXT_SHIMMER_DELAY_MS);
-
-    return () => clearTimeout(timer);
-  }, [isActuallyRunning]);
 
   // Get status text based on state
   const getStatusText = () => {
@@ -137,9 +121,7 @@ export function CollapsiblePart({
             </>
           )}
           {!showStatusIcon && <SquareTerminal className="h-4 w-4" />}
-          <span className={cn("font-medium", showRunningTextShimmer && RUNNING_TEXT_CLASS)}>
-            {toolName}
-          </span>
+          <span className="font-medium">{toolName}</span>
           {headerExtra ? (
             <span className="max-w-[360px] truncate font-mono text-sm text-muted-foreground">
               {headerExtra}

--- a/src/components/chat/message/collapsible-part.tsx
+++ b/src/components/chat/message/collapsible-part.tsx
@@ -5,31 +5,37 @@ import { useEffect, useRef, useState } from "react";
 export const RUNNING_TEXT_CLASS =
   "animate-tool-call-text-shimmer bg-[linear-gradient(100deg,color-mix(in_oklch,var(--muted-foreground)_62%,transparent)_0%,var(--foreground)_24%,color-mix(in_oklch,var(--muted-foreground)_62%,transparent)_48%)] bg-[length:220%_100%] [background-position:140%_0] bg-clip-text text-transparent motion-reduce:animate-none motion-reduce:bg-none motion-reduce:text-muted-foreground";
 
+function formatElapsedTime(seconds: number): string {
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}m ${remainingSeconds.toString().padStart(2, "0")}s`;
+}
+
 export function Timer({ isRunning }: { isRunning: boolean }) {
-  const [formattedTime, setFormattedTime] = useState("");
+  const [elapsedSeconds, setElapsedSeconds] = useState<number | null>(null);
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
     if (isRunning) {
-      // Start timing
       const now = Date.now();
+      setElapsedSeconds(null);
 
-      // Update every 100ms
-      // Use the captured 'now' value directly since state updates are async
       intervalRef.current = setInterval(() => {
-        const elapsed = Date.now() - now;
-        setFormattedTime(`${(elapsed / 1000).toFixed(1)}s`);
-      }, 100);
+        const elapsed = Math.floor((Date.now() - now) / 1000);
+        setElapsedSeconds(elapsed > 0 ? elapsed : null);
+      }, 1000);
     } else {
-      // Stop timing
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
         intervalRef.current = null;
       }
     }
 
-    // Cleanup on unmount or when isExecuting changes
     return () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
@@ -38,7 +44,22 @@ export function Timer({ isRunning }: { isRunning: boolean }) {
     };
   }, [isRunning]);
 
-  return <span className="text-xs text-muted-foreground">{formattedTime}</span>;
+  if (elapsedSeconds === null) {
+    return null;
+  }
+
+  const formattedTime = formatElapsedTime(elapsedSeconds);
+
+  return (
+    <span
+      className={cn(
+        "text-left text-xs tabular-nums text-muted-foreground",
+        elapsedSeconds < 60 ? "min-w-[3ch]" : "min-w-[6ch]"
+      )}
+    >
+      {formattedTime}
+    </span>
+  );
 }
 
 /**

--- a/src/components/chat/message/collapsible-part.tsx
+++ b/src/components/chat/message/collapsible-part.tsx
@@ -5,6 +5,8 @@ import { useEffect, useRef, useState } from "react";
 export const RUNNING_TEXT_CLASS =
   "animate-tool-call-text-shimmer bg-[linear-gradient(100deg,color-mix(in_oklch,var(--muted-foreground)_62%,transparent)_0%,var(--foreground)_24%,color-mix(in_oklch,var(--muted-foreground)_62%,transparent)_48%)] bg-[length:220%_100%] [background-position:140%_0] bg-clip-text text-transparent motion-reduce:animate-none motion-reduce:bg-none motion-reduce:text-muted-foreground";
 
+const RUNNING_TEXT_SHIMMER_DELAY_MS = 600;
+
 export function Timer({ isRunning }: { isRunning: boolean }) {
   const [formattedTime, setFormattedTime] = useState("");
 
@@ -89,6 +91,20 @@ export function CollapsiblePart({
 
   // If streaming stopped and tool is not complete, treat it as stopped (no timer, no spinner)
   const isActuallyRunning = !isComplete && isRunning;
+  const [showRunningTextShimmer, setShowRunningTextShimmer] = useState(false);
+
+  useEffect(() => {
+    if (!isActuallyRunning) {
+      setShowRunningTextShimmer(false);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setShowRunningTextShimmer(true);
+    }, RUNNING_TEXT_SHIMMER_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, [isActuallyRunning]);
 
   // Get status text based on state
   const getStatusText = () => {
@@ -121,7 +137,7 @@ export function CollapsiblePart({
             </>
           )}
           {!showStatusIcon && <SquareTerminal className="h-4 w-4" />}
-          <span className={cn("font-medium", isActuallyRunning && RUNNING_TEXT_CLASS)}>
+          <span className={cn("font-medium", showRunningTextShimmer && RUNNING_TEXT_CLASS)}>
             {toolName}
           </span>
           {headerExtra ? (

--- a/src/components/chat/message/collapsible-part.tsx
+++ b/src/components/chat/message/collapsible-part.tsx
@@ -121,9 +121,11 @@ export function CollapsiblePart({
             </>
           )}
           {!showStatusIcon && <SquareTerminal className="h-4 w-4" />}
-          <span className="font-medium">{toolName}</span>
+          <span className={cn("font-medium", isActuallyRunning && RUNNING_TEXT_CLASS)}>
+            {toolName}
+          </span>
           {headerExtra ? (
-            <span className="max-w-[360px] truncate font-mono text-sm text-muted-foreground">
+            <span className="max-w-[360px] truncate text-sm font-medium">
               {headerExtra}
             </span>
           ) : null}

--- a/src/components/chat/message/collapsible-part.tsx
+++ b/src/components/chat/message/collapsible-part.tsx
@@ -99,46 +99,57 @@ export function CollapsiblePart({
   };
 
   const statusText = getStatusText();
+  const isCollapsible = Boolean(children);
+  const headerClassName = cn(
+    "group flex w-fit items-center rounded-md px-1.5 py-1 text-left text-muted-foreground transition-colors hover:bg-muted/30 hover:text-foreground",
+    isExpanded ? "bg-muted/30 text-foreground" : "",
+    isCollapsible
+      ? "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+      : ""
+  );
+  const headerContent = (
+    <div className="flex items-center gap-2 text-sm leading-5">
+      {showStatusIcon && (
+        <>
+          {isError || (!isComplete && !isActuallyRunning) ? (
+            <CircleX className="h-3.5 w-3.5 text-destructive" />
+          ) : (
+            <Wrench className="h-4 w-4" />
+          )}
+        </>
+      )}
+      {!showStatusIcon && <SquareTerminal className="h-4 w-4" />}
+      <span className={cn("font-medium", isActuallyRunning && RUNNING_TEXT_CLASS)}>{toolName}</span>
+      {headerExtra ? (
+        <span className="max-w-[360px] truncate text-sm font-medium">{headerExtra}</span>
+      ) : null}
+      {statusText && <span className="text-sm text-muted-foreground">{statusText}</span>}
+      <Timer isRunning={isActuallyRunning} />
+      {isCollapsible && (
+        <ChevronRight
+          className={cn(
+            "h-4 w-4 text-muted-foreground opacity-0 transition-all group-hover:opacity-100",
+            isExpanded ? "rotate-90 opacity-100" : ""
+          )}
+        />
+      )}
+    </div>
+  );
 
   return (
     <div className="flex flex-col overflow-hidden">
-      <div
-        className={cn(
-          "group flex w-fit items-center rounded-md px-1.5 py-1 text-muted-foreground transition-colors hover:bg-muted/30 hover:text-foreground",
-          isExpanded ? "bg-muted/30 text-foreground" : "",
-          children ? "cursor-pointer" : ""
-        )}
-        onClick={() => setIsExpanded(!isExpanded)}
-      >
-        <div className="flex items-center gap-2 text-sm leading-5">
-          {showStatusIcon && (
-            <>
-              {isError || (!isComplete && !isActuallyRunning) ? (
-                <CircleX className="h-3.5 w-3.5 text-destructive" />
-              ) : (
-                <Wrench className="h-4 w-4" />
-              )}
-            </>
-          )}
-          {!showStatusIcon && <SquareTerminal className="h-4 w-4" />}
-          <span className={cn("font-medium", isActuallyRunning && RUNNING_TEXT_CLASS)}>
-            {toolName}
-          </span>
-          {headerExtra ? (
-            <span className="max-w-[360px] truncate text-sm font-medium">{headerExtra}</span>
-          ) : null}
-          {statusText && <span className="text-sm text-muted-foreground">{statusText}</span>}
-          <Timer isRunning={isActuallyRunning} />
-          {children && (
-            <ChevronRight
-              className={cn(
-                "h-4 w-4 text-muted-foreground opacity-0 transition-all group-hover:opacity-100",
-                isExpanded ? "rotate-90 opacity-100" : ""
-              )}
-            />
-          )}
-        </div>
-      </div>
+      {isCollapsible ? (
+        <button
+          type="button"
+          className={headerClassName}
+          onClick={() => setIsExpanded((current) => !current)}
+          aria-expanded={isExpanded}
+        >
+          {headerContent}
+        </button>
+      ) : (
+        <div className={headerClassName}>{headerContent}</div>
+      )}
       {(isExpanded || keepChildrenMounted) && (
         <div
           className={cn(

--- a/src/components/chat/message/collapsible-part.tsx
+++ b/src/components/chat/message/collapsible-part.tsx
@@ -125,9 +125,7 @@ export function CollapsiblePart({
             {toolName}
           </span>
           {headerExtra ? (
-            <span className="max-w-[360px] truncate text-sm font-medium">
-              {headerExtra}
-            </span>
+            <span className="max-w-[360px] truncate text-sm font-medium">{headerExtra}</span>
           ) : null}
           {statusText && <span className="text-sm text-muted-foreground">{statusText}</span>}
           <Timer isRunning={isActuallyRunning} />

--- a/src/components/chat/message/collapsible-part.tsx
+++ b/src/components/chat/message/collapsible-part.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils";
 import { ChevronRight, CircleX, SquareTerminal, Wrench } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { Children, useEffect, useRef, useState } from "react";
 
 export const RUNNING_TEXT_CLASS =
   "animate-tool-call-text-shimmer bg-[linear-gradient(100deg,color-mix(in_oklch,var(--muted-foreground)_62%,transparent)_0%,var(--foreground)_24%,color-mix(in_oklch,var(--muted-foreground)_62%,transparent)_48%)] bg-[length:220%_100%] [background-position:140%_0] bg-clip-text text-transparent motion-reduce:animate-none motion-reduce:bg-none motion-reduce:text-muted-foreground";
@@ -120,7 +120,10 @@ export function CollapsiblePart({
   };
 
   const statusText = getStatusText();
-  const isCollapsible = Boolean(children);
+  const renderableChildren = Children.toArray(children).filter(
+    (child) => typeof child !== "string" || child.length > 0
+  );
+  const isCollapsible = renderableChildren.length > 0;
   const headerClassName = cn(
     "group flex w-fit items-center rounded-md px-1.5 py-1 text-left text-muted-foreground transition-colors hover:bg-muted/30 hover:text-foreground",
     isExpanded ? "bg-muted/30 text-foreground" : "",
@@ -171,15 +174,12 @@ export function CollapsiblePart({
       ) : (
         <div className={headerClassName}>{headerContent}</div>
       )}
-      {(isExpanded || keepChildrenMounted) && (
+      {isCollapsible && (isExpanded || keepChildrenMounted) && (
         <div
-          className={cn(
-            "ml-3 border-l border-muted/50 pl-4 transition-all",
-            children ? "mb-1" : ""
-          )}
+          className="mb-1 ml-3 border-l border-muted/50 pl-4 transition-all"
           style={keepChildrenMounted && !isExpanded ? { display: "none" } : undefined}
         >
-          {children}
+          {renderableChildren}
         </div>
       )}
     </div>

--- a/src/components/chat/message/collapsible-part.tsx
+++ b/src/components/chat/message/collapsible-part.tsx
@@ -1,8 +1,9 @@
-import { Formatter } from "@/lib/formatter";
 import { cn } from "@/lib/utils";
-import { Check, ChevronDown, ChevronRight, CircleX, Loader2 } from "lucide-react";
+import { ChevronRight, CircleX, SquareTerminal, Wrench } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { Badge } from "../../ui/badge";
+
+export const RUNNING_TEXT_CLASS =
+  "animate-tool-call-text-shimmer bg-[linear-gradient(100deg,color-mix(in_oklch,var(--muted-foreground)_62%,transparent)_0%,var(--foreground)_24%,color-mix(in_oklch,var(--muted-foreground)_62%,transparent)_48%)] bg-[length:220%_100%] [background-position:140%_0] bg-clip-text text-transparent motion-reduce:animate-none motion-reduce:bg-none motion-reduce:text-muted-foreground";
 
 export function Timer({ isRunning }: { isRunning: boolean }) {
   const [formattedTime, setFormattedTime] = useState("");
@@ -18,7 +19,7 @@ export function Timer({ isRunning }: { isRunning: boolean }) {
       // Use the captured 'now' value directly since state updates are async
       intervalRef.current = setInterval(() => {
         const elapsed = Date.now() - now;
-        setFormattedTime(Formatter.getInstance().milliFormat(elapsed, 2));
+        setFormattedTime(`${(elapsed / 1000).toFixed(1)}s`);
       }, 100);
     } else {
       // Stop timing
@@ -37,7 +38,7 @@ export function Timer({ isRunning }: { isRunning: boolean }) {
     };
   }, [isRunning]);
 
-  return <span className="text-xs text-muted-foreground text-[10px]">{formattedTime}</span>;
+  return <span className="text-xs text-muted-foreground">{formattedTime}</span>;
 }
 
 /**
@@ -100,53 +101,50 @@ export function CollapsiblePart({
   const statusText = getStatusText();
 
   return (
-    <div className="flex flex-col mt-0 overflow-hidden">
+    <div className="flex flex-col mt-1 overflow-hidden">
       <div
         className={cn(
-          "flex items-center hover:bg-muted/50 transition-colors w-fit pr-2 rounded-sm",
-          isExpanded ? "bg-muted/50" : "",
+          "group flex w-fit items-center rounded-md px-1.5 py-1 text-muted-foreground transition-colors hover:bg-muted/30 hover:text-foreground",
+          isExpanded ? "bg-muted/30 text-foreground" : "",
           children ? "cursor-pointer" : ""
         )}
         onClick={() => setIsExpanded(!isExpanded)}
       >
-        <div className="flex items-center gap-2 py-0.5 text-[10px] leading-4">
+        <div className="flex items-center gap-2 text-sm leading-5">
           {showStatusIcon && (
             <>
-              {isComplete ? (
-                isError ? (
-                  <CircleX className="h-3 w-3 text-destructive" />
-                ) : (
-                  <Check className="h-3 w-3" />
-                )
-              ) : isActuallyRunning ? (
-                <Loader2 className="h-3 w-3 animate-spin" />
+              {isError || (!isComplete && !isActuallyRunning) ? (
+                <CircleX className="h-3.5 w-3.5 text-destructive" />
               ) : (
-                <CircleX className="h-3 w-3 text-destructive" />
+                <Wrench className="h-4 w-4" />
               )}
             </>
           )}
-          <Badge className="flex items-center gap-0.5 rounded-sm border-none pl-1 pr-2 h-4 py-0 font-normal text-[10px]">
-            {children &&
-              (isExpanded ? (
-                <ChevronDown className="h-3 w-3" />
-              ) : (
-                <ChevronRight className="h-3 w-3" />
-              ))}
+          {!showStatusIcon && <SquareTerminal className="h-4 w-4" />}
+          <span className={cn("font-medium", isActuallyRunning && RUNNING_TEXT_CLASS)}>
             {toolName}
-          </Badge>
+          </span>
           {headerExtra ? (
-            <span className="max-w-[360px] truncate font-mono text-[10px] text-muted-foreground">
+            <span className="max-w-[360px] truncate font-mono text-sm text-muted-foreground">
               {headerExtra}
             </span>
           ) : null}
-          {statusText && <span className="text-muted-foreground">{statusText}</span>}
+          {statusText && <span className="text-sm text-muted-foreground">{statusText}</span>}
           <Timer isRunning={isActuallyRunning} />
+          {children && (
+            <ChevronRight
+              className={cn(
+                "h-4 w-4 text-muted-foreground opacity-0 transition-all group-hover:opacity-100",
+                isExpanded ? "rotate-90 opacity-100" : ""
+              )}
+            />
+          )}
         </div>
       </div>
       {(isExpanded || keepChildrenMounted) && (
         <div
           className={cn(
-            "pl-3 border-l ml-1.5 border-muted/50 transition-all",
+            "ml-3 border-l border-muted/50 pl-4 transition-all",
             children ? "mb-1" : ""
           )}
           style={keepChildrenMounted && !isExpanded ? { display: "none" } : undefined}

--- a/src/components/chat/message/message-reasoning.tsx
+++ b/src/components/chat/message/message-reasoning.tsx
@@ -2,7 +2,7 @@ import type { AppUIMessage } from "@/lib/ai/ai-types";
 import { memo } from "react";
 import { MessageMarkdown } from "./message-markdown";
 
-const REASONING_MARKDOWN_STYLE = { fontSize: "10px", lineHeight: "1.45" } as const;
+const REASONING_MARKDOWN_STYLE = { fontSize: "0.9rem", lineHeight: "1.6" } as const;
 
 /**
  * Render reasoning as assistant text instead of a tool part.
@@ -19,12 +19,12 @@ export const MessageReasoning = memo(function MessageReasoning({
   const isStreaming = part.state !== undefined && part.state !== "done";
   if (isStreaming) {
     return (
-      <div className="whitespace-pre-wrap break-words text-[10px] leading-[1.45]">{part.text}</div>
+      <div className="whitespace-pre-wrap break-words text-sm leading-relaxed">{part.text}</div>
     );
   }
 
   return (
-    <div className="text-[10px] [&_.prose]:text-[10px] [&_.prose_*]:text-[10px]">
+    <div className="text-sm">
       <MessageMarkdown
         text={part.text}
         customStyle={REASONING_MARKDOWN_STYLE}

--- a/src/components/chat/message/message-tool-skill.test.tsx
+++ b/src/components/chat/message/message-tool-skill.test.tsx
@@ -61,7 +61,7 @@ describe("MessageToolSkill", () => {
       );
     });
 
-    expect(container.textContent).toContain("Load Skill Resources");
+    expect(container.textContent).toContain("Load skill resources:");
     expect(container.textContent).toContain("vizlayer | reference/flowchart.md");
     expect(container.textContent).toContain("vizlayer | reference/sequence-diagram.md");
     expect(container.textContent).toContain("input:");
@@ -78,7 +78,7 @@ describe("MessageToolSkill", () => {
       );
     });
 
-    expect(container.textContent).toContain("Load Skill");
+    expect(container.textContent).toContain("Load skill:");
     expect(container.textContent).toContain("vizlayer");
     expect(container.textContent).toContain("clickhouse-best-practices");
     expect(container.textContent).toContain("input:");
@@ -102,7 +102,7 @@ describe("MessageToolSkill", () => {
       );
     });
 
-    expect(container.textContent).toContain("Load Skill Resources");
+    expect(container.textContent).toContain("Load skill resources:");
     expect(container.textContent).toContain("vizlayer | reference/flowchart.md");
     expect(container.textContent).not.toContain("reference/class-diagram.md");
   });
@@ -118,7 +118,7 @@ describe("MessageToolSkill", () => {
       );
     });
 
-    expect(container.textContent).toContain("Load Skill");
+    expect(container.textContent).toContain("Load skill:");
     expect(container.textContent).toContain("clickhouse-best-practices");
     expect(container.textContent).not.toContain("input:");
   });

--- a/src/components/chat/message/message-tool-skill.test.tsx
+++ b/src/components/chat/message/message-tool-skill.test.tsx
@@ -106,4 +106,20 @@ describe("MessageToolSkill", () => {
     expect(container.textContent).toContain("vizlayer | reference/flowchart.md");
     expect(container.textContent).not.toContain("reference/class-diagram.md");
   });
+
+  it("falls back to the loaded manual name when input is empty", () => {
+    act(() => {
+      root.render(
+        <MessageToolSkill
+          part={createToolPart({}, "# Manual Loaded: clickhouse-best-practices\n\n# Guidelines")}
+          isRunning={false}
+          label="Load Skill"
+        />
+      );
+    });
+
+    expect(container.textContent).toContain("Load Skill");
+    expect(container.textContent).toContain("clickhouse-best-practices");
+    expect(container.textContent).not.toContain("input:");
+  });
 });

--- a/src/components/chat/message/message-tool-skill.tsx
+++ b/src/components/chat/message/message-tool-skill.tsx
@@ -47,8 +47,7 @@ function getLoadedManuals(outputText: string | null): string[] {
     .filter((name): name is string => Boolean(name));
 }
 
-function buildHeader(input: SkillInput, outputText: string | null): string {
-  const requestedItems = getRequestedItems(input);
+function buildHeader(requestedItems: string[], outputText: string | null): string {
   const headerItems = requestedItems.length > 0 ? requestedItems : getLoadedManuals(outputText);
   if (headerItems.length === 0) {
     return "";
@@ -83,7 +82,7 @@ export const MessageToolSkill = memo(function MessageToolSkill({
   const outputText = typeof toolPart.output === "string" ? toolPart.output : null;
   const characterCount = outputText?.length ?? null;
   const requestedItems = getRequestedItems(input);
-  const header = buildHeader(input, outputText);
+  const header = buildHeader(requestedItems, outputText);
   const displayLabel = normalizeToolLabel(label);
 
   return (

--- a/src/components/chat/message/message-tool-skill.tsx
+++ b/src/components/chat/message/message-tool-skill.tsx
@@ -40,13 +40,21 @@ function getRequestedItems(input: SkillInput): string[] {
   });
 }
 
-function buildHeader(input: SkillInput): string {
+function getLoadedManuals(outputText: string | null): string[] {
+  if (!outputText) return [];
+  return [...outputText.matchAll(/^# Manual Loaded: (.+)$/gm)]
+    .map((match) => match[1]?.trim())
+    .filter((name): name is string => Boolean(name));
+}
+
+function buildHeader(input: SkillInput, outputText: string | null): string {
   const requestedItems = getRequestedItems(input);
-  if (requestedItems.length === 0) {
+  const headerItems = requestedItems.length > 0 ? requestedItems : getLoadedManuals(outputText);
+  if (headerItems.length === 0) {
     return "";
   }
 
-  const joinedNames = requestedItems.join(", ");
+  const joinedNames = headerItems.join(", ");
   if (joinedNames.length <= MAX_HEADER_LENGTH) {
     return joinedNames;
   }
@@ -57,7 +65,7 @@ function buildHeader(input: SkillInput): string {
 export const MessageToolSkill = memo(function MessageToolSkill({
   isRunning = true,
   part,
-  label = "Load Skill",
+  label = "Load skill",
 }: {
   part: AppUIMessage["parts"][0];
   isRunning?: boolean;
@@ -73,7 +81,7 @@ export const MessageToolSkill = memo(function MessageToolSkill({
   return (
     <CollapsiblePart
       toolName={label}
-      headerExtra={buildHeader(input)}
+      headerExtra={buildHeader(input, outputText)}
       state={state}
       isRunning={isRunning}
     >

--- a/src/components/chat/message/message-tool-skill.tsx
+++ b/src/components/chat/message/message-tool-skill.tsx
@@ -62,6 +62,12 @@ function buildHeader(input: SkillInput, outputText: string | null): string {
   return `${joinedNames.slice(0, MAX_HEADER_LENGTH - 1).trimEnd()}…`;
 }
 
+function normalizeToolLabel(label: string): string {
+  if (label === "Load Skill Resources") return "Load skill resources";
+  if (label === "Load Skill") return "Load skill";
+  return label;
+}
+
 export const MessageToolSkill = memo(function MessageToolSkill({
   isRunning = true,
   part,
@@ -77,11 +83,13 @@ export const MessageToolSkill = memo(function MessageToolSkill({
   const outputText = typeof toolPart.output === "string" ? toolPart.output : null;
   const characterCount = outputText?.length ?? null;
   const requestedItems = getRequestedItems(input);
+  const header = buildHeader(input, outputText);
+  const displayLabel = normalizeToolLabel(label);
 
   return (
     <CollapsiblePart
-      toolName={label}
-      headerExtra={buildHeader(input, outputText)}
+      toolName={header ? `${displayLabel}:` : displayLabel}
+      headerExtra={header || undefined}
       state={state}
       isRunning={isRunning}
     >

--- a/src/components/chat/message/remark-extensions.test.ts
+++ b/src/components/chat/message/remark-extensions.test.ts
@@ -14,6 +14,49 @@ function transformTree(tree: MarkdownNode): MarkdownNode {
 }
 
 describe("remarkReferenceTokens", () => {
+  it("converts CJK literal strong markers left by markdown parsing into strong nodes", () => {
+    const tree = transformTree({
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "text",
+              value:
+                "如果你不特别指定，我下面先按**“行业龙头 + AI 受益程度”**给出一个较实用的版本。",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(tree.children?.[0]?.children).toEqual([
+      { type: "text", value: "如果你不特别指定，我下面先按" },
+      {
+        type: "strong",
+        children: [{ type: "text", value: "“行业龙头 + AI 受益程度”" }],
+      },
+      { type: "text", value: "给出一个较实用的版本。" },
+    ]);
+  });
+
+  it("leaves non-CJK literal strong markers untouched", () => {
+    const tree = transformTree({
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [{ type: "text", value: 'Use word**"quoted"**word literally.' }],
+        },
+      ],
+    });
+
+    expect(tree.children?.[0]?.children).toEqual([
+      { type: "text", value: 'Use word**"quoted"**word literally.' },
+    ]);
+  });
+
   it("converts skill and file tokens inside text nodes into link nodes", () => {
     const tree = transformTree({
       type: "root",

--- a/src/components/chat/message/remark-extensions.test.ts
+++ b/src/components/chat/message/remark-extensions.test.ts
@@ -41,6 +41,61 @@ describe("remarkReferenceTokens", () => {
     ]);
   });
 
+  it("converts reference tokens inside CJK literal strong markers once", () => {
+    const tree = transformTree({
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "text",
+              value: "打开**中文 [[file:src/app/page.tsx#L1]]**继续。",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(tree.children?.[0]?.children).toEqual([
+      { type: "text", value: "打开" },
+      {
+        type: "strong",
+        children: [
+          { type: "text", value: "中文 " },
+          {
+            type: "link",
+            url: "codefile://open?path=src%2Fapp%2Fpage.tsx&startLine=1",
+            title: null,
+            children: [{ type: "text", value: "page.tsx:1" }],
+          },
+        ],
+      },
+      { type: "text", value: "继续。" },
+    ]);
+  });
+
+  it("abandons a CJK literal strong opener after an invalid closer", () => {
+    const tree = transformTree({
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [{ type: "text", value: "如果**abc **中**后" }],
+        },
+      ],
+    });
+
+    expect(tree.children?.[0]?.children).toEqual([
+      { type: "text", value: "如果**abc " },
+      {
+        type: "strong",
+        children: [{ type: "text", value: "中" }],
+      },
+      { type: "text", value: "后" },
+    ]);
+  });
+
   it("leaves non-CJK literal strong markers untouched", () => {
     const tree = transformTree({
       type: "root",

--- a/src/components/chat/message/remark-extensions.test.ts
+++ b/src/components/chat/message/remark-extensions.test.ts
@@ -96,6 +96,27 @@ describe("remarkReferenceTokens", () => {
     ]);
   });
 
+  it("continues scanning after non-CJK literal strong markers", () => {
+    const tree = transformTree({
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [{ type: "text", value: "Use **plain** then **中文** markers." }],
+        },
+      ],
+    });
+
+    expect(tree.children?.[0]?.children).toEqual([
+      { type: "text", value: "Use **plain** then " },
+      {
+        type: "strong",
+        children: [{ type: "text", value: "中文" }],
+      },
+      { type: "text", value: " markers." },
+    ]);
+  });
+
   it("leaves non-CJK literal strong markers untouched", () => {
     const tree = transformTree({
       type: "root",

--- a/src/components/chat/message/remark-extensions.ts
+++ b/src/components/chat/message/remark-extensions.ts
@@ -166,21 +166,20 @@ function findFallbackStrongSpan(value: string, fromIndex: number) {
       const content = value.slice(contentStart, end);
       const lastContentChar = value[end - 1];
       const next = value[end + 2];
-
-      if (
+      const hasValidCloser =
         lastContentChar !== "\\" &&
         lastContentChar !== "*" &&
         next !== "*" &&
-        !isWhitespace(lastContentChar)
-      ) {
+        !isWhitespace(lastContentChar);
+
+      if (hasValidCloser) {
         if (hasCjkScript(content)) {
           return { start, end: end + 2, content };
         }
         nextStartIndex = end + 2;
-        break;
+      } else {
+        nextStartIndex = end;
       }
-
-      nextStartIndex = end;
     }
 
     start = value.indexOf("**", nextStartIndex);

--- a/src/components/chat/message/remark-extensions.ts
+++ b/src/components/chat/message/remark-extensions.ts
@@ -61,7 +61,7 @@ function createBreakNode(): BreakNode {
 }
 
 function createStrongNode(value: string): StrongNode {
-  return { type: "strong", children: transformTextValue(value) };
+  return { type: "strong", children: [createTextNode(value)] };
 }
 
 function isBrHtmlNode(node: MarkdownNode): node is HtmlNode {
@@ -161,8 +161,8 @@ function findFallbackStrongSpan(value: string, fromIndex: number) {
     }
 
     let nextStartIndex = contentStart;
-    let end = value.indexOf("**", contentStart);
-    while (end !== -1) {
+    const end = value.indexOf("**", contentStart);
+    if (end !== -1) {
       const content = value.slice(contentStart, end);
       const lastContentChar = value[end - 1];
       const next = value[end + 2];
@@ -180,7 +180,7 @@ function findFallbackStrongSpan(value: string, fromIndex: number) {
         break;
       }
 
-      end = value.indexOf("**", end + 2);
+      nextStartIndex = end;
     }
 
     start = value.indexOf("**", nextStartIndex);
@@ -199,7 +199,7 @@ function transformTextValue(value: string): MarkdownNode[] {
       nodes.push(...transformReferenceTokens(value.slice(cursor, span.start)));
     }
 
-    nodes.push(createStrongNode(span.content));
+    nodes.push(transformNode(createStrongNode(span.content)));
     cursor = span.end;
     span = findFallbackStrongSpan(value, cursor);
   }

--- a/src/components/chat/message/remark-extensions.ts
+++ b/src/components/chat/message/remark-extensions.ts
@@ -39,7 +39,14 @@ type LinkNode = MarkdownNode & {
   children: MarkdownNode[];
 };
 
+type StrongNode = MarkdownNode & {
+  type: "strong";
+  children: MarkdownNode[];
+};
+
 const LINKNODE_TOKEN_PATTERN = /\[\[\s*(file|skill)\s*:\s*((?:\\.|[^\]])+?)\s*\]\]/gi;
+const CJK_SCRIPT_PATTERN =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
 
 function hasChildren(node: MarkdownNode): node is ParentNode {
   return Array.isArray(node.children);
@@ -51,6 +58,10 @@ function createTextNode(value: string): TextNode {
 
 function createBreakNode(): BreakNode {
   return { type: "break" };
+}
+
+function createStrongNode(value: string): StrongNode {
+  return { type: "strong", children: transformTextValue(value) };
 }
 
 function isBrHtmlNode(node: MarkdownNode): node is HtmlNode {
@@ -81,7 +92,7 @@ function createLinkNode(referenceType: string, tokenBody: string): LinkNode | nu
   return null;
 }
 
-function transformTextValue(value: string): MarkdownNode[] {
+function transformReferenceTokens(value: string): MarkdownNode[] {
   const nodes: MarkdownNode[] = [];
   let lastIndex = 0;
 
@@ -118,6 +129,87 @@ function transformTextValue(value: string): MarkdownNode[] {
 
   if (lastIndex < value.length) {
     nodes.push(createTextNode(value.slice(lastIndex)));
+  }
+
+  return nodes;
+}
+
+function hasCjkScript(value: string) {
+  return CJK_SCRIPT_PATTERN.test(value);
+}
+
+function isWhitespace(value: string | undefined) {
+  return value !== undefined && /\s/u.test(value);
+}
+
+function findFallbackStrongSpan(value: string, fromIndex: number) {
+  let start = value.indexOf("**", fromIndex);
+
+  while (start !== -1) {
+    const contentStart = start + 2;
+    const previous = value[start - 1];
+    const firstContentChar = value[contentStart];
+
+    if (
+      previous === "\\" ||
+      previous === "*" ||
+      firstContentChar === "*" ||
+      isWhitespace(firstContentChar)
+    ) {
+      start = value.indexOf("**", contentStart);
+      continue;
+    }
+
+    let nextStartIndex = contentStart;
+    let end = value.indexOf("**", contentStart);
+    while (end !== -1) {
+      const content = value.slice(contentStart, end);
+      const lastContentChar = value[end - 1];
+      const next = value[end + 2];
+
+      if (
+        lastContentChar !== "\\" &&
+        lastContentChar !== "*" &&
+        next !== "*" &&
+        !isWhitespace(lastContentChar)
+      ) {
+        if (hasCjkScript(content)) {
+          return { start, end: end + 2, content };
+        }
+        nextStartIndex = end + 2;
+        break;
+      }
+
+      end = value.indexOf("**", end + 2);
+    }
+
+    start = value.indexOf("**", nextStartIndex);
+  }
+
+  return null;
+}
+
+function transformTextValue(value: string): MarkdownNode[] {
+  const nodes: MarkdownNode[] = [];
+  let cursor = 0;
+  let span = findFallbackStrongSpan(value, cursor);
+
+  while (span) {
+    if (span.start > cursor) {
+      nodes.push(...transformReferenceTokens(value.slice(cursor, span.start)));
+    }
+
+    nodes.push(createStrongNode(span.content));
+    cursor = span.end;
+    span = findFallbackStrongSpan(value, cursor);
+  }
+
+  if (cursor === 0) {
+    return transformReferenceTokens(value);
+  }
+
+  if (cursor < value.length) {
+    nodes.push(...transformReferenceTokens(value.slice(cursor)));
   }
 
   return nodes;

--- a/src/components/chat/view/chat-panel.tsx
+++ b/src/components/chat/view/chat-panel.tsx
@@ -495,21 +495,6 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
     clearSelectedChat();
   }, [chat, clearSelectedChat, connection, loadChat, selectedChat]);
 
-  useEffect(() => {
-    if (
-      !chat ||
-      !loadedChatIsDraft ||
-      isRunning ||
-      chat.messages.length > 0 ||
-      !isNoConnectionSessionConnectionId(loadedChatConnectionId) ||
-      isNoConnectionSessionConnectionId(chatConnectionId)
-    ) {
-      return;
-    }
-
-    void loadChat(chat.id, { isNewSession: true });
-  }, [chat, chatConnectionId, isRunning, loadedChatConnectionId, loadedChatIsDraft, loadChat]);
-
   // Update context builder when props change
   useEffect(() => {
     ChatContext.setBuilder(() => ({

--- a/src/components/chat/view/chat-panel.tsx
+++ b/src/components/chat/view/chat-panel.tsx
@@ -495,6 +495,21 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
     clearSelectedChat();
   }, [chat, clearSelectedChat, connection, loadChat, selectedChat]);
 
+  useEffect(() => {
+    if (
+      !chat ||
+      !loadedChatIsDraft ||
+      isRunning ||
+      chat.messages.length > 0 ||
+      !isNoConnectionSessionConnectionId(loadedChatConnectionId) ||
+      isNoConnectionSessionConnectionId(chatConnectionId)
+    ) {
+      return;
+    }
+
+    void loadChat(chat.id, { isNewSession: true });
+  }, [chat, chatConnectionId, isRunning, loadedChatConnectionId, loadedChatIsDraft, loadChat]);
+
   // Update context builder when props change
   useEffect(() => {
     ChatContext.setBuilder(() => ({

--- a/src/components/chat/view/chat-panel.tsx
+++ b/src/components/chat/view/chat-panel.tsx
@@ -508,14 +508,7 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
     }
 
     void loadChat(chat.id, { isNewSession: true });
-  }, [
-    chat,
-    chatConnectionId,
-    isRunning,
-    loadedChatConnectionId,
-    loadedChatIsDraft,
-    loadChat,
-  ]);
+  }, [chat, chatConnectionId, isRunning, loadedChatConnectionId, loadedChatIsDraft, loadChat]);
 
   // Update context builder when props change
   useEffect(() => {

--- a/src/components/chat/view/chat-panel.tsx
+++ b/src/components/chat/view/chat-panel.tsx
@@ -495,6 +495,28 @@ export function ChatPanel({ currentDatabase, onClose }: ChatPanelProps) {
     clearSelectedChat();
   }, [chat, clearSelectedChat, connection, loadChat, selectedChat]);
 
+  useEffect(() => {
+    if (
+      !chat ||
+      !loadedChatIsDraft ||
+      isRunning ||
+      chat.messages.length > 0 ||
+      !isNoConnectionSessionConnectionId(loadedChatConnectionId) ||
+      isNoConnectionSessionConnectionId(chatConnectionId)
+    ) {
+      return;
+    }
+
+    void loadChat(chat.id, { isNewSession: true });
+  }, [
+    chat,
+    chatConnectionId,
+    isRunning,
+    loadedChatConnectionId,
+    loadedChatIsDraft,
+    loadChat,
+  ]);
+
   // Update context builder when props change
   useEffect(() => {
     ChatContext.setBuilder(() => ({

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -6,6 +6,9 @@ export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {
+      animation: {
+        "tool-call-text-shimmer": "tool-call-text-shimmer 1.6s linear infinite",
+      },
       colors: {
         border: "var(--border)",
         input: "var(--input)",
@@ -57,6 +60,12 @@ export default {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
+      },
+      keyframes: {
+        "tool-call-text-shimmer": {
+          "0%": { backgroundPosition: "140% 0" },
+          "100%": { backgroundPosition: "-80% 0" },
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary
- refine chat tool rendering labels, alignment, and running shimmer styling
- add CJK bold fallback in chat markdown extensions
- port the first-chat streaming reload fix so the initial assistant response streams into the visible chat

## Validation
- npm run build
- npm run test -- src/components/chat/message/message-tool-skill.test.tsx src/components/chat/message/collapsible-part.test.tsx src/components/chat/message/chat-message-parts.test.ts src/components/chat/message/chat-message-list.test.tsx
- npm run typecheck