### PR TITLE
fix: align timeseries panel x-axes across dashboard

### DIFF
--- a/src/components/shared/dashboard/dashboard-visualization-timeseries.tsx
+++ b/src/components/shared/dashboard/dashboard-visualization-timeseries.tsx
@@ -1145,21 +1145,26 @@ export const TimeseriesVisualization = React.forwardRef<
           icon: "circle",
         },
         grid: {
-          left: 20,
+          // Fixed left gutter (containLabel: false) so every panel's plot area
+          // starts at the same x regardless of y-axis label width, keeping the
+          // time axes aligned across the dashboard grid.
+          left: 72,
           right: 20,
-          bottom: 8,
+          bottom: 24,
           // Adjust top margin based on whether ECharts legend is shown
           top:
             series.length > 0 &&
             (!descriptor.legendOption || descriptor.legendOption.placement === "inside")
               ? 32
               : 12,
-          containLabel: true,
+          containLabel: false,
         },
         xAxis: {
           type: "category",
           data: xAxisData,
           boundaryGap: descriptor.type === "bar",
+          // Deterministic label thinning so equal-width panels show the same ticks.
+          axisLabel: { hideOverlap: true },
         },
         yAxis,
         series,


### PR DESCRIPTION
## Problem

When viewing/refreshing a dashboard, the time x-axis of different timeseries panels did not line up:

- Plot areas were **horizontally offset** — a panel with wide y-axis labels (e.g. `143.05 MiB`) started further right than one with short labels (e.g. `150`).
- Panels showed **different time tick labels** (one ending at `15:43`, another at `15:45`) even over the same range.

## Root cause

The ECharts grid used `containLabel: true`, which sizes each panel's left margin to fit *its own* y-axis labels. Because label widths differ per panel, the plot areas started at different x positions. The resulting plot widths also differed, so ECharts auto-picked a different x-axis tick interval per panel, producing different time labels.

## Fix

A small, contained change to the timeseries chart grid:

- Use a **fixed left gutter** (`left: 72`, `containLabel: false`) so every panel's plot area starts at the same x regardless of y-axis label width. `bottom` is bumped to reserve the x-axis label space `containLabel` previously added.
- Add `xAxis.axisLabel.hideOverlap: true` for deterministic label thinning, so equal-width panels render the same ticks.

## Before / After

Before: panels' x-axes misaligned (different left edges, different end times).
After: all panels share the same plot left edge and the same time tick labels.

## Test plan

- [x] `tsc --noEmit` clean
- [x] ESLint clean
- [x] Existing dashboard test suite passes (25 tests)
- [x] Verified visually: dashboard panels now align after refresh