### PR TITLE
[codex] Add configurable reasoning levels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Primary areas:
 Use the existing root scripts unless there is a documented reason not to:
 
 - `npm run dev`: main development workflow
+- `npm run format`: format code after code changes
 - `npm run build`: production build
 - `npm run typecheck`: TypeScript validation
 - `npm run lint`: ESLint
@@ -76,6 +77,7 @@ Apply the `vercel-react-best-practices` skill when writing, reviewing, or refact
 
 ## Testing Guidance
 
+- After any code change, run `npm run format` before the final validation pass. If formatting cannot be run, call that out explicitly.
 - For non-`src` changes, run `npm run lint` whenever the touched files or config can affect ESLint behavior or results.
 - For behavior changes with test coverage, run `npm run test` or the narrowest Vitest target available.
 - For docs changes that affect the manual, run `npm run docs:build` when practical.
@@ -94,6 +96,7 @@ Before finishing, verify:
 - The change matches local patterns in the touched area.
 - Imports, types, and call sites are consistent.
 - Error and empty states are still coherent.
+- `npm run format` has been run after code changes.
 - Relevant validation has been run, or the gap is called out clearly.
 
 ## Commit Rules

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -18,9 +18,9 @@
  * RELEASE_ID, HEAD, OUTPUT_DIR default from git and cwd. Optional: FROM=last_release_sha.
  */
 
+import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
-import { execSync } from "child_process";
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const REPO = process.env.REPO; // owner/repo
@@ -49,7 +49,9 @@ const PREVIOUS_RELEASE_NOTES_JSON = process.env.PREVIOUS_RELEASE_NOTES_JSON;
 const OUTPUT_DIR = process.env.OUTPUT_DIR || process.cwd();
 
 if (!GITHUB_TOKEN || !REPO || !RELEASE_ID) {
-  console.error("Error: GITHUB_TOKEN and REPO are required. RELEASE_ID is required if not in a git repo.");
+  console.error(
+    "Error: GITHUB_TOKEN and REPO are required. RELEASE_ID is required if not in a git repo."
+  );
   process.exit(1);
 }
 
@@ -84,9 +86,7 @@ function typeFromLabels(labelNames) {
   }
   // Skip if PR has only documentation (docs/documentation) and no highlight/feature/fix
   const hasAnyDocsLabel = lowerNames.some((n) => DOCS_LABELS.has(n));
-  const hasReleaseNoteType = lowerNames.some((n) =>
-    ["highlight", "feature", "fix"].includes(n)
-  );
+  const hasReleaseNoteType = lowerNames.some((n) => ["highlight", "feature", "fix"].includes(n));
   if (hasAnyDocsLabel && !hasReleaseNoteType) return null;
 
   let chosen = "feature"; // default when no label matches
@@ -101,8 +101,16 @@ function typeFromLabels(labelNames) {
   return chosen;
 }
 
+function stripCodexPrefix(title) {
+  return title.replace(/^\s*(?:\[codex\]\s*)+/i, "").trim() || title;
+}
+
 function stripConventionalPrefix(title) {
   return title.replace(/^(feat|fix|docs|chore)(\([^)]*\))?!?:\s*/i, "").trim() || title;
+}
+
+function normalizeReleaseTitle(title) {
+  return stripConventionalPrefix(stripCodexPrefix(title));
 }
 
 const PR_NUMBER_REGEX = /#(\d+)|Merge pull request #(\d+)/gi;
