### PR TITLE
Fix query log table predicate filtering

### DIFF
--- a/src/lib/ai/tools/clickhouse/search-query-log.test.ts
+++ b/src/lib/ai/tools/clickhouse/search-query-log.test.ts
@@ -75,6 +75,23 @@ describe("search_query_log helpers", () => {
     expect(result.sql).toContain("ORDER BY metric_value DESC, last_execution_time DESC");
   });
 
+  it("keeps table predicates on the source column in patterns mode", () => {
+    const result = buildSearchQueryLogSql(
+      {
+        mode: "patterns",
+        metric_aggregation: "sum",
+        limit: 20,
+        time_window: 1440,
+        predicates: [{ field: "table", op: "has", value: "bithon_trace_span_summary_local" }],
+      },
+      new Set(["query_duration_ms"])
+    );
+
+    expect(result.sql).toContain("has(tables, 'bithon_trace_span_summary_local')");
+    expect(result.sql).toContain("any(tables) AS query_log_tables");
+    expect(result.sql).not.toContain("any(tables) AS tables");
+  });
+
   it("lets explicit predicates override default query_kind and is_initial_query filters", () => {
     const result = buildSearchQueryLogSql(
       {
@@ -163,5 +180,77 @@ describe("search_query_log helpers", () => {
 
     expect(systemColumnsCalls).toHaveLength(1);
     expect(connection.metadata).toEqual({});
+  });
+
+  it("uses internal pattern table projection to qualify previews without leaking it", async () => {
+    const query = vi.fn((sql: string) => {
+      if (sql.includes("FROM system.columns")) {
+        return {
+          response: Promise.resolve(
+            createJsonCompactResponse(
+              [{ name: "name", type: "String" }],
+              [
+                ["query_duration_ms"],
+                ["memory_usage"],
+                ["read_rows"],
+                ["read_bytes"],
+                ["result_rows"],
+              ]
+            )
+          ),
+          abortController: new AbortController(),
+        };
+      }
+
+      return {
+        response: Promise.resolve(
+          createJsonCompactResponse(
+            [
+              { name: "normalized_query_hash", type: "UInt64" },
+              { name: "sample_query_id", type: "String" },
+              { name: "sample_user", type: "String" },
+              { name: "sql_preview", type: "String" },
+              { name: "last_execution_time", type: "DateTime" },
+              { name: "execution_count", type: "UInt64" },
+              { name: "avg_duration_ms", type: "Float64" },
+              { name: "max_duration_ms", type: "UInt64" },
+              { name: "max_memory_usage", type: "UInt64" },
+              { name: "sum_read_rows", type: "UInt64" },
+              { name: "sum_read_bytes", type: "UInt64" },
+              { name: "query_log_tables", type: "Array(String)" },
+            ],
+            [
+              [
+                "123",
+                "query-1",
+                "alice",
+                "SELECT * FROM spans",
+                "2026-05-14 12:00:00",
+                3,
+                10,
+                15,
+                1024,
+                100,
+                2048,
+                ["analytics.spans"],
+              ],
+            ]
+          )
+        ),
+        abortController: new AbortController(),
+      };
+    });
+    const connection = {
+      metadata: {},
+      query,
+    } as unknown as Connection;
+
+    const result = await searchQueryLogExecutor({ mode: "patterns" }, connection);
+
+    expect(result.success).toBe(true);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].sql_preview).toBe("SELECT * FROM analytics.spans");
+    expect(result.rows[0]).not.toHaveProperty("query_log_tables");
+    expect(result.rows[0]).not.toHaveProperty("tables");
   });
 });

--- a/src/lib/ai/tools/clickhouse/search-query-log.ts
+++ b/src/lib/ai/tools/clickhouse/search-query-log.ts
@@ -138,6 +138,7 @@ const METRIC_CONFIG: Record<SearchQueryLogMetric, MetricConfig> = {
 
 const queryLogColumnsCache = new WeakMap<Connection, Set<string>>();
 const queryLogColumnsPromiseCache = new WeakMap<Connection, Promise<Set<string>>>();
+const PATTERN_TABLES_PROJECTION = "query_log_tables";
 
 function isDateOnly(value: string): boolean {
   return /^\d{4}-\d{2}-\d{2}$/.test(value);
@@ -439,7 +440,7 @@ SELECT
   max(memory_usage) AS max_memory_usage,
   sum(read_rows) AS sum_read_rows,
   sum(read_bytes) AS sum_read_bytes,
-  any(tables) AS tables${metricProjection}
+  any(tables) AS ${PATTERN_TABLES_PROJECTION}${metricProjection}
 FROM {clusterAllReplicas:system.query_log}
 WHERE
   ${conditions.join("\n  AND ")}
@@ -484,10 +485,15 @@ LIMIT ${limit}
 
 function qualifyPreviewSql(row: Record<string, unknown>) {
   const sqlPreview = typeof row.sql_preview === "string" ? row.sql_preview : undefined;
-  const tables = Array.isArray(row.tables) ? (row.tables as string[]) : undefined;
+  const tables = Array.isArray(row[PATTERN_TABLES_PROJECTION])
+    ? (row[PATTERN_TABLES_PROJECTION] as string[])
+    : Array.isArray(row.tables)
+      ? (row.tables as string[])
+      : undefined;
   if (sqlPreview && tables && tables.length > 0) {
     row.sql_preview = SqlUtils.qualifyTableNames(sqlPreview, tables);
   }
+  delete row[PATTERN_TABLES_PROJECTION];
   delete row.tables;
 }
 


### PR DESCRIPTION
## Summary
- Avoid aliasing pattern-mode `any(tables)` as `tables`, which made table predicates resolve to an aggregate alias in `WHERE`
- Keep the internal table projection for SQL preview qualification and strip it from tool output
- Add regression coverage for pattern-mode table predicates and internal projection cleanup

## Validation
- npm run format
- npm run test -- --run src/lib/ai/tools/clickhouse/search-query-log.test.ts
- npm run typecheck
- npm run lint -- src/lib/ai/tools/clickhouse/search-query-log.ts src/lib/ai/tools/clickhouse/search-query-log.test.ts
- git diff --check
- npm run build