@@ -146,9 +154,9 @@ async function getPrTitleAndLabels(prNumber) {
   let type = typeFromLabels(labelNames);
   if (type === null) return null;
   // Title prefix "fix" (case insensitive) maps to fix category
-  const title = issue.title || "";
+  const title = stripCodexPrefix(issue.title || "");
   if (/^fix\b/i.test(title)) type = "fix";
-  const text = stripConventionalPrefix(title);
+  const text = normalizeReleaseTitle(title);
 
   let mergedAt = null;
   try {
@@ -213,8 +221,7 @@ async function main() {
 
   history = history.filter((h) => h.id !== RELEASE_ID);
   if (notes.length > 0) history.unshift(releaseData);
-  const finalHistory = history
-    .filter((h) => h.notes && h.notes.length > 0);
+  const finalHistory = history.filter((h) => h.notes && h.notes.length > 0);
 
   if (!fs.existsSync(publicDir)) fs.mkdirSync(publicDir, { recursive: true });
   fs.writeFileSync(outputPath, JSON.stringify(finalHistory, null, 2));

--- a/src/app/api/ai/agent/route.ts
+++ b/src/app/api/ai/agent/route.ts
@@ -12,9 +12,14 @@ import {
   resolveModelConfig,
   resolveModelSupportsImageInput,
 } from "@/lib/ai/llm/llm-provider-factory";
-import { PROVIDER_OPENAI_CODEX } from "@/lib/ai/llm/provider-ids";
+import { PROVIDER_NEBIUS, PROVIDER_OPENAI_CODEX } from "@/lib/ai/llm/provider-ids";
 import { MentionContext } from "@/lib/ai/mention-context";
 import { MessagePruner } from "@/lib/ai/message-pruner";
+import {
+  DEFAULT_REASONING_LEVEL,
+  isReasoningLevel,
+  type ReasoningLevel,
+} from "@/lib/ai/reasoning-levels";
 import {
   hasCompletedToolOutputs,
   replaceOrAppendMessageById,
@@ -45,8 +50,13 @@ import { getRuntimeAvailableToolNames } from "@/lib/ai/tools/server/runtime-tool
 import { SERVER_TOOL_NAMES } from "@/lib/ai/tools/server/server-tool-names";
 import { createServerTools } from "@/lib/ai/tools/server/server-tools";
 import { defaultCodeSearchFactory } from "@/lib/code-search/code-search-factory";
+import type { AnthropicProviderOptions } from "@ai-sdk/anthropic";
+import type { GoogleGenerativeAIProviderOptions } from "@ai-sdk/google";
+import type { GroqLanguageModelOptions } from "@ai-sdk/groq";
 import type { OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
+import type { OpenAICompatibleLanguageModelChatOptions } from "@ai-sdk/openai-compatible";
 import { APICallError } from "@ai-sdk/provider";
+import type { OpenRouterProviderOptions } from "@openrouter/ai-sdk-provider";
 import {
   convertToModelMessages,
   createUIMessageStreamResponse,
@@ -71,6 +81,17 @@ interface AgentRequest {
 }
 
 const TITLE_WAIT_MS = 3000;
+const ANTHROPIC_MANUAL_THINKING_BUDGET_TOKENS = 1024;
+
+type AgentProviderOptions = {
+  openai?: OpenAIResponsesProviderOptions;
+  anthropic?: AnthropicProviderOptions;
+  cerebras?: OpenAICompatibleLanguageModelChatOptions;
+  google?: GoogleGenerativeAIProviderOptions;
+  groq?: GroqLanguageModelOptions;
+  nebius?: OpenAICompatibleLanguageModelChatOptions;
+  openrouter?: OpenRouterProviderOptions;
+};
 
 function messageHasImageParts(message: UIMessage): boolean {
   return (message.parts ?? []).some((part) => {
@@ -97,15 +118,93 @@ function shouldOutputReasoning(
   );
 }
 
-function buildOpenAIProviderOptions(input: {
+function resolveReasoningLevelForModel(input: {
   provider: string;
+  modelId: string;
+  reasoningLevel?: unknown;
+}): ReasoningLevel | undefined {
+  const levels = LanguageModelProviderFactory.getReasoningLevels(input.provider, input.modelId);
+  if (levels.length === 0) {
+    return undefined;
+  }
+
+  if (isReasoningLevel(input.reasoningLevel) && levels.includes(input.reasoningLevel)) {
+    return input.reasoningLevel;
+  }
+
+  if (levels.includes(DEFAULT_REASONING_LEVEL)) {
+    return DEFAULT_REASONING_LEVEL;
+  }
+
+  return levels[0];
+}
+
+function toAnthropicEffort(
+  level: ReasoningLevel
+): NonNullable<AnthropicProviderOptions["effort"]> | undefined {
+  if (level === "xhigh") return "max";
+  if (level === "low" || level === "medium" || level === "high" || level === "max") return level;
+  return undefined;
+}
+
+function supportsAnthropicAdaptiveThinking(modelId: string): boolean {
+  return modelId.includes("claude-opus-4-6") || modelId.includes("claude-sonnet-4-6");
+}
+
+function getAnthropicThinkingOptions(
+  modelId: string,
+  outputReasoning: boolean
+): AnthropicProviderOptions["thinking"] | undefined {
+  if (supportsAnthropicAdaptiveThinking(modelId)) {
+    return { type: "adaptive" };
+  }
+
+  if (outputReasoning) {
+    return {
+      type: "enabled",
+      budgetTokens: ANTHROPIC_MANUAL_THINKING_BUDGET_TOKENS,
+    };
+  }
+
+  return undefined;
+}
+
+function toGoogleThinkingLevel(
+  level: ReasoningLevel
+):
+  | NonNullable<NonNullable<GoogleGenerativeAIProviderOptions["thinkingConfig"]>["thinkingLevel"]>
+  | undefined {
+  if (level === "xhigh") return "high";
+  if (level === "minimal" || level === "low" || level === "medium" || level === "high") {
+    return level;
+  }
+  return undefined;
+}
+
+function toStandardReasoningLevel(level: ReasoningLevel): "low" | "medium" | "high" | undefined {
+  if (level === "xhigh") return "high";
+  if (level === "low" || level === "medium" || level === "high") return level;
+  return undefined;
+}
+
+function buildProviderOptions(input: {
+  provider: string;
+  modelId: string;
   outputReasoning: boolean;
+  reasoningLevel?: unknown;
   instructions: string;
-}): { openai: OpenAIResponsesProviderOptions } | undefined {
+}): AgentProviderOptions | undefined {
+  const reasoningLevel = resolveReasoningLevelForModel({
+    provider: input.provider,
+    modelId: input.modelId,
+    reasoningLevel: input.reasoningLevel,
+  });
+
   if (input.provider === PROVIDER_OPENAI_CODEX) {
     return {
       openai: {
         instructions: input.instructions,
+        ...(reasoningLevel ? { reasoningEffort: reasoningLevel } : {}),
         ...(input.outputReasoning ? { reasoningSummary: "auto" as const } : {}),
         // Keep chat state in DataStoria instead of creating stored OpenAI responses.
         store: false,
@@ -113,11 +212,110 @@ function buildOpenAIProviderOptions(input: {
     };
   }
 
-  if (input.provider === "OpenAI" && input.outputReasoning) {
+  if (input.provider === "OpenAI" && (input.outputReasoning || reasoningLevel)) {
     return {
       openai: {
-        reasoningSummary: "auto",
+        ...(reasoningLevel ? { reasoningEffort: reasoningLevel } : {}),
+        ...(input.outputReasoning ? { reasoningSummary: "auto" as const } : {}),
       } satisfies OpenAIResponsesProviderOptions,
+    };
+  }
+
+  if (input.provider === "Anthropic" && reasoningLevel) {
+    const effort = toAnthropicEffort(reasoningLevel);
+    if (!effort) {
+      return undefined;
+    }
+    const thinking = getAnthropicThinkingOptions(input.modelId, input.outputReasoning);
+
+    return {
+      anthropic: {
+        ...(thinking ? { thinking } : {}),
+        effort,
+      } satisfies AnthropicProviderOptions,
+    };
+  }
+
+  if (input.provider === "Anthropic" && input.outputReasoning) {
+    return {
+      anthropic: {
+        thinking: {
+          type: "enabled",
+          budgetTokens: ANTHROPIC_MANUAL_THINKING_BUDGET_TOKENS,
+        },
+      } satisfies AnthropicProviderOptions,
+    };
+  }
+
+  if (input.provider === "Google" && reasoningLevel) {
+    const thinkingLevel = toGoogleThinkingLevel(reasoningLevel);
+    if (!thinkingLevel) {
+      return undefined;
+    }
+
+    return {
+      google: {
+        thinkingConfig: {
+          thinkingLevel,
+          ...(input.outputReasoning ? { includeThoughts: true } : {}),
+        },
+      } satisfies GoogleGenerativeAIProviderOptions,
+    };
+  }
+
+  if (input.provider === "OpenRouter" && reasoningLevel) {
+    const effort = toStandardReasoningLevel(reasoningLevel);
+    if (!effort) {
+      return undefined;
+    }
+
+    return {
+      openrouter: {
+        reasoning: {
+          enabled: true,
+          effort,
+        },
+      } satisfies OpenRouterProviderOptions,
+    };
+  }
+
+  if (input.provider === "Groq" && reasoningLevel) {
+    const reasoningEffort = toStandardReasoningLevel(reasoningLevel);
+    if (!reasoningEffort) {
+      return undefined;
+    }
+
+    return {
+      groq: {
+        reasoningEffort,
+        ...(input.outputReasoning ? { reasoningFormat: "parsed" as const } : {}),
+      } satisfies GroqLanguageModelOptions,
+    };
+  }
+
+  if (input.provider === "Cerebras" && reasoningLevel) {
+    const reasoningEffort = toStandardReasoningLevel(reasoningLevel);
+    if (!reasoningEffort) {
+      return undefined;
+    }
+
+    return {
+      cerebras: {
+        reasoningEffort,
+      } satisfies OpenAICompatibleLanguageModelChatOptions,
+    };
+  }
+
+  if (input.provider === PROVIDER_NEBIUS && reasoningLevel) {
+    const reasoningEffort = toStandardReasoningLevel(reasoningLevel);
+    if (!reasoningEffort) {
+      return undefined;
+    }
+
+    return {
+      nebius: {
+        reasoningEffort,
+      } satisfies OpenAICompatibleLanguageModelChatOptions,
     };
   }
 
@@ -563,9 +761,11 @@ export async function POST(req: Request) {
       model,
       system: orchestratorSystemPrompt,
       messages: modelMessages,
-      providerOptions: buildOpenAIProviderOptions({
+      providerOptions: buildProviderOptions({
         provider: modelConfig.provider,
+        modelId: modelConfig.modelId,
         outputReasoning,
+        reasoningLevel: agentContext?.reasoningLevel,
         instructions: orchestratorSystemPrompt,
       }),
       tools,

--- a/src/app/api/ai/agent/route.ts
+++ b/src/app/api/ai/agent/route.ts
@@ -12,14 +12,8 @@ import {
   resolveModelConfig,
   resolveModelSupportsImageInput,
 } from "@/lib/ai/llm/llm-provider-factory";
-import { PROVIDER_NEBIUS, PROVIDER_OPENAI_CODEX } from "@/lib/ai/llm/provider-ids";
 import { MentionContext } from "@/lib/ai/mention-context";
 import { MessagePruner } from "@/lib/ai/message-pruner";
-import {
-  DEFAULT_REASONING_LEVEL,
-  isReasoningLevel,
-  type ReasoningLevel,
-} from "@/lib/ai/reasoning-levels";
 import {
   hasCompletedToolOutputs,
   replaceOrAppendMessageById,
@@ -50,13 +44,7 @@ import { getRuntimeAvailableToolNames } from "@/lib/ai/tools/server/runtime-tool
 import { SERVER_TOOL_NAMES } from "@/lib/ai/tools/server/server-tool-names";
 import { createServerTools } from "@/lib/ai/tools/server/server-tools";
 import { defaultCodeSearchFactory } from "@/lib/code-search/code-search-factory";
-import type { AnthropicProviderOptions } from "@ai-sdk/anthropic";
-import type { GoogleGenerativeAIProviderOptions } from "@ai-sdk/google";
-import type { GroqLanguageModelOptions } from "@ai-sdk/groq";
-import type { OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
-import type { OpenAICompatibleLanguageModelChatOptions } from "@ai-sdk/openai-compatible";
 import { APICallError } from "@ai-sdk/provider";
-import type { OpenRouterProviderOptions } from "@openrouter/ai-sdk-provider";
 import {
   convertToModelMessages,
   createUIMessageStreamResponse,
@@ -81,17 +69,6 @@ interface AgentRequest {
 }
 
 const TITLE_WAIT_MS = 3000;
-const ANTHROPIC_MANUAL_THINKING_BUDGET_TOKENS = 1024;
-
-type AgentProviderOptions = {
-  openai?: OpenAIResponsesProviderOptions;
-  anthropic?: AnthropicProviderOptions;
-  cerebras?: OpenAICompatibleLanguageModelChatOptions;
-  google?: GoogleGenerativeAIProviderOptions;
-  groq?: GroqLanguageModelOptions;
-  nebius?: OpenAICompatibleLanguageModelChatOptions;
-  openrouter?: OpenRouterProviderOptions;
-};
 
 function messageHasImageParts(message: UIMessage): boolean {
   return (message.parts ?? []).some((part) => {
@@ -116,210 +93,6 @@ function shouldOutputReasoning(
     agentContext?.outputReasoning === true &&
     LanguageModelProviderFactory.supportsReasoning(model.provider, model.modelId)
   );
-}
-
-function resolveReasoningLevelForModel(input: {
-  provider: string;
-  modelId: string;
-  reasoningLevel?: unknown;
-}): ReasoningLevel | undefined {
-  const levels = LanguageModelProviderFactory.getReasoningLevels(input.provider, input.modelId);
-  if (levels.length === 0) {
-    return undefined;
-  }
-
-  if (isReasoningLevel(input.reasoningLevel) && levels.includes(input.reasoningLevel)) {
-    return input.reasoningLevel;
-  }
-
-  if (levels.includes(DEFAULT_REASONING_LEVEL)) {
-    return DEFAULT_REASONING_LEVEL;
-  }
-
-  return levels[0];
-}
-
-function toAnthropicEffort(
-  level: ReasoningLevel
-): NonNullable<AnthropicProviderOptions["effort"]> | undefined {
-  if (level === "xhigh") return "max";
-  if (level === "low" || level === "medium" || level === "high" || level === "max") return level;
-  return undefined;
-}
-
-function supportsAnthropicAdaptiveThinking(modelId: string): boolean {
-  return modelId.includes("claude-opus-4-6") || modelId.includes("claude-sonnet-4-6");
-}
-
-function getAnthropicThinkingOptions(
-  modelId: string,
-  outputReasoning: boolean
-): AnthropicProviderOptions["thinking"] | undefined {
-  if (supportsAnthropicAdaptiveThinking(modelId)) {
-    return { type: "adaptive" };
-  }
-
-  if (outputReasoning) {
-    return {
-      type: "enabled",
-      budgetTokens: ANTHROPIC_MANUAL_THINKING_BUDGET_TOKENS,
-    };
-  }
-
-  return undefined;
-}
-
-function toGoogleThinkingLevel(
-  level: ReasoningLevel
-):
-  | NonNullable<NonNullable<GoogleGenerativeAIProviderOptions["thinkingConfig"]>["thinkingLevel"]>
-  | undefined {
-  if (level === "xhigh") return "high";
-  if (level === "minimal" || level === "low" || level === "medium" || level === "high") {
-    return level;
-  }
-  return undefined;
-}
-
-function toStandardReasoningLevel(level: ReasoningLevel): "low" | "medium" | "high" | undefined {
-  if (level === "xhigh") return "high";
-  if (level === "low" || level === "medium" || level === "high") return level;
-  return undefined;
-}
-
-function buildProviderOptions(input: {
-  provider: string;
-  modelId: string;
-  outputReasoning: boolean;
-  reasoningLevel?: unknown;
-  instructions: string;
-}): AgentProviderOptions | undefined {
-  const reasoningLevel = resolveReasoningLevelForModel({
-    provider: input.provider,
-    modelId: input.modelId,
-    reasoningLevel: input.reasoningLevel,
-  });
-
-  if (input.provider === PROVIDER_OPENAI_CODEX) {
-    return {
-      openai: {
-        instructions: input.instructions,
-        ...(reasoningLevel ? { reasoningEffort: reasoningLevel } : {}),
-        ...(input.outputReasoning ? { reasoningSummary: "auto" as const } : {}),
-        // Keep chat state in DataStoria instead of creating stored OpenAI responses.
-        store: false,
-      } satisfies OpenAIResponsesProviderOptions,
-    };
-  }
-
-  if (input.provider === "OpenAI" && (input.outputReasoning || reasoningLevel)) {
-    return {
-      openai: {
-        ...(reasoningLevel ? { reasoningEffort: reasoningLevel } : {}),
-        ...(input.outputReasoning ? { reasoningSummary: "auto" as const } : {}),
-      } satisfies OpenAIResponsesProviderOptions,
-    };
-  }
-
-  if (input.provider === "Anthropic" && reasoningLevel) {
-    const effort = toAnthropicEffort(reasoningLevel);
-    if (!effort) {
-      return undefined;
-    }
-    const thinking = getAnthropicThinkingOptions(input.modelId, input.outputReasoning);
-
-    return {
-      anthropic: {
-        ...(thinking ? { thinking } : {}),
-        effort,
-      } satisfies AnthropicProviderOptions,
-    };
-  }
-
-  if (input.provider === "Anthropic" && input.outputReasoning) {
-    return {
-      anthropic: {
-        thinking: {
-          type: "enabled",
-          budgetTokens: ANTHROPIC_MANUAL_THINKING_BUDGET_TOKENS,
-        },
-      } satisfies AnthropicProviderOptions,
-    };
-  }
-
-  if (input.provider === "Google" && reasoningLevel) {
-    const thinkingLevel = toGoogleThinkingLevel(reasoningLevel);
-    if (!thinkingLevel) {
-      return undefined;
-    }
-
-    return {
-      google: {
-        thinkingConfig: {
-          thinkingLevel,
-          ...(input.outputReasoning ? { includeThoughts: true } : {}),
-        },
-      } satisfies GoogleGenerativeAIProviderOptions,
-    };
-  }
-
-  if (input.provider === "OpenRouter" && reasoningLevel) {
-    const effort = toStandardReasoningLevel(reasoningLevel);
-    if (!effort) {
-      return undefined;
-    }
-
-    return {
-      openrouter: {
-        reasoning: {
-          enabled: true,
-          effort,
-        },
-      } satisfies OpenRouterProviderOptions,
-    };
-  }
-
-  if (input.provider === "Groq" && reasoningLevel) {
-    const reasoningEffort = toStandardReasoningLevel(reasoningLevel);
-    if (!reasoningEffort) {
-      return undefined;
-    }
-
-    return {
-      groq: {
-        reasoningEffort,
-        ...(input.outputReasoning ? { reasoningFormat: "parsed" as const } : {}),
-      } satisfies GroqLanguageModelOptions,
-    };
-  }
-
-  if (input.provider === "Cerebras" && reasoningLevel) {
-    const reasoningEffort = toStandardReasoningLevel(reasoningLevel);
-    if (!reasoningEffort) {
-      return undefined;
-    }
-
-    return {
-      cerebras: {
-        reasoningEffort,
-      } satisfies OpenAICompatibleLanguageModelChatOptions,
-    };
-  }
-
-  if (input.provider === PROVIDER_NEBIUS && reasoningLevel) {
-    const reasoningEffort = toStandardReasoningLevel(reasoningLevel);
-    if (!reasoningEffort) {
-      return undefined;
-    }
-
-    return {
-      nebius: {
-        reasoningEffort,
-      } satisfies OpenAICompatibleLanguageModelChatOptions,
-    };
-  }
-
-  return undefined;
 }
 
 function getMessageIdFromMessages(messages: UIMessage[]): string {
@@ -761,9 +534,8 @@ export async function POST(req: Request) {
       model,
       system: orchestratorSystemPrompt,
       messages: modelMessages,
-      providerOptions: buildProviderOptions({
-        provider: modelConfig.provider,
-        modelId: modelConfig.modelId,
+      providerOptions: LanguageModelProviderFactory.buildProviderOptions({
+        modelConfig,
         outputReasoning,
         reasoningLevel: agentContext?.reasoningLevel,
         instructions: orchestratorSystemPrompt,

--- a/src/app/api/ai/agent/route.ts
+++ b/src/app/api/ai/agent/route.ts
@@ -539,6 +539,7 @@ export async function POST(req: Request) {
         outputReasoning,
         reasoningLevel: agentContext?.reasoningLevel,
         instructions: orchestratorSystemPrompt,
+        responseLanguage: agentContext?.responseLanguage,
       }),
       tools,
       stopWhen: stepCountIs(10),

--- a/src/components/chat/chat-factory.test.ts
+++ b/src/components/chat/chat-factory.test.ts
@@ -154,6 +154,32 @@ describe("buildSendMessagesRequestPayload", () => {
     });
   });
 
+  it("adds the selected reasoning level to agent context", () => {
+    const payload = buildSendMessagesRequestPayload({
+      sessionId: "session-1",
+      connectionId: "default@https://example.com",
+      messages: [createMessage({})],
+      trigger: "submit-message",
+      messageId: "message-1",
+      body: {},
+      requestContext: diagnosisContext,
+      currentModel: { provider: "OpenAI", modelId: "gpt-5.2" },
+      generateTitle: false,
+      ephemeral: true,
+      pruneValidateSql: true,
+      outputReasoning: true,
+      reasoningLevel: "high",
+      chatPersistenceMode: "remote",
+    });
+
+    expect(payload).toMatchObject({
+      agentContext: {
+        outputReasoning: true,
+        reasoningLevel: "high",
+      },
+    });
+  });
+
   it("preserves mention metadata on remote user messages", () => {
     const message = createMessage({
       metadata: {

--- a/src/components/chat/chat-factory.test.ts
+++ b/src/components/chat/chat-factory.test.ts
@@ -1,6 +1,9 @@
 import type { AppUIMessage } from "@/lib/ai/ai-types";
 import { describe, expect, it } from "vitest";
-import { buildSendMessagesRequestPayload } from "./chat-factory";
+import {
+  buildAgentContextWithResponseLanguage,
+  buildSendMessagesRequestPayload,
+} from "./chat-factory";
 import { NO_CONNECTION_SESSION_CONNECTION_ID } from "./session/session-connection-id";
 
 function createMessage(overrides: Partial<AppUIMessage>): AppUIMessage {
@@ -238,5 +241,23 @@ describe("buildSendMessagesRequestPayload", () => {
       connectionId: NO_CONNECTION_SESSION_CONNECTION_ID,
     });
     expect(payload).not.toHaveProperty("context");
+  });
+});
+
+describe("buildAgentContextWithResponseLanguage", () => {
+  it("adds configured non-English response language to agent context", () => {
+    expect(buildAgentContextWithResponseLanguage(undefined, "zh-CN")).toEqual({
+      responseLanguage: "zh-CN",
+    });
+  });
+
+  it("lets explicit agent context override configured response language", () => {
+    expect(buildAgentContextWithResponseLanguage({ responseLanguage: "ja" }, "zh-CN")).toEqual({
+      responseLanguage: "ja",
+    });
+  });
+
+  it("does not force English as an explicit response language", () => {
+    expect(buildAgentContextWithResponseLanguage(undefined, "en")).toBeUndefined();
   });
 });

--- a/src/components/chat/chat-factory.ts
+++ b/src/components/chat/chat-factory.ts
@@ -90,6 +90,7 @@ type SendMessagesRequestPayloadArgs = {
   ephemeral?: boolean;
   pruneValidateSql: boolean;
   outputReasoning?: boolean;
+  reasoningLevel?: AgentContext["reasoningLevel"];
   agentContext?: Partial<AgentContext>;
   chatPersistenceMode: "local" | "remote";
 };
@@ -161,6 +162,7 @@ export function buildSendMessagesRequestPayload({
   ephemeral,
   pruneValidateSql,
   outputReasoning = true,
+  reasoningLevel,
   agentContext,
   chatPersistenceMode,
 }: SendMessagesRequestPayloadArgs): Record<string, unknown> {
@@ -179,6 +181,7 @@ export function buildSendMessagesRequestPayload({
         ...(agentContext ?? {}),
         pruneValidateSql,
         outputReasoning,
+        reasoningLevel,
       },
       ...(clickHouseConnection ? { connection: clickHouseConnection } : {}),
       ...(requestContext ? { context: requestContext } : {}),
@@ -195,6 +198,7 @@ export function buildSendMessagesRequestPayload({
       ...(agentContext ?? {}),
       pruneValidateSql,
       outputReasoning,
+      reasoningLevel,
     },
     ...(clickHouseConnection ? { connection: clickHouseConnection } : {}),
     generateTitle,
@@ -533,8 +537,9 @@ export class ChatFactory {
 
           const requestContext = options.context ?? ChatContext.build();
           const chatPersistenceMode = getRuntimeConfig().sessionRepositoryType;
+          const agentConfiguration = AgentConfigurationManager.getConfiguration();
           const clickHouseConnection =
-            AgentConfigurationManager.getConfiguration().mode === "v2"
+            agentConfiguration.mode === "v2"
               ? buildClickHouseConnectionPayload(connection)
               : undefined;
           return {
@@ -550,9 +555,9 @@ export class ChatFactory {
               currentModel,
               generateTitle: options.generateTitle,
               ephemeral: options.ephemeral,
-              pruneValidateSql:
-                AgentConfigurationManager.getConfiguration().pruneValidateSql ?? true,
-              outputReasoning: AgentConfigurationManager.getConfiguration().outputReasoning ?? true,
+              pruneValidateSql: agentConfiguration.pruneValidateSql ?? true,
+              outputReasoning: agentConfiguration.outputReasoning ?? true,
+              reasoningLevel: agentConfiguration.reasoningLevel,
               agentContext: options.agentContext,
               chatPersistenceMode,
             }),

--- a/src/components/chat/chat-factory.ts
+++ b/src/components/chat/chat-factory.ts
@@ -1,5 +1,8 @@
 import { getRuntimeConfig } from "@/components/runtime-config-provider";
-import { AgentConfigurationManager } from "@/components/settings/agent/agent-manager";
+import {
+  AgentConfigurationManager,
+  normalizeAIResponseLanguage,
+} from "@/components/settings/agent/agent-manager";
 import { ModelManager } from "@/components/settings/models/model-manager";
 import type { PlanToolOutput } from "@/lib/ai/agent/plan/planning-types";
 import type { AgentContext, AppUIMessage, Message, MessageMetadata } from "@/lib/ai/ai-types";
@@ -94,6 +97,22 @@ type SendMessagesRequestPayloadArgs = {
   agentContext?: Partial<AgentContext>;
   chatPersistenceMode: "local" | "remote";
 };
+
+export function buildAgentContextWithResponseLanguage(
+  agentContext: Partial<AgentContext> | undefined,
+  configuredLanguage: string | undefined
+): Partial<AgentContext> | undefined {
+  const responseLanguage = normalizeAIResponseLanguage(configuredLanguage);
+  const configuredAgentContext =
+    responseLanguage === "en" ? undefined : ({ responseLanguage } satisfies Partial<AgentContext>);
+
+  return configuredAgentContext || agentContext
+    ? {
+        ...configuredAgentContext,
+        ...(agentContext ?? {}),
+      }
+    : undefined;
+}
 
 function extractTextFromMessage(
   message: Pick<Message, "parts"> | Pick<AppUIMessage, "parts">
@@ -538,6 +557,10 @@ export class ChatFactory {
           const requestContext = options.context ?? ChatContext.build();
           const chatPersistenceMode = getRuntimeConfig().sessionRepositoryType;
           const agentConfiguration = AgentConfigurationManager.getConfiguration();
+          const agentContext = buildAgentContextWithResponseLanguage(
+            options.agentContext,
+            agentConfiguration.aiResponseLanguage
+          );
           const clickHouseConnection =
             agentConfiguration.mode === "v2"
               ? buildClickHouseConnectionPayload(connection)
@@ -558,7 +581,7 @@ export class ChatFactory {
               pruneValidateSql: agentConfiguration.pruneValidateSql ?? true,
               outputReasoning: agentConfiguration.outputReasoning ?? true,
               reasoningLevel: agentConfiguration.reasoningLevel,
-              agentContext: options.agentContext,
+              agentContext,
               chatPersistenceMode,
             }),
             headers: buildChatRequestHeaders(headers, options.shareCode),

--- a/src/components/chat/input/model-selector-impl.tsx
+++ b/src/components/chat/input/model-selector-impl.tsx
@@ -26,8 +26,8 @@ import {
 } from "@/lib/ai/llm/llm-provider-factory";
 import { PROVIDER_GITHUB_COPILOT } from "@/lib/ai/llm/provider-ids";
 import {
-  DEFAULT_REASONING_LEVEL,
   formatReasoningLevel,
+  getDefaultReasoningLevel,
   type ReasoningLevel,
 } from "@/lib/ai/reasoning-levels";
 import { cn } from "@/lib/utils";
@@ -59,6 +59,7 @@ type ModelDetailField = {
 
 const MODEL_PANEL_HEIGHT_WITH_REASONING = "h-[320px] min-h-[320px] max-h-[320px]";
 const MODEL_PANEL_HEIGHT_DEFAULT = "h-[250px] min-h-[250px] max-h-[250px]";
+const UNSUPPORTED_REASONING_VALUE = "__reasoning_not_supported__";
 
 function toDescriptionHeaderLabel(label: string): string {
   return label
@@ -115,11 +116,7 @@ function resolveActiveReasoningLevel(
     return configuredLevel;
   }
 
-  if (levels.includes(DEFAULT_REASONING_LEVEL)) {
-    return DEFAULT_REASONING_LEVEL;
-  }
-
-  return levels[0];
+  return getDefaultReasoningLevel(levels);
 }
 
 function ReasoningDetailSection({
@@ -140,7 +137,7 @@ function ReasoningDetailSection({
     ? levels.length > 0
       ? "Configurable"
       : "Built-in"
-    : "No";
+    : "Not supported";
 
   const handleSelect = useCallback(
     (level: ReasoningLevel) => {
@@ -152,7 +149,40 @@ function ReasoningDetailSection({
     [configuration, levels, onChange]
   );
 
-  if (!isInteractive || !supportsReasoning || levels.length === 0) {
+  if (isInteractive && !supportsReasoning) {
+    return (
+      <div className="flex flex-col gap-1">
+        <div className="text-[9px] font-semibold text-muted-foreground">Reasoning Level</div>
+        <RadioGroup
+          className="flex flex-col gap-0.5"
+          value={UNSUPPORTED_REASONING_VALUE}
+          aria-label="Reasoning level"
+        >
+          <div
+            title="Reasoning is not supported by this model"
+            className={cn(
+              "flex h-6 w-full items-center gap-2 rounded-sm px-2 text-left text-[10px] outline-none transition-colors",
+              "bg-accent text-accent-foreground"
+            )}
+          >
+            <RadioGroupItem
+              id="reasoning-level-not-supported"
+              value={UNSUPPORTED_REASONING_VALUE}
+              className="h-3 w-3 shrink-0 border-muted-foreground/60 text-current"
+            />
+            <Label
+              htmlFor="reasoning-level-not-supported"
+              className="min-w-0 flex-1 cursor-pointer truncate text-[10px] font-normal leading-none"
+            >
+              Not supported
+            </Label>
+          </div>
+        </RadioGroup>
+      </div>
+    );
+  }
+
+  if (!isInteractive || levels.length === 0) {
     return (
       <div className="flex flex-col gap-1">
         <div className="text-[9px] font-semibold text-muted-foreground">Reasoning Level</div>
@@ -313,7 +343,7 @@ export function ModelSelectorImpl({
   const [highlightedValue, setHighlightedValue] = useState<string | undefined>(
     activeModel ? `${activeModel.provider} ${activeModel.modelId}` : undefined
   );
-  const [groupByProvider, setGroupByProvider] = useState(false);
+  const [groupByProvider, setGroupByProvider] = useState(true);
   const [agentConfiguration, setAgentConfiguration] = useState(() =>
     AgentConfigurationManager.getConfiguration()
   );

--- a/src/components/chat/input/model-selector-impl.tsx
+++ b/src/components/chat/input/model-selector-impl.tsx
@@ -13,7 +13,9 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Switch } from "@/components/ui/switch";
 import { useModelConfig } from "@/hooks/use-model-config";
 import {
@@ -71,7 +73,7 @@ function toDescriptionHeaderLabel(label: string): string {
 function parseModelDetailFields(model: ModelProps): ModelDetailField[] {
   const fields: ModelDetailField[] = [
     {
-      label: "Support Image Input",
+      label: "Supports Image Input",
       value: resolveModelSupportsImageInput(model) ? "Yes" : "No",
     },
   ];
@@ -164,29 +166,40 @@ function ReasoningDetailSection({
   return (
     <div className="flex flex-col gap-1">
       <div className="text-[9px] font-semibold text-muted-foreground">Reasoning Level</div>
-      <div className="flex flex-col gap-0.5" role="radiogroup" aria-label="Reasoning level">
+      <RadioGroup
+        className="flex flex-col gap-0.5"
+        value={activeLevel}
+        onValueChange={handleSelect}
+        aria-label="Reasoning level"
+      >
         {levels.map((level) => {
+          const itemId = `reasoning-level-${level.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
           const isSelected = activeLevel === level;
           return (
-            <button
+            <div
               key={level}
-              type="button"
-              role="radio"
-              aria-checked={isSelected}
               title={`Use ${formatReasoningLevel(level)} reasoning`}
               className={cn(
                 "flex h-6 w-full items-center gap-2 rounded-sm px-2 text-left text-[10px] outline-none transition-colors",
-                "cursor-pointer hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground",
+                "hover:bg-accent hover:text-accent-foreground",
                 isSelected && "bg-accent text-accent-foreground"
               )}
-              onClick={() => handleSelect(level)}
             >
-              <Check className={cn("h-3 w-3 shrink-0", isSelected ? "opacity-100" : "opacity-0")} />
-              <span className="truncate">{formatReasoningLevel(level)}</span>
-            </button>
+              <RadioGroupItem
+                id={itemId}
+                value={level}
+                className="h-3 w-3 shrink-0 border-muted-foreground/60 text-current"
+              />
+              <Label
+                htmlFor={itemId}
+                className="min-w-0 flex-1 cursor-pointer truncate text-[10px] font-normal leading-none"
+              >
+                {formatReasoningLevel(level)}
+              </Label>
+            </div>
           );
         })}
-      </div>
+      </RadioGroup>
     </div>
   );
 }

--- a/src/components/chat/input/model-selector-impl.tsx
+++ b/src/components/chat/input/model-selector-impl.tsx
@@ -60,6 +60,7 @@ type ModelDetailField = {
 const MODEL_PANEL_HEIGHT_WITH_REASONING = "h-[320px] min-h-[320px] max-h-[320px]";
 const MODEL_PANEL_HEIGHT_DEFAULT = "h-[250px] min-h-[250px] max-h-[250px]";
 const UNSUPPORTED_REASONING_VALUE = "__reasoning_not_supported__";
+const BUILT_IN_REASONING_VALUE = "__reasoning_built_in__";
 
 function toDescriptionHeaderLabel(label: string): string {
   return label
@@ -149,37 +150,58 @@ function ReasoningDetailSection({
     [configuration, levels, onChange]
   );
 
-  if (isInteractive && !supportsReasoning) {
-    return (
-      <div className="flex flex-col gap-1">
-        <div className="text-[9px] font-semibold text-muted-foreground">Reasoning Level</div>
-        <RadioGroup
-          className="flex flex-col gap-0.5"
-          value={UNSUPPORTED_REASONING_VALUE}
-          aria-label="Reasoning level"
+  const renderStaticReasoningOption = (input: {
+    id: string;
+    label: string;
+    title: string;
+    value: string;
+  }) => (
+    <div className="flex flex-col gap-1">
+      <div className="text-[9px] font-semibold text-muted-foreground">Reasoning Level</div>
+      <RadioGroup
+        className="flex flex-col gap-0.5"
+        value={input.value}
+        aria-label="Reasoning level"
+      >
+        <div
+          title={input.title}
+          className={cn(
+            "flex h-6 w-full items-center gap-2 rounded-sm px-2 text-left text-[10px] outline-none transition-colors",
+            "bg-accent text-accent-foreground"
+          )}
         >
-          <div
-            title="Reasoning is not supported by this model"
-            className={cn(
-              "flex h-6 w-full items-center gap-2 rounded-sm px-2 text-left text-[10px] outline-none transition-colors",
-              "bg-accent text-accent-foreground"
-            )}
+          <RadioGroupItem
+            id={input.id}
+            value={input.value}
+            className="h-3 w-3 shrink-0 border-muted-foreground/60 text-current"
+          />
+          <Label
+            htmlFor={input.id}
+            className="min-w-0 flex-1 cursor-pointer truncate text-[10px] font-normal leading-none"
           >
-            <RadioGroupItem
-              id="reasoning-level-not-supported"
-              value={UNSUPPORTED_REASONING_VALUE}
-              className="h-3 w-3 shrink-0 border-muted-foreground/60 text-current"
-            />
-            <Label
-              htmlFor="reasoning-level-not-supported"
-              className="min-w-0 flex-1 cursor-pointer truncate text-[10px] font-normal leading-none"
-            >
-              Not supported
-            </Label>
-          </div>
-        </RadioGroup>
-      </div>
-    );
+            {input.label}
+          </Label>
+        </div>
+      </RadioGroup>
+    </div>
+  );
+
+  if (isInteractive && !supportsReasoning) {
+    return renderStaticReasoningOption({
+      id: "reasoning-level-not-supported",
+      label: "Not supported",
+      title: "Reasoning is not supported by this model",
+      value: UNSUPPORTED_REASONING_VALUE,
+    });
+  }
+
+  if (isInteractive && supportsReasoning && levels.length === 0) {
+    return renderStaticReasoningOption({
+      id: "reasoning-level-built-in",
+      label: "Built-in",
+      title: "Reasoning is built into this model",
+      value: BUILT_IN_REASONING_VALUE,
+    });
   }
 
   if (!isInteractive || levels.length === 0) {

--- a/src/components/chat/input/model-selector-impl.tsx
+++ b/src/components/chat/input/model-selector-impl.tsx
@@ -153,9 +153,7 @@ function ReasoningDetailSection({
   if (!isInteractive || !supportsReasoning || levels.length === 0) {
     return (
       <div className="flex flex-col gap-1">
-        <div className="text-[9px] font-semibold text-muted-foreground">
-          Reasoning Level
-        </div>
+        <div className="text-[9px] font-semibold text-muted-foreground">Reasoning Level</div>
         <div className="text-[10px] leading-relaxed text-popover-foreground">
           {staticReasoningLevelLabel}
         </div>
@@ -165,9 +163,7 @@ function ReasoningDetailSection({
 
   return (
     <div className="flex flex-col gap-1">
-      <div className="text-[9px] font-semibold text-muted-foreground">
-        Reasoning Level
-      </div>
+      <div className="text-[9px] font-semibold text-muted-foreground">Reasoning Level</div>
       <div className="flex flex-col gap-0.5" role="radiogroup" aria-label="Reasoning level">
         {levels.map((level) => {
           const isSelected = activeLevel === level;

--- a/src/components/chat/input/model-selector-impl.tsx
+++ b/src/components/chat/input/model-selector-impl.tsx
@@ -1,3 +1,8 @@
+import {
+  AGENT_CONFIG_UPDATED_EVENT,
+  AgentConfigurationManager,
+  type AgentConfiguration,
+} from "@/components/settings/agent/agent-manager";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -11,8 +16,18 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
 import { useModelConfig } from "@/hooks/use-model-config";
-import { resolveModelSupportsImageInput, type ModelProps } from "@/lib/ai/llm/llm-provider-factory";
+import {
+  resolveModelReasoningLevels,
+  resolveModelSupportsImageInput,
+  resolveModelSupportsReasoning,
+  type ModelProps,
+} from "@/lib/ai/llm/llm-provider-factory";
 import { PROVIDER_GITHUB_COPILOT } from "@/lib/ai/llm/provider-ids";
+import {
+  DEFAULT_REASONING_LEVEL,
+  formatReasoningLevel,
+  type ReasoningLevel,
+} from "@/lib/ai/reasoning-levels";
 import { cn } from "@/lib/utils";
 import { Check, ChevronsUpDown, Layers, Settings2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -26,6 +41,7 @@ interface ModelCommandItemProps {
   model: ModelProps;
   isSelected: boolean;
   onSelect: (model: { provider: string; modelId: string }) => void;
+  onHighlight?: (model: ModelProps) => void;
   showProvider?: boolean;
 }
 
@@ -39,8 +55,26 @@ type ModelDetailField = {
   value: string;
 };
 
+const MODEL_PANEL_HEIGHT_WITH_REASONING = "h-[320px] min-h-[320px] max-h-[320px]";
+const MODEL_PANEL_HEIGHT_DEFAULT = "h-[250px] min-h-[250px] max-h-[250px]";
+
+function toDescriptionHeaderLabel(label: string): string {
+  return label
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[^a-zA-Z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .toLowerCase()
+    .replace(/\b[a-z]/g, (char) => char.toUpperCase());
+}
+
 function parseModelDetailFields(model: ModelProps): ModelDetailField[] {
-  const fields: ModelDetailField[] = [];
+  const fields: ModelDetailField[] = [
+    {
+      label: "Support Image Input",
+      value: resolveModelSupportsImageInput(model) ? "Yes" : "No",
+    },
+  ];
   const rawDescription = model.description?.trim();
 
   if (rawDescription) {
@@ -64,12 +98,101 @@ function parseModelDetailFields(model: ModelProps): ModelDetailField[] {
     }
   }
 
-  fields.push({
-    label: "Support Image Input",
-    value: resolveModelSupportsImageInput(model) ? "Yes" : "No",
-  });
-
   return fields;
+}
+
+function resolveActiveReasoningLevel(
+  levels: readonly ReasoningLevel[],
+  configuredLevel: ReasoningLevel | undefined
+): ReasoningLevel | undefined {
+  if (levels.length === 0) {
+    return undefined;
+  }
+
+  if (configuredLevel && levels.includes(configuredLevel)) {
+    return configuredLevel;
+  }
+
+  if (levels.includes(DEFAULT_REASONING_LEVEL)) {
+    return DEFAULT_REASONING_LEVEL;
+  }
+
+  return levels[0];
+}
+
+function ReasoningDetailSection({
+  configuration,
+  isInteractive,
+  levels,
+  onChange,
+  supportsReasoning,
+}: {
+  configuration: AgentConfiguration;
+  isInteractive: boolean;
+  levels: readonly ReasoningLevel[];
+  onChange: (configuration: AgentConfiguration) => void;
+  supportsReasoning: boolean;
+}) {
+  const activeLevel = resolveActiveReasoningLevel(levels, configuration.reasoningLevel);
+  const staticReasoningLevelLabel = supportsReasoning
+    ? levels.length > 0
+      ? "Configurable"
+      : "Built-in"
+    : "No";
+
+  const handleSelect = useCallback(
+    (level: ReasoningLevel) => {
+      if (!levels.includes(level)) {
+        return;
+      }
+      onChange({ ...configuration, reasoningLevel: level });
+    },
+    [configuration, levels, onChange]
+  );
+
+  if (!isInteractive || !supportsReasoning || levels.length === 0) {
+    return (
+      <div className="flex flex-col gap-1">
+        <div className="text-[9px] font-semibold text-muted-foreground">
+          Reasoning Level
+        </div>
+        <div className="text-[10px] leading-relaxed text-popover-foreground">
+          {staticReasoningLevelLabel}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="text-[9px] font-semibold text-muted-foreground">
+        Reasoning Level
+      </div>
+      <div className="flex flex-col gap-0.5" role="radiogroup" aria-label="Reasoning level">
+        {levels.map((level) => {
+          const isSelected = activeLevel === level;
+          return (
+            <button
+              key={level}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              title={`Use ${formatReasoningLevel(level)} reasoning`}
+              className={cn(
+                "flex h-6 w-full items-center gap-2 rounded-sm px-2 text-left text-[10px] outline-none transition-colors",
+                "cursor-pointer hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground",
+                isSelected && "bg-accent text-accent-foreground"
+              )}
+              onClick={() => handleSelect(level)}
+            >
+              <Check className={cn("h-3 w-3 shrink-0", isSelected ? "opacity-100" : "opacity-0")} />
+              <span className="truncate">{formatReasoningLevel(level)}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
 }
 
 function FreeBadge() {
@@ -92,6 +215,7 @@ function ModelCommandItem({
   model,
   isSelected,
   onSelect,
+  onHighlight,
   showProvider = true,
 }: ModelCommandItemProps) {
   return (
@@ -99,6 +223,8 @@ function ModelCommandItem({
       value={`${model.provider} ${model.modelId}`}
       keywords={showProvider ? [model.provider, model.modelId] : [model.modelId]}
       onSelect={() => onSelect({ provider: model.provider, modelId: model.modelId })}
+      onMouseEnter={() => onHighlight?.(model)}
+      onFocus={() => onHighlight?.(model)}
       className="m-1 text-xs cursor-pointer py-0.5"
     >
       {showProvider ? (
@@ -144,6 +270,7 @@ export interface ModelSelectorImplProps {
   popoverSideOffset?: number;
   popoverContentClassName?: string;
   showConfigureAction?: boolean;
+  showReasoningControls?: boolean;
 }
 
 export function ModelSelectorImpl({
@@ -159,6 +286,7 @@ export function ModelSelectorImpl({
   popoverSideOffset = 4,
   popoverContentClassName,
   showConfigureAction = true,
+  showReasoningControls,
 }: ModelSelectorImplProps = {}) {
   const [open, setOpen] = useState(false);
   const {
@@ -177,6 +305,10 @@ export function ModelSelectorImpl({
     activeModel ? `${activeModel.provider} ${activeModel.modelId}` : undefined
   );
   const [groupByProvider, setGroupByProvider] = useState(false);
+  const [agentConfiguration, setAgentConfiguration] = useState(() =>
+    AgentConfigurationManager.getConfiguration()
+  );
+  const shouldShowReasoningControls = showReasoningControls ?? !onChange;
 
   // Filter out "System (Auto)" if auto-select is not available
   const filteredModels = useMemo(() => {
@@ -264,6 +396,20 @@ export function ModelSelectorImpl({
     }
   }, [activeModel, open]);
 
+  useEffect(() => {
+    if (!shouldShowReasoningControls) {
+      return;
+    }
+
+    const refreshAgentConfiguration = () => {
+      setAgentConfiguration(AgentConfigurationManager.getConfiguration());
+    };
+    window.addEventListener(AGENT_CONFIG_UPDATED_EVENT, refreshAgentConfiguration);
+    return () => {
+      window.removeEventListener(AGENT_CONFIG_UPDATED_EVENT, refreshAgentConfiguration);
+    };
+  }, [shouldShowReasoningControls]);
+
   const handleSelect = useCallback(
     (model: ModelSelection) => {
       if (onChange) {
@@ -283,6 +429,33 @@ export function ModelSelectorImpl({
     (m) => activeModel && m.provider === activeModel.provider && m.modelId === activeModel.modelId
   );
   const displayModel = currentModel ?? activeModel;
+  const displayReasoningLevels = useMemo(
+    () => resolveModelReasoningLevels(displayModel),
+    [displayModel]
+  );
+  const displayReasoningLevel = resolveActiveReasoningLevel(
+    displayReasoningLevels,
+    agentConfiguration.reasoningLevel
+  );
+  const displayLabel = displayModel
+    ? `${displayModel.provider} | ${displayModel.modelId}${
+        shouldShowReasoningControls && displayReasoningLevel
+          ? ` · ${formatReasoningLevel(displayReasoningLevel)}`
+          : ""
+      }`
+    : "Select model...";
+  const modelPanelHeightClass = shouldShowReasoningControls
+    ? MODEL_PANEL_HEIGHT_WITH_REASONING
+    : MODEL_PANEL_HEIGHT_DEFAULT;
+
+  const handleReasoningConfigurationChange = useCallback((configuration: AgentConfiguration) => {
+    AgentConfigurationManager.setConfiguration(configuration);
+    setAgentConfiguration(configuration);
+  }, []);
+
+  const handleHighlight = useCallback((model: ModelProps) => {
+    setHighlightedValue(`${model.provider} ${model.modelId}`);
+  }, []);
 
   const highlightedModel = useMemo(() => {
     // When searching, highlightedValue matches the composite value (provider + modelId)
@@ -296,6 +469,16 @@ export function ModelSelectorImpl({
   const highlightedModelFields = useMemo(
     () => (highlightedModel ? parseModelDetailFields(highlightedModel) : []),
     [highlightedModel]
+  );
+
+  const previewModel = highlightedModel ?? displayModel;
+  const previewReasoningLevels = useMemo(
+    () => resolveModelReasoningLevels(previewModel),
+    [previewModel]
+  );
+  const previewSupportsReasoning = useMemo(
+    () => resolveModelSupportsReasoning(previewModel),
+    [previewModel]
   );
 
   return (
@@ -313,13 +496,7 @@ export function ModelSelectorImpl({
             className
           )}
         >
-          {showLabel ? (
-            <span className="truncate max-w-[350px]">
-              {displayModel
-                ? `${displayModel.provider} | ${displayModel.modelId}`
-                : "Select model..."}
-            </span>
-          ) : null}
+          {showLabel ? <span className="truncate max-w-[350px]">{displayLabel}</span> : null}
           <ChevronsUpDown className="ml-0.5 h-3 w-3 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
@@ -335,7 +512,7 @@ export function ModelSelectorImpl({
         <Command
           value={highlightedValue}
           onValueChange={setHighlightedValue}
-          className="flex flex-row items-stretch overflow-visible bg-transparent shadow-none border-0"
+          className="flex flex-col items-stretch overflow-visible bg-transparent shadow-none border-0"
           filter={(value: string, search: string, keywords?: string[]) => {
             const normalizedSearch = search.toLowerCase();
             const searchTargets =
@@ -343,123 +520,138 @@ export function ModelSelectorImpl({
             return searchTargets.some((target) => target.toLowerCase().includes(normalizedSearch));
           }}
         >
-          <div
-            data-panel="left"
-            className={cn(
-              "flex h-[250px] min-h-[250px] max-h-[250px] w-[300px] flex-col overflow-hidden rounded-sm border bg-popover shadow-md",
-              highlightedModelFields.length > 0 ? "rounded-r-none" : ""
-            )}
-          >
-            <CommandInput
-              placeholder="Search models..."
-              className="h-[32px] text-[10px] shrink-0"
-              wrapperClassName="px-2"
-              iconClassName="h-3 w-3"
-            />
-            {(providerEntries.length > 0 || sortedModels.length > 0) && (
-              <div className="flex items-center justify-between px-2 pt-1.5 shrink-0">
-                <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-                  <Layers className="h-3 w-3 opacity-50" />
-                  <span>Group by provider</span>
-                </div>
-                <Switch
-                  checked={groupByProvider}
-                  onCheckedChange={setGroupByProvider}
-                  className="h-4 w-7 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input [&>span]:h-3 [&>span]:w-3 [&>span]:data-[state=checked]:translate-x-3"
-                />
-              </div>
-            )}
-            <CommandList
-              id="model-list"
+          <div className="flex flex-row items-stretch">
+            <div
+              data-panel="left"
               className={cn(
-                "min-h-0 flex-1 overflow-y-auto [&_[cmdk-list-sizer]]:max-h-none",
-                groupByProvider && "[&_[cmdk-list-sizer]]:pt-1"
+                "flex w-[300px] flex-col overflow-hidden rounded-sm border bg-popover shadow-md",
+                modelPanelHeightClass,
+                highlightedModelFields.length > 0 ? "rounded-r-none" : ""
               )}
             >
-              <CommandEmpty className="h-[32px] py-2 text-center text-[10px]">
-                No model found.
-              </CommandEmpty>
-              {groupByProvider
-                ? // Grouped view
-                  providerEntries.map(([provider, models]) => (
-                    <CommandGroup
-                      key={provider}
-                      heading={
-                        <span className="flex items-center gap-1.5">
-                          <ProviderLogo provider={provider} className="h-3 w-3 opacity-70" />
-                          <span>{provider}</span>
-                        </span>
-                      }
-                      className="py-0 [&_[cmdk-group-heading]]:py-0 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-items]]:pt-0"
-                    >
-                      {models.map((model) => (
-                        <ModelCommandItem
-                          key={`${model.provider}-${model.modelId}`}
-                          model={model}
-                          isSelected={
-                            activeModel?.modelId === model.modelId &&
-                            activeModel?.provider === model.provider
-                          }
-                          onSelect={handleSelect}
-                          showProvider={false}
-                        />
-                      ))}
-                    </CommandGroup>
-                  ))
-                : // Flat view
-                  sortedModels.map((model) => (
-                    <ModelCommandItem
-                      key={`${model.provider}-${model.modelId}`}
-                      model={model}
-                      isSelected={
-                        activeModel?.modelId === model.modelId &&
-                        activeModel?.provider === model.provider
-                      }
-                      onSelect={handleSelect}
-                      showProvider={true}
-                    />
-                  ))}
-            </CommandList>
-            {showConfigureAction ? (
-              <>
-                <div className="h-px bg-border shrink-0" />
-                <div className="h-[32px] items-center flex mx-1 shrink-0">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="w-full h-[24px] justify-start px-2 text-[10px] font-normal gap-2 rounded-sm"
-                    onClick={() => {
-                      setOpen(false);
-                      showSettingsDialog({ initialSection: "models" });
-                    }}
-                  >
-                    <Settings2 className="h-3 w-3" />
-                    Configure more AI Models...
-                  </Button>
-                </div>
-              </>
-            ) : null}
-          </div>
-
-          {highlightedModelFields.length > 0 && (
-            <div
-              data-panel="right"
-              className="h-[250px] min-h-[250px] max-h-[250px] w-[250px] overflow-y-auto rounded-sm rounded-l-none border border-l-0 bg-popover p-2 text-[10px] text-popover-foreground shadow-md"
-            >
-              <div className="flex flex-col gap-3">
-                {highlightedModelFields.map((field) => (
-                  <div key={field.label} className="flex flex-col gap-1">
-                    <div className="text-[9px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-                      {field.label}
-                    </div>
-                    <div className="text-[10px] leading-relaxed text-popover-foreground">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{field.value}</ReactMarkdown>
-                    </div>
+              <CommandInput
+                placeholder="Search models..."
+                className="h-[32px] text-[10px] shrink-0"
+                wrapperClassName="px-2"
+                iconClassName="h-3 w-3"
+              />
+              {(providerEntries.length > 0 || sortedModels.length > 0) && (
+                <div className="flex items-center justify-between px-2 pt-1.5 shrink-0">
+                  <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+                    <Layers className="h-3 w-3 opacity-50" />
+                    <span>Group by provider</span>
                   </div>
-                ))}
-              </div>
+                  <Switch
+                    checked={groupByProvider}
+                    onCheckedChange={setGroupByProvider}
+                    className="h-4 w-7 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input [&>span]:h-3 [&>span]:w-3 [&>span]:data-[state=checked]:translate-x-3"
+                  />
+                </div>
+              )}
+              <CommandList
+                id="model-list"
+                className={cn(
+                  "min-h-0 flex-1 overflow-y-auto [&_[cmdk-list-sizer]]:max-h-none",
+                  groupByProvider && "[&_[cmdk-list-sizer]]:pt-1"
+                )}
+              >
+                <CommandEmpty className="h-[32px] py-2 text-center text-[10px]">
+                  No model found.
+                </CommandEmpty>
+                {groupByProvider
+                  ? // Grouped view
+                    providerEntries.map(([provider, models]) => (
+                      <CommandGroup
+                        key={provider}
+                        heading={
+                          <span className="flex items-center gap-1.5">
+                            <ProviderLogo provider={provider} className="h-3 w-3 opacity-70" />
+                            <span>{provider}</span>
+                          </span>
+                        }
+                        className="py-0 [&_[cmdk-group-heading]]:py-0 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-items]]:pt-0"
+                      >
+                        {models.map((model) => (
+                          <ModelCommandItem
+                            key={`${model.provider}-${model.modelId}`}
+                            model={model}
+                            isSelected={
+                              activeModel?.modelId === model.modelId &&
+                              activeModel?.provider === model.provider
+                            }
+                            onSelect={handleSelect}
+                            onHighlight={handleHighlight}
+                            showProvider={false}
+                          />
+                        ))}
+                      </CommandGroup>
+                    ))
+                  : // Flat view
+                    sortedModels.map((model) => (
+                      <ModelCommandItem
+                        key={`${model.provider}-${model.modelId}`}
+                        model={model}
+                        isSelected={
+                          activeModel?.modelId === model.modelId &&
+                          activeModel?.provider === model.provider
+                        }
+                        onSelect={handleSelect}
+                        onHighlight={handleHighlight}
+                        showProvider={true}
+                      />
+                    ))}
+              </CommandList>
+              {showConfigureAction ? (
+                <>
+                  <div className="h-px bg-border shrink-0" />
+                  <div className="h-[32px] items-center flex mx-1 shrink-0">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="w-full h-[24px] justify-start px-2 text-[10px] font-normal gap-2 rounded-sm"
+                      onClick={() => {
+                        setOpen(false);
+                        showSettingsDialog({ initialSection: "models" });
+                      }}
+                    >
+                      <Settings2 className="h-3 w-3" />
+                      Configure more AI Models...
+                    </Button>
+                  </div>
+                </>
+              ) : null}
             </div>
-          )}
+
+            {highlightedModelFields.length > 0 && (
+              <div
+                data-panel="right"
+                className={cn(
+                  "w-[250px] overflow-y-auto rounded-sm rounded-l-none border border-l-0 bg-popover p-2 text-[10px] text-popover-foreground shadow-md",
+                  modelPanelHeightClass
+                )}
+              >
+                <div className="flex flex-col gap-3">
+                  <ReasoningDetailSection
+                    configuration={agentConfiguration}
+                    isInteractive={shouldShowReasoningControls}
+                    levels={previewReasoningLevels}
+                    onChange={handleReasoningConfigurationChange}
+                    supportsReasoning={previewSupportsReasoning}
+                  />
+                  {highlightedModelFields.map((field) => (
+                    <div key={field.label} className="flex flex-col gap-1">
+                      <div className="text-[9px] font-semibold text-muted-foreground">
+                        {toDescriptionHeaderLabel(field.label)}
+                      </div>
+                      <div className="text-[10px] leading-relaxed text-popover-foreground">
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>{field.value}</ReactMarkdown>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
         </Command>
       </PopoverContent>
     </Popover>

--- a/src/components/settings/agent/agent-edit.tsx
+++ b/src/components/settings/agent/agent-edit.tsx
@@ -397,8 +397,8 @@ export function AgentEdit() {
               </DropdownMenu>
             </TableCell>
             <TableCell className="px-0 py-1 align-middle text-sm text-muted-foreground">
-              Controls the response language for AI commands in the SQL editor, including auto
-              explain and other quick commands.
+              Controls the response language for AI chat, visible reasoning summaries, and SQL
+              editor AI commands.
             </TableCell>
           </TableRow>
 

--- a/src/components/settings/agent/agent-manager.ts
+++ b/src/components/settings/agent/agent-manager.ts
@@ -1,9 +1,15 @@
+import {
+  DEFAULT_REASONING_LEVEL,
+  normalizeReasoningLevel,
+  type ReasoningLevel,
+} from "@/lib/ai/reasoning-levels";
 import type { LocalStorage } from "@/lib/storage/local-storage-provider";
 import { StorageManager } from "@/lib/storage/storage-provider-manager";
 
 export type AgentMode = "v2" | "legacy";
 
 const STORAGE_KEY = "settings:ai:agent";
+export const AGENT_CONFIG_UPDATED_EVENT = "AGENT_CONFIG_UPDATED";
 
 // See clickhouse-error-code.ts
 export const DEFAULT_AUTO_EXPLAIN_BLACKLIST = [
@@ -45,6 +51,8 @@ export type AgentConfiguration = {
   pruneValidateSql?: boolean;
   /** Whether to request reasoning summaries from models that support them. Default true. */
   outputReasoning?: boolean;
+  /** Preferred reasoning level for models that expose configurable reasoning. Default medium. */
+  reasoningLevel?: ReasoningLevel;
   /** Whether eligible ClickHouse errors should auto-trigger an inline AI explanation. */
   autoExplainClickHouseErrors?: boolean;
   /** ClickHouse error codes that should never auto-trigger inline explanation. */
@@ -71,12 +79,14 @@ export class AgentConfigurationManager {
         mode: "v2",
         pruneValidateSql: true,
         outputReasoning: true,
+        reasoningLevel: DEFAULT_REASONING_LEVEL,
         autoExplainClickHouseErrors: true,
         autoExplainBlacklist: DEFAULT_AUTO_EXPLAIN_BLACKLIST,
         aiResponseLanguage: DEFAULT_AI_RESPONSE_LANGUAGE,
       }));
       this.configuration = {
         ...stored,
+        reasoningLevel: normalizeReasoningLevel(stored.reasoningLevel),
         aiResponseLanguage: normalizeAIResponseLanguage(
           stored.aiResponseLanguage ?? stored.sqlReviewLanguage ?? stored.autoExplainLanguage
         ),
@@ -93,9 +103,13 @@ export class AgentConfigurationManager {
     } = cfg;
     const normalized = {
       ...rest,
+      reasoningLevel: normalizeReasoningLevel(cfg.reasoningLevel),
       aiResponseLanguage: normalizeAIResponseLanguage(cfg.aiResponseLanguage),
     };
     this.configuration = normalized;
     this.getStorage().setJSON(normalized);
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent(AGENT_CONFIG_UPDATED_EVENT));
+    }
   }
 }

--- a/src/components/settings/agent/agent-manager.ts
+++ b/src/components/settings/agent/agent-manager.ts
@@ -51,7 +51,7 @@ export type AgentConfiguration = {
   pruneValidateSql?: boolean;
   /** Whether to request reasoning summaries from models that support them. Default true. */
   outputReasoning?: boolean;
-  /** Preferred reasoning level for models that expose configurable reasoning. Default medium. */
+  /** Preferred reasoning level for models that expose configurable reasoning. Defaults to DEFAULT_REASONING_LEVEL. */
   reasoningLevel?: ReasoningLevel;
   /** Whether eligible ClickHouse errors should auto-trigger an inline AI explanation. */
   autoExplainClickHouseErrors?: boolean;

--- a/src/lib/ai/agent/orchestrator-prompt.test.ts
+++ b/src/lib/ai/agent/orchestrator-prompt.test.ts
@@ -46,7 +46,10 @@ describe("buildOrchestratorSystemPrompt", () => {
     expect(prompt).toContain("## Response Language Policy");
     expect(prompt).toContain("Response language (BCP-47): zh-CN");
     expect(prompt).toContain(
-      "You MUST write all explanatory prose, headings, and visible reasoning summaries in this language."
+      "You MUST write all explanatory prose, headings, reasoning blocks, visible reasoning summaries, thinking summaries, and planning notes in this language."
+    );
+    expect(prompt).toContain(
+      "Never write visible reasoning text in English unless the configured response language is English."
     );
   });
 

--- a/src/lib/ai/agent/orchestrator-prompt.test.ts
+++ b/src/lib/ai/agent/orchestrator-prompt.test.ts
@@ -9,6 +9,8 @@ describe("buildOrchestratorSystemPrompt", () => {
     expect(prompt).toContain(
       "Use the available skill names and descriptions to choose the best match"
     );
+    expect(prompt).toContain("Use the user's language");
+    expect(prompt).toContain("visible reasoning summaries");
   });
 
   it("appends diagnosis context when present", () => {
@@ -43,7 +45,9 @@ describe("buildOrchestratorSystemPrompt", () => {
 
     expect(prompt).toContain("## Response Language Policy");
     expect(prompt).toContain("Response language (BCP-47): zh-CN");
-    expect(prompt).toContain("You MUST write all explanatory prose and headings in this language.");
+    expect(prompt).toContain(
+      "You MUST write all explanatory prose, headings, and visible reasoning summaries in this language."
+    );
   });
 
   it("ignores invalid response language values", () => {

--- a/src/lib/ai/agent/orchestrator-prompt.ts
+++ b/src/lib/ai/agent/orchestrator-prompt.ts
@@ -18,7 +18,7 @@ const ORCHESTRATOR_SYSTEM_PROMPT_BASE = `You are a ClickHouse Expert with access
 3. **Execute**: Use \`execute_sql\` without a skill only for trivial one-off checks (e.g. \`SELECT 1\`).
 4. **Retry**: On tool error, consult the loaded skill instructions, fix, and retry. Do not give up after one failure.
 5. **Time context**: Reuse the most recent explicit time range from the conversation. Default to the last 60 minutes only when none exists.
-6. **Output**: Respond in markdown. Follow the loaded skill's output instructions exactly.`;
+6. **Output**: Respond in markdown. Follow the loaded skill's output instructions exactly. Use the user's language for explanatory prose, headings, and visible reasoning summaries unless a response language policy below says otherwise.`;
 
 export function buildOrchestratorSystemPrompt(
   context?: ServerDatabaseContext,
@@ -31,7 +31,7 @@ export function buildOrchestratorSystemPrompt(
   const responseLanguage = sanitizeLanguageTag(options?.responseLanguage);
   const languagePolicy =
     responseLanguage && !isEnglishLanguageTag(responseLanguage)
-      ? `\n\n## Response Language Policy\n- Response language (BCP-47): ${responseLanguage}\n- You MUST write all explanatory prose and headings in this language.\n- Keep SQL, code, error codes, identifiers, and setting names unchanged.`
+      ? `\n\n## Response Language Policy\n- Response language (BCP-47): ${responseLanguage}\n- You MUST write all explanatory prose, headings, and visible reasoning summaries in this language.\n- Keep SQL, code, error codes, identifiers, and setting names unchanged.`
       : "";
 
   if (!hasDatabaseContextFacts(context)) {

--- a/src/lib/ai/agent/orchestrator-prompt.ts
+++ b/src/lib/ai/agent/orchestrator-prompt.ts
@@ -31,7 +31,7 @@ export function buildOrchestratorSystemPrompt(
   const responseLanguage = sanitizeLanguageTag(options?.responseLanguage);
   const languagePolicy =
     responseLanguage && !isEnglishLanguageTag(responseLanguage)
-      ? `\n\n## Response Language Policy\n- Response language (BCP-47): ${responseLanguage}\n- You MUST write all explanatory prose, headings, and visible reasoning summaries in this language.\n- Keep SQL, code, error codes, identifiers, and setting names unchanged.`
+      ? `\n\n## Response Language Policy\n- Response language (BCP-47): ${responseLanguage}\n- You MUST write all explanatory prose, headings, reasoning blocks, visible reasoning summaries, thinking summaries, and planning notes in this language.\n- Never write visible reasoning text in English unless the configured response language is English.\n- Keep SQL, code, error codes, identifiers, and setting names unchanged.`
       : "";
 
   if (!hasDatabaseContextFacts(context)) {

--- a/src/lib/ai/ai-types.ts
+++ b/src/lib/ai/ai-types.ts
@@ -1,4 +1,5 @@
 import type { PlannerMetadata } from "@/lib/ai/agent/plan/planning-types";
+import type { ReasoningLevel } from "@/lib/ai/reasoning-levels";
 import type { InferUITools, LanguageModelUsage, UIDataTypes, UIMessage } from "ai";
 
 export interface AgentContext {
@@ -8,6 +9,8 @@ export interface AgentContext {
   responseLanguage?: string;
   /** Whether to request model reasoning summaries when the selected model supports them. */
   outputReasoning?: boolean;
+  /** Preferred reasoning level for models that expose configurable reasoning. */
+  reasoningLevel?: ReasoningLevel;
 }
 
 export type MessageRole = "user" | "assistant" | "system" | "data" | "tool";

--- a/src/lib/ai/llm/llm-provider-anthropic.ts
+++ b/src/lib/ai/llm/llm-provider-anthropic.ts
@@ -1,0 +1,77 @@
+import { createAnthropic, type AnthropicProviderOptions } from "@ai-sdk/anthropic";
+import type { ReasoningLevel } from "../reasoning-levels";
+import type { ProviderDefinition } from "./llm-provider-factory";
+
+const ANTHROPIC_MANUAL_THINKING_BUDGET_TOKENS = 1024;
+
+function toAnthropicEffort(
+  level: ReasoningLevel
+): NonNullable<AnthropicProviderOptions["effort"]> | undefined {
+  if (level === "xhigh") return "max";
+  if (level === "low" || level === "medium" || level === "high" || level === "max") return level;
+  return undefined;
+}
+
+function supportsAnthropicAdaptiveThinking(modelId: string): boolean {
+  return (
+    modelId.includes("claude-opus-4-7") ||
+    modelId.includes("claude-opus-4-6") ||
+    modelId.includes("claude-sonnet-4-6")
+  );
+}
+
+function getAnthropicThinkingOptions(
+  modelId: string,
+  outputReasoning: boolean
+): AnthropicProviderOptions["thinking"] | undefined {
+  if (supportsAnthropicAdaptiveThinking(modelId)) {
+    return { type: "adaptive" };
+  }
+
+  if (outputReasoning) {
+    return {
+      type: "enabled",
+      budgetTokens: ANTHROPIC_MANUAL_THINKING_BUDGET_TOKENS,
+    };
+  }
+
+  return undefined;
+}
+
+export const ANTHROPIC_PROVIDER = {
+  logo: "anthropic.svg",
+  create: (modelId, apiKey) =>
+    createAnthropic({
+      apiKey,
+    })(modelId),
+  systemApiKey: () => process.env.ANTHROPIC_API_KEY,
+  buildProviderOptions: ({ modelConfig, outputReasoning, reasoningLevel }) => {
+    if (reasoningLevel) {
+      const effort = toAnthropicEffort(reasoningLevel);
+      if (!effort) {
+        return undefined;
+      }
+      const thinking = getAnthropicThinkingOptions(modelConfig.modelId, outputReasoning);
+
+      return {
+        anthropic: {
+          ...(thinking ? { thinking } : {}),
+          effort,
+        } satisfies AnthropicProviderOptions,
+      };
+    }
+
+    if (!outputReasoning) {
+      return undefined;
+    }
+
+    return {
+      anthropic: {
+        thinking: {
+          type: "enabled",
+          budgetTokens: ANTHROPIC_MANUAL_THINKING_BUDGET_TOKENS,
+        },
+      } satisfies AnthropicProviderOptions,
+    };
+  },
+} satisfies ProviderDefinition;

--- a/src/lib/ai/llm/llm-provider-factory.test.ts
+++ b/src/lib/ai/llm/llm-provider-factory.test.ts
@@ -250,5 +250,4 @@ The API may emit visible reasoning summaries separately from the final answer. E
       })?.anthropic
     ).toEqual({ thinking: { type: "adaptive" }, effort: "max" });
   });
-
 });

--- a/src/lib/ai/llm/llm-provider-factory.test.ts
+++ b/src/lib/ai/llm/llm-provider-factory.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { MODELS } from "./llm-provider-factory";
-import { PROVIDER_OPENAI_CODEX } from "./provider-ids";
+import {
+  MODELS,
+  resolveModelReasoningLevels,
+  resolveModelSupportsReasoning,
+} from "./llm-provider-factory";
+import { PROVIDER_NEBIUS, PROVIDER_OPENAI_CODEX } from "./provider-ids";
 
 function getModel(provider: string, modelId: string) {
   return MODELS.find((model) => model.provider === provider && model.modelId === modelId);
@@ -37,5 +41,96 @@ describe("MODELS OpenAI Codex catalog", () => {
     expect(getModel(PROVIDER_OPENAI_CODEX, "gpt-5.4-mini")?.supportedEndpoints).toEqual([
       "responses",
     ]);
+  });
+});
+
+describe("MODELS reasoning capabilities", () => {
+  it("exposes configurable reasoning levels for reasoning-capable OpenAI models", () => {
+    expect(resolveModelReasoningLevels({ provider: "OpenAI", modelId: "gpt-5" })).toEqual([
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(resolveModelSupportsReasoning({ provider: "OpenAI", modelId: "gpt-5.2" })).toBe(true);
+    expect(resolveModelReasoningLevels({ provider: "OpenAI", modelId: "gpt-5.2" })).toEqual([
+      "none",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+  });
+
+  it("exposes extra high for Codex reasoning models", () => {
+    expect(
+      resolveModelReasoningLevels({ provider: PROVIDER_OPENAI_CODEX, modelId: "gpt-5.4" })
+    ).toEqual(["low", "medium", "high", "xhigh"]);
+  });
+
+  it("separates built-in reasoning support from configurable effort levels", () => {
+    expect(
+      resolveModelSupportsReasoning({
+        provider: PROVIDER_NEBIUS,
+        modelId: "deepseek-ai/DeepSeek-R1-0528",
+      })
+    ).toBe(true);
+    expect(
+      resolveModelReasoningLevels({
+        provider: PROVIDER_NEBIUS,
+        modelId: "deepseek-ai/DeepSeek-R1-0528",
+      })
+    ).toEqual([]);
+  });
+
+  it("exposes configurable effort for Claude Opus 4.5", () => {
+    expect(
+      resolveModelSupportsReasoning({ provider: "Anthropic", modelId: "claude-opus-4-5" })
+    ).toBe(true);
+    expect(
+      resolveModelReasoningLevels({ provider: "Anthropic", modelId: "claude-opus-4-5" })
+    ).toEqual(["low", "medium", "high"]);
+  });
+
+  it("marks Claude 4.5 non-Opus models as reasoning-capable without adaptive effort levels", () => {
+    for (const modelId of ["claude-sonnet-4-5", "claude-haiku-4-5"]) {
+      expect(resolveModelSupportsReasoning({ provider: "Anthropic", modelId })).toBe(true);
+      expect(resolveModelReasoningLevels({ provider: "Anthropic", modelId })).toEqual([]);
+    }
+  });
+
+  it("uses model-specific Gemini reasoning levels", () => {
+    expect(
+      resolveModelReasoningLevels({ provider: "Google", modelId: "gemini-3-pro-preview" })
+    ).toEqual(["low", "high"]);
+    expect(
+      resolveModelReasoningLevels({ provider: "Google", modelId: "gemini-3-flash-preview" })
+    ).toEqual(["minimal", "low", "medium", "high"]);
+  });
+
+  it("exposes configurable effort for provider paths that can send it", () => {
+    expect(
+      resolveModelReasoningLevels({ provider: "Groq", modelId: "openai/gpt-oss-20b" })
+    ).toEqual(["low", "medium", "high"]);
+    expect(resolveModelReasoningLevels({ provider: "Cerebras", modelId: "gpt-oss-120b" })).toEqual([
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(
+      resolveModelReasoningLevels({
+        provider: PROVIDER_NEBIUS,
+        modelId: "openai/gpt-oss-120b",
+      })
+    ).toEqual(["low", "medium", "high"]);
+  });
+
+  it("does not infer reasoning from matching model IDs on unrelated providers", () => {
+    expect(resolveModelSupportsReasoning({ provider: "GitHub Copilot", modelId: "gpt-5.2" })).toBe(
+      false
+    );
+    expect(resolveModelReasoningLevels({ provider: "GitHub Copilot", modelId: "gpt-5.2" })).toEqual(
+      []
+    );
   });
 });

--- a/src/lib/ai/llm/llm-provider-factory.test.ts
+++ b/src/lib/ai/llm/llm-provider-factory.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  LanguageModelProviderFactory,
   MODELS,
   resolveModelReasoningLevels,
   resolveModelSupportsReasoning,
@@ -132,5 +133,25 @@ describe("MODELS reasoning capabilities", () => {
     expect(resolveModelReasoningLevels({ provider: "GitHub Copilot", modelId: "gpt-5.2" })).toEqual(
       []
     );
+  });
+
+  it("builds provider options from model configuration", () => {
+    expect(
+      LanguageModelProviderFactory.buildProviderOptions({
+        modelConfig: { provider: "Google", modelId: "gemini-3-pro-preview" },
+        outputReasoning: true,
+        reasoningLevel: "medium",
+        instructions: "ignored",
+      })?.google?.thinkingConfig?.thinkingLevel
+    ).toBe("low");
+
+    expect(
+      LanguageModelProviderFactory.buildProviderOptions({
+        modelConfig: { provider: "Anthropic", modelId: "claude-opus-4-5" },
+        outputReasoning: false,
+        reasoningLevel: "medium",
+        instructions: "ignored",
+      })?.anthropic
+    ).toEqual({ effort: "medium" });
   });
 });

--- a/src/lib/ai/llm/llm-provider-factory.test.ts
+++ b/src/lib/ai/llm/llm-provider-factory.test.ts
@@ -62,6 +62,30 @@ describe("MODELS reasoning capabilities", () => {
     ]);
   });
 
+  it("lists the latest OpenAI GPT-5.5 and GPT-5.4 models", () => {
+    expect(
+      MODELS.filter((model) => model.provider === "OpenAI")
+        .slice(0, 6)
+        .map((model) => model.modelId)
+    ).toEqual(["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5.4-pro", "gpt-5.4-mini", "gpt-5.4-nano"]);
+
+    for (const modelId of [
+      "gpt-5.5",
+      "gpt-5.5-pro",
+      "gpt-5.4",
+      "gpt-5.4-pro",
+      "gpt-5.4-mini",
+      "gpt-5.4-nano",
+    ]) {
+      expect(resolveModelReasoningLevels({ provider: "OpenAI", modelId })).toEqual([
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+      ]);
+    }
+  });
+
   it("exposes extra high for Codex reasoning models", () => {
     expect(
       resolveModelReasoningLevels({ provider: PROVIDER_OPENAI_CODEX, modelId: "gpt-5.4" })
@@ -90,6 +114,21 @@ describe("MODELS reasoning capabilities", () => {
     expect(
       resolveModelReasoningLevels({ provider: "Anthropic", modelId: "claude-opus-4-5" })
     ).toEqual(["low", "medium", "high"]);
+  });
+
+  it("lists Claude 4.6 and 4.7 adaptive reasoning models", () => {
+    expect(
+      resolveModelSupportsReasoning({ provider: "Anthropic", modelId: "claude-opus-4-7" })
+    ).toBe(true);
+    expect(
+      resolveModelReasoningLevels({ provider: "Anthropic", modelId: "claude-opus-4-7" })
+    ).toEqual(["low", "medium", "high", "xhigh"]);
+    expect(
+      resolveModelSupportsReasoning({ provider: "Anthropic", modelId: "claude-sonnet-4-6" })
+    ).toBe(true);
+    expect(
+      resolveModelReasoningLevels({ provider: "Anthropic", modelId: "claude-sonnet-4-6" })
+    ).toEqual(["low", "medium", "high", "xhigh"]);
   });
 
   it("marks Claude 4.5 non-Opus models as reasoning-capable without adaptive effort levels", () => {
@@ -142,7 +181,7 @@ describe("MODELS reasoning capabilities", () => {
         reasoningLevel: "medium",
         instructions: "ignored",
       })?.google?.thinkingConfig?.thinkingLevel
-    ).toBe("low");
+    ).toBe("high");
 
     expect(
       LanguageModelProviderFactory.buildProviderOptions({
@@ -152,5 +191,23 @@ describe("MODELS reasoning capabilities", () => {
         instructions: "ignored",
       })?.anthropic
     ).toEqual({ effort: "medium" });
+  });
+
+  it("defaults provider options to the highest supported reasoning level", () => {
+    expect(
+      LanguageModelProviderFactory.buildProviderOptions({
+        modelConfig: { provider: "Google", modelId: "gemini-3-flash-preview" },
+        outputReasoning: false,
+        instructions: "ignored",
+      })?.google?.thinkingConfig?.thinkingLevel
+    ).toBe("high");
+
+    expect(
+      LanguageModelProviderFactory.buildProviderOptions({
+        modelConfig: { provider: "Anthropic", modelId: "claude-opus-4-7" },
+        outputReasoning: false,
+        instructions: "ignored",
+      })?.anthropic
+    ).toEqual({ thinking: { type: "adaptive" }, effort: "max" });
   });
 });

--- a/src/lib/ai/llm/llm-provider-factory.test.ts
+++ b/src/lib/ai/llm/llm-provider-factory.test.ts
@@ -59,7 +59,6 @@ describe("MODELS reasoning capabilities", () => {
       "low",
       "medium",
       "high",
-      "xhigh",
     ]);
   });
 

--- a/src/lib/ai/llm/llm-provider-factory.test.ts
+++ b/src/lib/ai/llm/llm-provider-factory.test.ts
@@ -176,6 +176,46 @@ describe("MODELS reasoning capabilities", () => {
   it("builds provider options from model configuration", () => {
     expect(
       LanguageModelProviderFactory.buildProviderOptions({
+        modelConfig: { provider: "OpenAI", modelId: "gpt-5.5" },
+        outputReasoning: true,
+        reasoningLevel: "high",
+        instructions: "Use Chinese reasoning summaries.",
+        responseLanguage: "zh-CN",
+      })?.openai
+    ).toEqual({
+      instructions: `Use Chinese reasoning summaries.
+
+## Visible Reasoning Language
+The API may emit visible reasoning summaries separately from the final answer. Every visible reasoning summary, thinking summary, planning note, heading, and paragraph MUST be written in zh-CN. Never emit English visible reasoning text unless the configured response language is English.`,
+      reasoningEffort: "high",
+      reasoningSummary: "auto",
+    });
+
+    expect(
+      LanguageModelProviderFactory.buildProviderOptions({
+        modelConfig: { provider: PROVIDER_OPENAI_CODEX, modelId: "gpt-5.4" },
+        outputReasoning: true,
+        reasoningLevel: "high",
+        instructions: "Use Chinese reasoning summaries.",
+        responseLanguage: "zh-CN",
+      })?.openai?.instructions
+    ).toContain("Every visible reasoning summary, thinking summary, planning note");
+
+    expect(
+      LanguageModelProviderFactory.buildProviderOptions({
+        modelConfig: { provider: PROVIDER_OPENAI_CODEX, modelId: "gpt-5.4" },
+        outputReasoning: false,
+        reasoningLevel: "high",
+        instructions: "Use Chinese reasoning summaries.",
+      })?.openai
+    ).toEqual({
+      instructions: "Use Chinese reasoning summaries.",
+      reasoningEffort: "high",
+      store: false,
+    });
+
+    expect(
+      LanguageModelProviderFactory.buildProviderOptions({
         modelConfig: { provider: "Google", modelId: "gemini-3-pro-preview" },
         outputReasoning: true,
         reasoningLevel: "medium",
@@ -210,4 +250,5 @@ describe("MODELS reasoning capabilities", () => {
       })?.anthropic
     ).toEqual({ thinking: { type: "adaptive" }, effort: "max" });
   });
+
 });

--- a/src/lib/ai/llm/llm-provider-factory.ts
+++ b/src/lib/ai/llm/llm-provider-factory.ts
@@ -1,6 +1,6 @@
-import { createAnthropic, type AnthropicProviderOptions } from "@ai-sdk/anthropic";
+import type { AnthropicProviderOptions } from "@ai-sdk/anthropic";
 import { createCerebras } from "@ai-sdk/cerebras";
-import { createGoogleGenerativeAI, type GoogleGenerativeAIProviderOptions } from "@ai-sdk/google";
+import type { GoogleGenerativeAIProviderOptions } from "@ai-sdk/google";
 import { createGroq, type GroqLanguageModelOptions } from "@ai-sdk/groq";
 import { createOpenAI, type OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
 import {
@@ -12,10 +12,13 @@ import { createGitHubCopilotOpenAICompatible } from "@opeoginni/github-copilot-o
 import type { LanguageModel } from "ai";
 import {
   DEFAULT_REASONING_LEVEL,
+  getDefaultReasoningLevel,
   isReasoningLevel,
   type ReasoningLevel,
 } from "../reasoning-levels";
+import { ANTHROPIC_PROVIDER } from "./llm-provider-anthropic";
 import { PRIVATE_MODELS, PRIVATE_PROVIDERS } from "./llm-provider-factory-private";
+import { GOOGLE_PROVIDER } from "./llm-provider-google";
 import { mockModel } from "./models.mock";
 import { PROVIDER_GITHUB_COPILOT, PROVIDER_NEBIUS, PROVIDER_OPENAI_CODEX } from "./provider-ids";
 
@@ -213,8 +216,6 @@ export function resolveModelReasoningLevels(
   return findExactModel(model)?.reasoningLevels ?? [];
 }
 
-const ANTHROPIC_MANUAL_THINKING_BUDGET_TOKENS = 1024;
-
 function resolveReasoningLevelForModel(
   modelConfig: ProviderOptionsModelConfig,
   reasoningLevel?: unknown
@@ -233,49 +234,7 @@ function resolveReasoningLevelForModel(
     return DEFAULT_REASONING_LEVEL;
   }
 
-  return levels[0];
-}
-
-function toAnthropicEffort(
-  level: ReasoningLevel
-): NonNullable<AnthropicProviderOptions["effort"]> | undefined {
-  if (level === "xhigh") return "max";
-  if (level === "low" || level === "medium" || level === "high" || level === "max") return level;
-  return undefined;
-}
-
-function supportsAnthropicAdaptiveThinking(modelId: string): boolean {
-  return modelId.includes("claude-opus-4-6") || modelId.includes("claude-sonnet-4-6");
-}
-
-function getAnthropicThinkingOptions(
-  modelId: string,
-  outputReasoning: boolean
-): AnthropicProviderOptions["thinking"] | undefined {
-  if (supportsAnthropicAdaptiveThinking(modelId)) {
-    return { type: "adaptive" };
-  }
-
-  if (outputReasoning) {
-    return {
-      type: "enabled",
-      budgetTokens: ANTHROPIC_MANUAL_THINKING_BUDGET_TOKENS,
-    };
-  }
-
-  return undefined;
-}
-
-function toGoogleThinkingLevel(
-  level: ReasoningLevel
-):
-  | NonNullable<NonNullable<GoogleGenerativeAIProviderOptions["thinkingConfig"]>["thinkingLevel"]>
-  | undefined {
-  if (level === "xhigh") return "high";
-  if (level === "minimal" || level === "low" || level === "medium" || level === "high") {
-    return level;
-  }
-  return undefined;
+  return getDefaultReasoningLevel(levels);
 }
 
 function toStandardReasoningLevel(level: ReasoningLevel): "low" | "medium" | "high" | undefined {
@@ -311,70 +270,8 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
       };
     },
   },
-  Google: {
-    logo: "google.svg",
-    create: (modelId, apiKey) =>
-      createGoogleGenerativeAI({
-        apiKey,
-      })(modelId),
-    systemApiKey: () => process.env.GOOGLE_GENERATIVE_AI_API_KEY,
-    buildProviderOptions: ({ outputReasoning, reasoningLevel }) => {
-      if (!reasoningLevel) {
-        return undefined;
-      }
-
-      const thinkingLevel = toGoogleThinkingLevel(reasoningLevel);
-      if (!thinkingLevel) {
-        return undefined;
-      }
-
-      return {
-        google: {
-          thinkingConfig: {
-            thinkingLevel,
-            ...(outputReasoning ? { includeThoughts: true } : {}),
-          },
-        } satisfies GoogleGenerativeAIProviderOptions,
-      };
-    },
-  },
-  Anthropic: {
-    logo: "anthropic.svg",
-    create: (modelId, apiKey) =>
-      createAnthropic({
-        apiKey,
-      })(modelId),
-    systemApiKey: () => process.env.ANTHROPIC_API_KEY,
-    buildProviderOptions: ({ modelConfig, outputReasoning, reasoningLevel }) => {
-      if (reasoningLevel) {
-        const effort = toAnthropicEffort(reasoningLevel);
-        if (!effort) {
-          return undefined;
-        }
-        const thinking = getAnthropicThinkingOptions(modelConfig.modelId, outputReasoning);
-
-        return {
-          anthropic: {
-            ...(thinking ? { thinking } : {}),
-            effort,
-          } satisfies AnthropicProviderOptions,
-        };
-      }
-
-      if (!outputReasoning) {
-        return undefined;
-      }
-
-      return {
-        anthropic: {
-          thinking: {
-            type: "enabled",
-            budgetTokens: ANTHROPIC_MANUAL_THINKING_BUDGET_TOKENS,
-          },
-        } satisfies AnthropicProviderOptions,
-      };
-    },
-  },
+  Google: GOOGLE_PROVIDER,
+  Anthropic: ANTHROPIC_PROVIDER,
   OpenRouter: {
     logo: "openrouter.svg",
     create: (modelId, apiKey) =>
@@ -523,6 +420,72 @@ export const MODELS: ModelProps[] = [
   // https://platform.openai.com/chat/edit
   {
     provider: "OpenAI",
+    modelId: "gpt-5.5",
+    free: false,
+    autoSelectable: false,
+    supportsImageInput: true,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high", "xhigh"],
+    description: "A new class of intelligence for coding and professional work.",
+    source: "user",
+  },
+  {
+    provider: "OpenAI",
+    modelId: "gpt-5.5-pro",
+    free: false,
+    autoSelectable: false,
+    supportsImageInput: true,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high", "xhigh"],
+    description: "Version of GPT-5.5 that produces smarter and more precise responses.",
+    source: "user",
+  },
+  {
+    provider: "OpenAI",
+    modelId: "gpt-5.4",
+    free: false,
+    autoSelectable: false,
+    supportsImageInput: true,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high", "xhigh"],
+    description: "A more affordable model for coding and professional work.",
+    source: "user",
+  },
+  {
+    provider: "OpenAI",
+    modelId: "gpt-5.4-pro",
+    free: false,
+    autoSelectable: false,
+    supportsImageInput: true,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high", "xhigh"],
+    description: "Version of GPT-5.4 that produces smarter and more precise responses.",
+    source: "user",
+  },
+  {
+    provider: "OpenAI",
+    modelId: "gpt-5.4-mini",
+    free: false,
+    autoSelectable: false,
+    supportsImageInput: true,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high", "xhigh"],
+    description: "OpenAI's strongest mini model yet for coding, computer use, and subagents.",
+    source: "user",
+  },
+  {
+    provider: "OpenAI",
+    modelId: "gpt-5.4-nano",
+    free: false,
+    autoSelectable: false,
+    supportsImageInput: true,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high", "xhigh"],
+    description: "OpenAI's cheapest GPT-5.4-class model for simple high-volume tasks.",
+    source: "user",
+  },
+  {
+    provider: "OpenAI",
     modelId: "gpt-5",
     free: false,
     autoSelectable: false,
@@ -545,54 +508,10 @@ export const MODELS: ModelProps[] = [
   },
   {
     provider: "OpenAI",
-    modelId: "gpt-4.1",
-    free: false,
-    supportsImageInput: true,
-    description: "Updated GPT-4 model with improved performance and accuracy.",
-    source: "user",
-  },
-  {
-    provider: "OpenAI",
     modelId: "gpt-4o",
     free: false,
     supportsImageInput: true,
     description: "Omni model from OpenAI, designed for speed and multimodal interaction.",
-    source: "user",
-  },
-  {
-    provider: "OpenAI",
-    modelId: "gpt-4o-mini",
-    free: false,
-    supportsImageInput: true,
-    description: "Lighter version of GPT-4o for faster, cost-effective tasks.",
-    source: "user",
-  },
-  {
-    provider: "OpenAI",
-    modelId: "gpt-4",
-    free: false,
-    supportsImageInput: false,
-    description: "Robust high-capability model for complex reasoning and tasks.",
-    source: "user",
-  },
-  {
-    provider: "OpenAI",
-    modelId: "o1",
-    free: false,
-    supportsImageInput: true,
-    supportsReasoning: true,
-    reasoningLevels: ["low", "medium", "high"],
-    description: "OpenAI's latest reasoning model, optimized for chain-of-thought.",
-    source: "user",
-  },
-  {
-    provider: "OpenAI",
-    modelId: "o3-mini",
-    free: false,
-    supportsImageInput: false,
-    supportsReasoning: true,
-    reasoningLevels: ["low", "medium", "high"],
-    description: "Optimized version of OpenAI's reasoning models for fast responses.",
     source: "user",
   },
 
@@ -649,6 +568,17 @@ export const MODELS: ModelProps[] = [
   // https://platform.claude.com/docs/en/about-claude/models/overview
   {
     provider: "Anthropic",
+    modelId: "claude-opus-4-7",
+    free: false,
+    autoSelectable: false,
+    supportsImageInput: true,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high", "xhigh"],
+    description: "Anthropic's latest Opus model for complex analysis, agents, and coding.",
+    source: "user",
+  },
+  {
+    provider: "Anthropic",
     modelId: "claude-opus-4-6",
     free: false,
     autoSelectable: false,
@@ -666,6 +596,17 @@ export const MODELS: ModelProps[] = [
     supportsReasoning: true,
     reasoningLevels: ["low", "medium", "high"],
     description: "Anthropic's most powerful model for highly complex analysis.",
+    source: "user",
+  },
+  {
+    provider: "Anthropic",
+    modelId: "claude-sonnet-4-6",
+    free: false,
+    autoSelectable: false,
+    supportsImageInput: true,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high", "xhigh"],
+    description: "Anthropic's most capable Sonnet model for agents, coding, and computer use.",
     source: "user",
   },
   {

--- a/src/lib/ai/llm/llm-provider-factory.ts
+++ b/src/lib/ai/llm/llm-provider-factory.ts
@@ -1,13 +1,20 @@
-import { createAnthropic } from "@ai-sdk/anthropic";
+import { createAnthropic, type AnthropicProviderOptions } from "@ai-sdk/anthropic";
 import { createCerebras } from "@ai-sdk/cerebras";
-import { createGoogleGenerativeAI } from "@ai-sdk/google";
-import { createGroq } from "@ai-sdk/groq";
-import { createOpenAI } from "@ai-sdk/openai";
-import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
-import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import { createGoogleGenerativeAI, type GoogleGenerativeAIProviderOptions } from "@ai-sdk/google";
+import { createGroq, type GroqLanguageModelOptions } from "@ai-sdk/groq";
+import { createOpenAI, type OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
+import {
+  createOpenAICompatible,
+  type OpenAICompatibleLanguageModelChatOptions,
+} from "@ai-sdk/openai-compatible";
+import { createOpenRouter, type OpenRouterProviderOptions } from "@openrouter/ai-sdk-provider";
 import { createGitHubCopilotOpenAICompatible } from "@opeoginni/github-copilot-openai-compatible";
 import type { LanguageModel } from "ai";
-import type { ReasoningLevel } from "../reasoning-levels";
+import {
+  DEFAULT_REASONING_LEVEL,
+  isReasoningLevel,
+  type ReasoningLevel,
+} from "../reasoning-levels";
 import { PRIVATE_MODELS, PRIVATE_PROVIDERS } from "./llm-provider-factory-private";
 import { mockModel } from "./models.mock";
 import { PROVIDER_GITHUB_COPILOT, PROVIDER_NEBIUS, PROVIDER_OPENAI_CODEX } from "./provider-ids";
@@ -22,10 +29,39 @@ type ModelCreator = (modelId: string, apiKey: string) => LanguageModel;
 type RequestedModelConfig = { provider: string; modelId: string; apiKey?: string };
 type ResolvedModelConfig = { provider: string; modelId: string; apiKey: string };
 export type ModelSource = "user" | "system";
+
+type ProviderOptionsModelConfig = {
+  provider: string;
+  modelId: string;
+  reasoningLevels?: readonly ReasoningLevel[];
+};
+
+type ProviderOptionsInput = {
+  modelConfig: ProviderOptionsModelConfig;
+  outputReasoning: boolean;
+  reasoningLevel?: ReasoningLevel;
+  instructions: string;
+};
+
+type ProviderOptionsRequestInput = Omit<ProviderOptionsInput, "reasoningLevel"> & {
+  reasoningLevel?: unknown;
+};
+
+export type LanguageModelProviderOptions = {
+  openai?: OpenAIResponsesProviderOptions;
+  anthropic?: AnthropicProviderOptions;
+  cerebras?: OpenAICompatibleLanguageModelChatOptions;
+  google?: GoogleGenerativeAIProviderOptions;
+  groq?: GroqLanguageModelOptions;
+  nebius?: OpenAICompatibleLanguageModelChatOptions;
+  openrouter?: OpenRouterProviderOptions;
+};
+
 export interface ProviderDefinition {
   create: ModelCreator;
   systemApiKey?: () => string | undefined;
   logo?: string;
+  buildProviderOptions?: (input: ProviderOptionsInput) => LanguageModelProviderOptions | undefined;
 }
 
 export interface ModelProps {
@@ -177,6 +213,77 @@ export function resolveModelReasoningLevels(
   return findExactModel(model)?.reasoningLevels ?? [];
 }
 
+const ANTHROPIC_MANUAL_THINKING_BUDGET_TOKENS = 1024;
+
+function resolveReasoningLevelForModel(
+  modelConfig: ProviderOptionsModelConfig,
+  reasoningLevel?: unknown
+): ReasoningLevel | undefined {
+  const levels = resolveModelReasoningLevels(modelConfig);
+  if (levels.length === 0) {
+    return undefined;
+  }
+
+  const requestedLevel = isReasoningLevel(reasoningLevel) ? reasoningLevel.trim() : undefined;
+  if (requestedLevel && levels.includes(requestedLevel)) {
+    return requestedLevel;
+  }
+
+  if (levels.includes(DEFAULT_REASONING_LEVEL)) {
+    return DEFAULT_REASONING_LEVEL;
+  }
+
+  return levels[0];
+}
+
+function toAnthropicEffort(
+  level: ReasoningLevel
+): NonNullable<AnthropicProviderOptions["effort"]> | undefined {
+  if (level === "xhigh") return "max";
+  if (level === "low" || level === "medium" || level === "high" || level === "max") return level;
+  return undefined;
+}
+
+function supportsAnthropicAdaptiveThinking(modelId: string): boolean {
+  return modelId.includes("claude-opus-4-6") || modelId.includes("claude-sonnet-4-6");
+}
+
+function getAnthropicThinkingOptions(
+  modelId: string,
+  outputReasoning: boolean
+): AnthropicProviderOptions["thinking"] | undefined {
+  if (supportsAnthropicAdaptiveThinking(modelId)) {
+    return { type: "adaptive" };
+  }
+
+  if (outputReasoning) {
+    return {
+      type: "enabled",
+      budgetTokens: ANTHROPIC_MANUAL_THINKING_BUDGET_TOKENS,
+    };
+  }
+
+  return undefined;
+}
+
+function toGoogleThinkingLevel(
+  level: ReasoningLevel
+):
+  | NonNullable<NonNullable<GoogleGenerativeAIProviderOptions["thinkingConfig"]>["thinkingLevel"]>
+  | undefined {
+  if (level === "xhigh") return "high";
+  if (level === "minimal" || level === "low" || level === "medium" || level === "high") {
+    return level;
+  }
+  return undefined;
+}
+
+function toStandardReasoningLevel(level: ReasoningLevel): "low" | "medium" | "high" | undefined {
+  if (level === "xhigh") return "high";
+  if (level === "low" || level === "medium" || level === "high") return level;
+  return undefined;
+}
+
 /**
  * Provider definitions map
  * Key: provider name (e.g., "OpenAI", "Google", "Anthropic", "OpenRouter", "Groq")
@@ -191,6 +298,18 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         apiKey,
       })(modelId),
     systemApiKey: () => process.env.OPENAI_API_KEY,
+    buildProviderOptions: ({ outputReasoning, reasoningLevel }) => {
+      if (!outputReasoning && !reasoningLevel) {
+        return undefined;
+      }
+
+      return {
+        openai: {
+          ...(reasoningLevel ? { reasoningEffort: reasoningLevel } : {}),
+          ...(outputReasoning ? { reasoningSummary: "auto" as const } : {}),
+        } satisfies OpenAIResponsesProviderOptions,
+      };
+    },
   },
   Google: {
     logo: "google.svg",
@@ -199,6 +318,25 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         apiKey,
       })(modelId),
     systemApiKey: () => process.env.GOOGLE_GENERATIVE_AI_API_KEY,
+    buildProviderOptions: ({ outputReasoning, reasoningLevel }) => {
+      if (!reasoningLevel) {
+        return undefined;
+      }
+
+      const thinkingLevel = toGoogleThinkingLevel(reasoningLevel);
+      if (!thinkingLevel) {
+        return undefined;
+      }
+
+      return {
+        google: {
+          thinkingConfig: {
+            thinkingLevel,
+            ...(outputReasoning ? { includeThoughts: true } : {}),
+          },
+        } satisfies GoogleGenerativeAIProviderOptions,
+      };
+    },
   },
   Anthropic: {
     logo: "anthropic.svg",
@@ -207,6 +345,35 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         apiKey,
       })(modelId),
     systemApiKey: () => process.env.ANTHROPIC_API_KEY,
+    buildProviderOptions: ({ modelConfig, outputReasoning, reasoningLevel }) => {
+      if (reasoningLevel) {
+        const effort = toAnthropicEffort(reasoningLevel);
+        if (!effort) {
+          return undefined;
+        }
+        const thinking = getAnthropicThinkingOptions(modelConfig.modelId, outputReasoning);
+
+        return {
+          anthropic: {
+            ...(thinking ? { thinking } : {}),
+            effort,
+          } satisfies AnthropicProviderOptions,
+        };
+      }
+
+      if (!outputReasoning) {
+        return undefined;
+      }
+
+      return {
+        anthropic: {
+          thinking: {
+            type: "enabled",
+            budgetTokens: ANTHROPIC_MANUAL_THINKING_BUDGET_TOKENS,
+          },
+        } satisfies AnthropicProviderOptions,
+      };
+    },
   },
   OpenRouter: {
     logo: "openrouter.svg",
@@ -215,6 +382,25 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         apiKey,
       })(modelId),
     systemApiKey: () => process.env.OPENROUTER_API_KEY,
+    buildProviderOptions: ({ reasoningLevel }) => {
+      if (!reasoningLevel) {
+        return undefined;
+      }
+
+      const effort = toStandardReasoningLevel(reasoningLevel);
+      if (!effort) {
+        return undefined;
+      }
+
+      return {
+        openrouter: {
+          reasoning: {
+            enabled: true,
+            effort,
+          },
+        } satisfies OpenRouterProviderOptions,
+      };
+    },
   },
   Groq: {
     logo: "groq.svg",
@@ -223,6 +409,23 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         apiKey,
       })(modelId),
     systemApiKey: () => process.env.GROQ_API_KEY,
+    buildProviderOptions: ({ outputReasoning, reasoningLevel }) => {
+      if (!reasoningLevel) {
+        return undefined;
+      }
+
+      const reasoningEffort = toStandardReasoningLevel(reasoningLevel);
+      if (!reasoningEffort) {
+        return undefined;
+      }
+
+      return {
+        groq: {
+          reasoningEffort,
+          ...(outputReasoning ? { reasoningFormat: "parsed" as const } : {}),
+        } satisfies GroqLanguageModelOptions,
+      };
+    },
   },
   Cerebras: {
     logo: "cerebras.svg",
@@ -231,6 +434,22 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         apiKey,
       })(modelId),
     systemApiKey: () => process.env.CEREBRAS_API_KEY,
+    buildProviderOptions: ({ reasoningLevel }) => {
+      if (!reasoningLevel) {
+        return undefined;
+      }
+
+      const reasoningEffort = toStandardReasoningLevel(reasoningLevel);
+      if (!reasoningEffort) {
+        return undefined;
+      }
+
+      return {
+        cerebras: {
+          reasoningEffort,
+        } satisfies OpenAICompatibleLanguageModelChatOptions,
+      };
+    },
   },
   [PROVIDER_GITHUB_COPILOT]: {
     logo: "github-copilot.svg",
@@ -259,6 +478,15 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         },
       })(modelId);
     },
+    buildProviderOptions: ({ instructions, outputReasoning, reasoningLevel }) => ({
+      openai: {
+        instructions,
+        ...(reasoningLevel ? { reasoningEffort: reasoningLevel } : {}),
+        ...(outputReasoning ? { reasoningSummary: "auto" as const } : {}),
+        // Keep chat state in DataStoria instead of creating stored OpenAI responses.
+        store: false,
+      } satisfies OpenAIResponsesProviderOptions,
+    }),
   },
   [PROVIDER_NEBIUS]: {
     logo: "nebius.svg",
@@ -269,6 +497,22 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         baseURL: "https://api.tokenfactory.nebius.com/v1/",
       })(modelId),
     systemApiKey: () => process.env.NEBIUS_API_KEY,
+    buildProviderOptions: ({ reasoningLevel }) => {
+      if (!reasoningLevel) {
+        return undefined;
+      }
+
+      const reasoningEffort = toStandardReasoningLevel(reasoningLevel);
+      if (!reasoningEffort) {
+        return undefined;
+      }
+
+      return {
+        nebius: {
+          reasoningEffort,
+        } satisfies OpenAICompatibleLanguageModelChatOptions,
+      };
+    },
   },
 };
 
@@ -880,5 +1124,21 @@ export class LanguageModelProviderFactory {
 
   static getReasoningLevels(provider: string, modelId: string): readonly ReasoningLevel[] {
     return resolveModelReasoningLevels({ provider, modelId });
+  }
+
+  static buildProviderOptions(
+    input: ProviderOptionsRequestInput
+  ): LanguageModelProviderOptions | undefined {
+    const providerDefinition = PROVIDERS[input.modelConfig.provider];
+    if (!providerDefinition?.buildProviderOptions) {
+      return undefined;
+    }
+
+    const reasoningLevel = resolveReasoningLevelForModel(input.modelConfig, input.reasoningLevel);
+
+    return providerDefinition.buildProviderOptions({
+      ...input,
+      reasoningLevel,
+    });
   }
 }

--- a/src/lib/ai/llm/llm-provider-factory.ts
+++ b/src/lib/ai/llm/llm-provider-factory.ts
@@ -539,7 +539,7 @@ export const MODELS: ModelProps[] = [
     autoSelectable: false,
     supportsImageInput: true,
     supportsReasoning: true,
-    reasoningLevels: ["none", "low", "medium", "high", "xhigh"],
+    reasoningLevels: ["none", "low", "medium", "high"],
     description: "Enhanced version of GPT-5 with improved reasoning capabilities.",
     source: "user",
   },

--- a/src/lib/ai/llm/llm-provider-factory.ts
+++ b/src/lib/ai/llm/llm-provider-factory.ts
@@ -7,6 +7,7 @@ import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { createGitHubCopilotOpenAICompatible } from "@opeoginni/github-copilot-openai-compatible";
 import type { LanguageModel } from "ai";
+import type { ReasoningLevel } from "../reasoning-levels";
 import { PRIVATE_MODELS, PRIVATE_PROVIDERS } from "./llm-provider-factory-private";
 import { mockModel } from "./models.mock";
 import { PROVIDER_GITHUB_COPILOT, PROVIDER_NEBIUS, PROVIDER_OPENAI_CODEX } from "./provider-ids";
@@ -38,6 +39,7 @@ export interface ModelProps {
   supportsImageInput?: boolean;
   supportsTemperature?: boolean;
   supportsReasoning?: boolean;
+  reasoningLevels?: readonly ReasoningLevel[];
   source?: ModelSource;
 }
 
@@ -125,6 +127,54 @@ export function resolveModelSupportsImageInput(
   }
 
   return false;
+}
+
+function findExactModel(model: Pick<ModelProps, "provider" | "modelId">): ModelProps | undefined {
+  return (
+    SYSTEM_MODELS.find(
+      (candidate) => candidate.provider === model.provider && candidate.modelId === model.modelId
+    ) ??
+    MODELS.find(
+      (candidate) => candidate.provider === model.provider && candidate.modelId === model.modelId
+    )
+  );
+}
+
+export function resolveModelSupportsReasoning(
+  model?: Pick<ModelProps, "provider" | "modelId" | "supportsReasoning" | "reasoningLevels"> | null
+): boolean {
+  if (!model) {
+    return false;
+  }
+
+  if (typeof model.supportsReasoning === "boolean") {
+    return model.supportsReasoning;
+  }
+
+  if (model.reasoningLevels && model.reasoningLevels.length > 0) {
+    return true;
+  }
+
+  const exactMatch = findExactModel(model);
+  if (typeof exactMatch?.supportsReasoning === "boolean") {
+    return exactMatch.supportsReasoning;
+  }
+
+  return Boolean(exactMatch?.reasoningLevels?.length);
+}
+
+export function resolveModelReasoningLevels(
+  model?: Pick<ModelProps, "provider" | "modelId" | "reasoningLevels"> | null
+): readonly ReasoningLevel[] {
+  if (!model) {
+    return [];
+  }
+
+  if (model.reasoningLevels) {
+    return model.reasoningLevels;
+  }
+
+  return findExactModel(model)?.reasoningLevels ?? [];
 }
 
 /**
@@ -234,6 +284,7 @@ export const MODELS: ModelProps[] = [
     autoSelectable: false,
     supportsImageInput: true,
     supportsReasoning: true,
+    reasoningLevels: ["minimal", "low", "medium", "high"],
     description: "Next-generation frontier model from OpenAI.",
     source: "user",
   },
@@ -244,6 +295,7 @@ export const MODELS: ModelProps[] = [
     autoSelectable: false,
     supportsImageInput: true,
     supportsReasoning: true,
+    reasoningLevels: ["none", "low", "medium", "high", "xhigh"],
     description: "Enhanced version of GPT-5 with improved reasoning capabilities.",
     source: "user",
   },
@@ -285,6 +337,7 @@ export const MODELS: ModelProps[] = [
     free: false,
     supportsImageInput: true,
     supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high"],
     description: "OpenAI's latest reasoning model, optimized for chain-of-thought.",
     source: "user",
   },
@@ -294,6 +347,7 @@ export const MODELS: ModelProps[] = [
     free: false,
     supportsImageInput: false,
     supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high"],
     description: "Optimized version of OpenAI's reasoning models for fast responses.",
     source: "user",
   },
@@ -306,6 +360,8 @@ export const MODELS: ModelProps[] = [
     free: false,
     autoSelectable: false,
     supportsImageInput: true,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "high"],
     description: "Google's most capable model for complex tasks and multimodal inputs.",
     source: "user",
   },
@@ -315,6 +371,8 @@ export const MODELS: ModelProps[] = [
     free: false,
     autoSelectable: false,
     supportsImageInput: true,
+    supportsReasoning: true,
+    reasoningLevels: ["minimal", "low", "medium", "high"],
     description: "Fast and efficient model from Google for rapid interactions.",
     source: "user",
   },
@@ -351,6 +409,8 @@ export const MODELS: ModelProps[] = [
     free: false,
     autoSelectable: false,
     supportsImageInput: true,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high", "xhigh"],
     description: "Anthropic's most intelligent model for building agents and coding.",
     source: "user",
   },
@@ -359,6 +419,8 @@ export const MODELS: ModelProps[] = [
     modelId: "claude-opus-4-5",
     free: false,
     supportsImageInput: true,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high"],
     description: "Anthropic's most powerful model for highly complex analysis.",
     source: "user",
   },
@@ -368,6 +430,7 @@ export const MODELS: ModelProps[] = [
     free: false,
     autoSelectable: false,
     supportsImageInput: true,
+    supportsReasoning: true,
     description: "Anthropic's best combination of speed and intelligence.",
     source: "user",
   },
@@ -376,6 +439,7 @@ export const MODELS: ModelProps[] = [
     modelId: "claude-haiku-4-5",
     free: false,
     supportsImageInput: true,
+    supportsReasoning: true,
     description: "Anthropic's fastest model with near-frontier intelligence.",
     source: "user",
   },
@@ -404,6 +468,8 @@ export const MODELS: ModelProps[] = [
     free: true,
     autoSelectable: true,
     supportsImageInput: false,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high"],
     description: "Open-source GPT model with large parameter count for general tasks.",
     source: "user",
   },
@@ -413,6 +479,8 @@ export const MODELS: ModelProps[] = [
     free: true,
     autoSelectable: true,
     supportsImageInput: false,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high"],
     description: "Open-source GPT model with large parameter count for general tasks.",
     source: "user",
   },
@@ -425,6 +493,8 @@ export const MODELS: ModelProps[] = [
     free: false,
     autoSelectable: true,
     supportsImageInput: false,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high"],
     description: "Fast-inference open-source model running on Groq hardware.",
     source: "user",
   },
@@ -448,6 +518,8 @@ export const MODELS: ModelProps[] = [
     free: false,
     autoSelectable: true,
     supportsImageInput: false,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high"],
     description: "Cerebras's latest model with extreme intelligence and reliability.",
     source: "user",
   },
@@ -460,6 +532,7 @@ export const MODELS: ModelProps[] = [
     free: false,
     autoSelectable: true,
     supportsImageInput: false,
+    supportsReasoning: true,
     description: "DeepSeek V3, powerful open-source model with strong reasoning.",
     source: "user",
   },
@@ -469,6 +542,7 @@ export const MODELS: ModelProps[] = [
     free: false,
     autoSelectable: true,
     supportsImageInput: false,
+    supportsReasoning: true,
     description: "DeepSeek R1, advanced reasoning model with chain-of-thought.",
     source: "user",
   },
@@ -478,6 +552,7 @@ export const MODELS: ModelProps[] = [
     free: false,
     autoSelectable: true,
     supportsImageInput: false,
+    supportsReasoning: true,
     description: "Qwen 3 235B, largest Qwen model for complex tasks.",
     source: "user",
   },
@@ -487,6 +562,7 @@ export const MODELS: ModelProps[] = [
     free: false,
     autoSelectable: true,
     supportsImageInput: false,
+    supportsReasoning: true,
     description: "Qwen3-Next-80B-A3B-Thinking, efficient reasoning model.",
     source: "user",
   },
@@ -496,6 +572,7 @@ export const MODELS: ModelProps[] = [
     free: false,
     autoSelectable: true,
     supportsImageInput: true,
+    supportsReasoning: true,
     description:
       "Flagship GLM model with strong multilingual reasoning, long context, and robust tool use.",
     source: "user",
@@ -506,6 +583,7 @@ export const MODELS: ModelProps[] = [
     free: false,
     autoSelectable: true,
     supportsImageInput: true,
+    supportsReasoning: true,
     description: "Kimi-K2.5, 15 trillion mixed visual and text tokens atop Kimi-K2-Base",
     source: "user",
   },
@@ -515,6 +593,8 @@ export const MODELS: ModelProps[] = [
     free: false,
     autoSelectable: true,
     supportsImageInput: false,
+    supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high"],
     description: "GPT-OSS 120B, open-source GPT model with strong general capabilities.",
     source: "user",
   },
@@ -526,6 +606,7 @@ export const MODELS: ModelProps[] = [
     supportsImageInput: true,
     supportsTemperature: false,
     supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high", "xhigh"],
     supportedEndpoints: ["responses"],
     description: "Codex model accessed with ChatGPT/Codex subscription authentication.",
     source: "user",
@@ -538,6 +619,7 @@ export const MODELS: ModelProps[] = [
     supportsImageInput: true,
     supportsTemperature: false,
     supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high", "xhigh"],
     supportedEndpoints: ["responses"],
     description: "Codex model accessed with ChatGPT/Codex subscription authentication.",
     source: "user",
@@ -550,6 +632,7 @@ export const MODELS: ModelProps[] = [
     supportsImageInput: true,
     supportsTemperature: false,
     supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high", "xhigh"],
     supportedEndpoints: ["responses"],
     description: "Lower-cost Codex model accessed with ChatGPT/Codex subscription authentication.",
     source: "user",
@@ -562,6 +645,7 @@ export const MODELS: ModelProps[] = [
     supportsImageInput: true,
     supportsTemperature: false,
     supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high", "xhigh"],
     supportedEndpoints: ["responses"],
     description: "Codex model accessed with ChatGPT/Codex subscription authentication.",
     source: "user",
@@ -574,6 +658,7 @@ export const MODELS: ModelProps[] = [
     supportsImageInput: false,
     supportsTemperature: false,
     supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high", "xhigh"],
     supportedEndpoints: ["responses"],
     description: "Text-only Codex model accessed with ChatGPT/Codex subscription authentication.",
     source: "user",
@@ -586,6 +671,7 @@ export const MODELS: ModelProps[] = [
     supportsImageInput: true,
     supportsTemperature: false,
     supportsReasoning: true,
+    reasoningLevels: ["low", "medium", "high", "xhigh"],
     supportedEndpoints: ["responses"],
     description: "Codex model accessed with ChatGPT/Codex subscription authentication.",
     source: "user",
@@ -789,9 +875,10 @@ export class LanguageModelProviderFactory {
   }
 
   static supportsReasoning(provider: string, modelId: string): boolean {
-    return (
-      MODELS.find((model) => model.provider === provider && model.modelId === modelId)
-        ?.supportsReasoning === true
-    );
+    return resolveModelSupportsReasoning({ provider, modelId });
+  }
+
+  static getReasoningLevels(provider: string, modelId: string): readonly ReasoningLevel[] {
+    return resolveModelReasoningLevels({ provider, modelId });
   }
 }

--- a/src/lib/ai/llm/llm-provider-factory.ts
+++ b/src/lib/ai/llm/llm-provider-factory.ts
@@ -19,6 +19,8 @@ import {
 import { ANTHROPIC_PROVIDER } from "./llm-provider-anthropic";
 import { PRIVATE_MODELS, PRIVATE_PROVIDERS } from "./llm-provider-factory-private";
 import { GOOGLE_PROVIDER } from "./llm-provider-google";
+import { OPENAI_CODEX_PROVIDER } from "./llm-provider-openai-codex";
+import { withVisibleReasoningLanguageInstruction } from "./llm-provider-openai-options";
 import { mockModel } from "./models.mock";
 import { PROVIDER_GITHUB_COPILOT, PROVIDER_NEBIUS, PROVIDER_OPENAI_CODEX } from "./provider-ids";
 
@@ -44,6 +46,7 @@ type ProviderOptionsInput = {
   outputReasoning: boolean;
   reasoningLevel?: ReasoningLevel;
   instructions: string;
+  responseLanguage?: string;
 };
 
 type ProviderOptionsRequestInput = Omit<ProviderOptionsInput, "reasoningLevel"> & {
@@ -80,48 +83,6 @@ export interface ModelProps {
   supportsReasoning?: boolean;
   reasoningLevels?: readonly ReasoningLevel[];
   source?: ModelSource;
-}
-
-function decodeJwtPayload(token: string): Record<string, unknown> | undefined {
-  const payload = token.split(".")[1];
-  if (!payload) return undefined;
-
-  try {
-    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
-    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), "=");
-    const decoded = globalThis.atob(padded);
-    const bytes = Uint8Array.from(decoded, (char) => char.charCodeAt(0));
-    return JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>;
-  } catch {
-    return undefined;
-  }
-}
-
-export function extractCodexAccountId(token: string): string | undefined {
-  const payload = decodeJwtPayload(token);
-  if (!payload) return undefined;
-
-  const authClaim = payload["https://api.openai.com/auth"];
-  if (authClaim && typeof authClaim === "object") {
-    const auth = authClaim as Record<string, unknown>;
-    if (typeof auth.chatgpt_account_id === "string") return auth.chatgpt_account_id;
-    if (typeof auth.account_id === "string") return auth.account_id;
-
-    const organizations = auth.organizations;
-    if (Array.isArray(organizations)) {
-      const organization = organizations.find(
-        (candidate): candidate is Record<string, unknown> =>
-          Boolean(candidate) && typeof candidate === "object" && typeof candidate.id === "string"
-      );
-      if (typeof organization?.id === "string") return organization.id;
-    }
-  }
-
-  if (typeof payload.chatgpt_account_id === "string") return payload.chatgpt_account_id;
-  if (typeof payload.account_id === "string") return payload.account_id;
-  if (typeof payload.sub === "string") return payload.sub;
-
-  return undefined;
 }
 
 export function resolveModelSupportsImageInput(
@@ -257,13 +218,18 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         apiKey,
       })(modelId),
     systemApiKey: () => process.env.OPENAI_API_KEY,
-    buildProviderOptions: ({ outputReasoning, reasoningLevel }) => {
+    buildProviderOptions: ({ instructions, outputReasoning, reasoningLevel, responseLanguage }) => {
       if (!outputReasoning && !reasoningLevel) {
         return undefined;
       }
 
       return {
         openai: {
+          instructions: withVisibleReasoningLanguageInstruction(
+            instructions,
+            outputReasoning,
+            responseLanguage
+          ),
           ...(reasoningLevel ? { reasoningEffort: reasoningLevel } : {}),
           ...(outputReasoning ? { reasoningSummary: "auto" as const } : {}),
         } satisfies OpenAIResponsesProviderOptions,
@@ -363,28 +329,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
       })(modelId);
     },
   },
-  [PROVIDER_OPENAI_CODEX]: {
-    logo: "openai.svg",
-    create: (modelId, apiKey) => {
-      const accountId = extractCodexAccountId(apiKey);
-      return createOpenAI({
-        apiKey,
-        baseURL: "https://chatgpt.com/backend-api/codex",
-        headers: {
-          ...(accountId ? { "chatgpt-account-id": accountId } : {}),
-        },
-      })(modelId);
-    },
-    buildProviderOptions: ({ instructions, outputReasoning, reasoningLevel }) => ({
-      openai: {
-        instructions,
-        ...(reasoningLevel ? { reasoningEffort: reasoningLevel } : {}),
-        ...(outputReasoning ? { reasoningSummary: "auto" as const } : {}),
-        // Keep chat state in DataStoria instead of creating stored OpenAI responses.
-        store: false,
-      } satisfies OpenAIResponsesProviderOptions,
-    }),
-  },
+  [PROVIDER_OPENAI_CODEX]: OPENAI_CODEX_PROVIDER,
   [PROVIDER_NEBIUS]: {
     logo: "nebius.svg",
     create: (modelId, apiKey) =>

--- a/src/lib/ai/llm/llm-provider-google.ts
+++ b/src/lib/ai/llm/llm-provider-google.ts
@@ -1,0 +1,43 @@
+import { createGoogleGenerativeAI, type GoogleGenerativeAIProviderOptions } from "@ai-sdk/google";
+import type { ReasoningLevel } from "../reasoning-levels";
+import type { ProviderDefinition } from "./llm-provider-factory";
+
+function toGoogleThinkingLevel(
+  level: ReasoningLevel
+):
+  | NonNullable<NonNullable<GoogleGenerativeAIProviderOptions["thinkingConfig"]>["thinkingLevel"]>
+  | undefined {
+  if (level === "xhigh") return "high";
+  if (level === "minimal" || level === "low" || level === "medium" || level === "high") {
+    return level;
+  }
+  return undefined;
+}
+
+export const GOOGLE_PROVIDER = {
+  logo: "google.svg",
+  create: (modelId, apiKey) =>
+    createGoogleGenerativeAI({
+      apiKey,
+    })(modelId),
+  systemApiKey: () => process.env.GOOGLE_GENERATIVE_AI_API_KEY,
+  buildProviderOptions: ({ outputReasoning, reasoningLevel }) => {
+    if (!reasoningLevel) {
+      return undefined;
+    }
+
+    const thinkingLevel = toGoogleThinkingLevel(reasoningLevel);
+    if (!thinkingLevel) {
+      return undefined;
+    }
+
+    return {
+      google: {
+        thinkingConfig: {
+          thinkingLevel,
+          ...(outputReasoning ? { includeThoughts: true } : {}),
+        },
+      } satisfies GoogleGenerativeAIProviderOptions,
+    };
+  },
+} satisfies ProviderDefinition;

--- a/src/lib/ai/llm/llm-provider-openai-codex.ts
+++ b/src/lib/ai/llm/llm-provider-openai-codex.ts
@@ -1,0 +1,72 @@
+import { createOpenAI, type OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
+import type { ProviderDefinition } from "./llm-provider-factory";
+import { withVisibleReasoningLanguageInstruction } from "./llm-provider-openai-options";
+
+function decodeJwtPayload(token: string): Record<string, unknown> | undefined {
+  const payload = token.split(".")[1];
+  if (!payload) return undefined;
+
+  try {
+    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), "=");
+    const decoded = globalThis.atob(padded);
+    const bytes = Uint8Array.from(decoded, (char) => char.charCodeAt(0));
+    return JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function extractCodexAccountId(token: string): string | undefined {
+  const payload = decodeJwtPayload(token);
+  if (!payload) return undefined;
+
+  const authClaim = payload["https://api.openai.com/auth"];
+  if (authClaim && typeof authClaim === "object") {
+    const auth = authClaim as Record<string, unknown>;
+    if (typeof auth.chatgpt_account_id === "string") return auth.chatgpt_account_id;
+    if (typeof auth.account_id === "string") return auth.account_id;
+
+    const organizations = auth.organizations;
+    if (Array.isArray(organizations)) {
+      const organization = organizations.find(
+        (candidate): candidate is Record<string, unknown> =>
+          Boolean(candidate) && typeof candidate === "object" && typeof candidate.id === "string"
+      );
+      if (typeof organization?.id === "string") return organization.id;
+    }
+  }
+
+  if (typeof payload.chatgpt_account_id === "string") return payload.chatgpt_account_id;
+  if (typeof payload.account_id === "string") return payload.account_id;
+  if (typeof payload.sub === "string") return payload.sub;
+
+  return undefined;
+}
+
+export const OPENAI_CODEX_PROVIDER = {
+  logo: "openai.svg",
+  create: (modelId, apiKey) => {
+    const accountId = extractCodexAccountId(apiKey);
+    return createOpenAI({
+      apiKey,
+      baseURL: "https://chatgpt.com/backend-api/codex",
+      headers: {
+        ...(accountId ? { "chatgpt-account-id": accountId } : {}),
+      },
+    })(modelId);
+  },
+  buildProviderOptions: ({ instructions, outputReasoning, reasoningLevel, responseLanguage }) => ({
+    openai: {
+      instructions: withVisibleReasoningLanguageInstruction(
+        instructions,
+        outputReasoning,
+        responseLanguage
+      ),
+      ...(reasoningLevel ? { reasoningEffort: reasoningLevel } : {}),
+      ...(outputReasoning ? { reasoningSummary: "auto" as const } : {}),
+      // Keep chat state in DataStoria instead of creating stored OpenAI responses.
+      store: false,
+    } satisfies OpenAIResponsesProviderOptions,
+  }),
+} satisfies ProviderDefinition;

--- a/src/lib/ai/llm/llm-provider-openai-options.ts
+++ b/src/lib/ai/llm/llm-provider-openai-options.ts
@@ -1,0 +1,17 @@
+import { isEnglishLanguageTag, sanitizeLanguageTag } from "../language-utils";
+
+export function withVisibleReasoningLanguageInstruction(
+  instructions: string,
+  outputReasoning: boolean,
+  responseLanguage?: string
+): string {
+  const language = sanitizeLanguageTag(responseLanguage);
+  if (!outputReasoning || !language || isEnglishLanguageTag(language)) {
+    return instructions;
+  }
+
+  return `${instructions}
+
+## Visible Reasoning Language
+The API may emit visible reasoning summaries separately from the final answer. Every visible reasoning summary, thinking summary, planning note, heading, and paragraph MUST be written in ${language}. Never emit English visible reasoning text unless the configured response language is English.`;
+}

--- a/src/lib/ai/reasoning-levels.ts
+++ b/src/lib/ai/reasoning-levels.ts
@@ -1,0 +1,15 @@
+export type ReasoningLevel = string;
+
+export const DEFAULT_REASONING_LEVEL: ReasoningLevel = "medium";
+
+export function isReasoningLevel(value: unknown): value is ReasoningLevel {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function normalizeReasoningLevel(value: unknown): ReasoningLevel {
+  return isReasoningLevel(value) ? value.trim() : DEFAULT_REASONING_LEVEL;
+}
+
+export function formatReasoningLevel(level: ReasoningLevel): string {
+  return level;
+}

--- a/src/lib/ai/reasoning-levels.ts
+++ b/src/lib/ai/reasoning-levels.ts
@@ -1,6 +1,6 @@
 export type ReasoningLevel = string;
 
-export const DEFAULT_REASONING_LEVEL: ReasoningLevel = "medium";
+export const DEFAULT_REASONING_LEVEL: ReasoningLevel = "xhigh";
 
 export function isReasoningLevel(value: unknown): value is ReasoningLevel {
   return typeof value === "string" && value.trim().length > 0;
@@ -8,6 +8,12 @@ export function isReasoningLevel(value: unknown): value is ReasoningLevel {
 
 export function normalizeReasoningLevel(value: unknown): ReasoningLevel {
   return isReasoningLevel(value) ? value.trim() : DEFAULT_REASONING_LEVEL;
+}
+
+export function getDefaultReasoningLevel(
+  levels: readonly ReasoningLevel[]
+): ReasoningLevel | undefined {
+  return levels[levels.length - 1];
 }
 
 export function formatReasoningLevel(level: ReasoningLevel): string {


### PR DESCRIPTION
## Summary
- add configurable reasoning levels to model metadata and persist the selected level through chat requests
- validate requested reasoning levels against the selected model before sending provider options
- configure model-specific levels for OpenAI, Gemini, Anthropic, GPT-OSS, and Codex models

## Validation
- npx vitest run src/lib/ai/llm/llm-provider-factory.test.ts
- npm run typecheck
- npm run lint
- npm run build
